### PR TITLE
Use mint and burn methods of balance contract

### DIFF
--- a/cmd/neofs-node/accounting.go
+++ b/cmd/neofs-node/accounting.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance/wrapper"
 	accountingTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/accounting/grpc"
 	accountingService "github.com/nspcc-dev/neofs-node/pkg/services/accounting"
 	accounting "github.com/nspcc-dev/neofs-node/pkg/services/accounting/morph"
@@ -25,6 +26,9 @@ func initAccountingService(c *cfg) {
 	balanceClient, err := balance.New(staticClient)
 	fatalOnErr(err)
 
+	balanceMorphWrapper, err := wrapper.New(balanceClient)
+	fatalOnErr(err)
+
 	metaHdr := new(session.ResponseMetaHeader)
 	xHdr := new(session.XHeader)
 	xHdr.SetKey("test X-Header key")
@@ -36,7 +40,7 @@ func initAccountingService(c *cfg) {
 			accountingService.NewSignService(
 				c.key,
 				accountingService.NewExecutionService(
-					accounting.NewExecutor(balanceClient),
+					accounting.NewExecutor(balanceMorphWrapper),
 					metaHdr,
 				),
 			),

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/nspcc-dev/hrw v1.0.9
-	github.com/nspcc-dev/neo-go v0.91.0
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20200821125006-afd2ce0400ec
+	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20200901143416-cf66f44adb32
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/netmap v1.7.0
 	github.com/nspcc-dev/tzhash v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,10 @@ github.com/nspcc-dev/neo-go v0.90.0 h1:ABNDrJuF9C1XuLQu0q9DKSVMlg9eQn/g6rX8Jbr31
 github.com/nspcc-dev/neo-go v0.90.0/go.mod h1:pPFdnApJwUSRAnpdiPBZl7I7jv0doDg5naecpSPK4+Q=
 github.com/nspcc-dev/neo-go v0.91.0 h1:KKOPMKs0fm8JIau1SuwxiLdrZ+1kDPBiVRlWwzfebWE=
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
+github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nBXK8uDY/JZaxIZzAUfkzfaotVw2FbnHxO4aZI=
+github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
+github.com/nspcc-dev/neo-go v0.91.1 h1:ynmqfTE5uKgt3kIZD6aVV1IDDbWybSUz3uEluyeSA6k=
+github.com/nspcc-dev/neo-go v0.91.1/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neofs-api-go v1.3.0 h1:w0wYIXzPJIElwhqahnQw/1NKiHxjRZKJhDUMSbEHmdk=
 github.com/nspcc-dev/neofs-api-go v1.3.0/go.mod h1:NlCjqm//ZRXBNlxtrilLM1GgkRz0mv4V3pdX8OcGoLw=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20200820112910-89e79ebe72b0 h1:aaDAx0xezfCzpD7NrmaJTLDHs58t5JM4ZV3ttyMJicY=

--- a/pkg/innerring/invoke/balance.go
+++ b/pkg/innerring/invoke/balance.go
@@ -22,11 +22,20 @@ type (
 		Amount      int64  // in Fixed16
 		Until       uint64 // epochs
 	}
+
+	// MintBurnParams for Mint and Burn invocations.
+	MintBurnParams struct {
+		ScriptHash []byte
+		Amount     int64 // in Fixed16
+		Comment    []byte
+	}
 )
 
 const (
 	transferXMethod = "transferX"
 	lockMethod      = "lock"
+	mintMethod      = "mint"
+	burnMethod      = "burn"
 )
 
 // TransferBalanceX invokes transferX method.
@@ -38,6 +47,32 @@ func TransferBalanceX(cli *client.Client, con util.Uint160, p *TransferXParams) 
 	return cli.Invoke(con, extraFee, transferXMethod,
 		p.Sender,
 		p.Receiver,
+		p.Amount,
+		p.Comment,
+	)
+}
+
+// Mint assets in contract.
+func Mint(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
+	if cli == nil {
+		return client.ErrNilClient
+	}
+
+	return cli.Invoke(con, extraFee, mintMethod,
+		p.ScriptHash,
+		p.Amount,
+		p.Comment,
+	)
+}
+
+// Burn minted assets.
+func Burn(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
+	if cli == nil {
+		return client.ErrNilClient
+	}
+
+	return cli.Invoke(con, extraFee, burnMethod,
+		p.ScriptHash,
 		p.Amount,
 		p.Comment,
 	)

--- a/pkg/morph/client/balance/wrapper/balanceOf.go
+++ b/pkg/morph/client/balance/wrapper/balanceOf.go
@@ -1,11 +1,25 @@
 package wrapper
 
-// OwnerID represents the container owner identifier.
-// FIXME: correct the definition.
-type OwnerID struct{}
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance"
+)
 
 // BalanceOf receives the amount of funds in the client's account
 // through the Balance contract call, and returns it.
-func (w *Wrapper) BalanceOf(ownerID OwnerID) (int64, error) {
-	panic("implement me")
+func (w *Wrapper) BalanceOf(id *owner.ID) (int64, error) {
+	v, err := owner.ScriptHashBE(id)
+	if err != nil {
+		return 0, err
+	}
+
+	args := balance.GetBalanceOfArgs{}
+	args.SetWallet(v)
+
+	result, err := w.client.BalanceOf(args)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.Amount(), nil
 }

--- a/pkg/morph/client/balance/wrapper/decimals.go
+++ b/pkg/morph/client/balance/wrapper/decimals.go
@@ -17,6 +17,5 @@ func (w *Wrapper) Decimals() (uint32, error) {
 		return 0, errors.Wrap(err, "could not invoke smart contract")
 	}
 
-	// FIXME: avoid narrowing cast
 	return uint32(values.Decimals()), nil
 }

--- a/pkg/morph/client/util.go
+++ b/pkg/morph/client/util.go
@@ -136,7 +136,7 @@ func StringFromStackParameter(param sc.Parameter) (string, error) {
 func BoolFromStackItem(param stackitem.Item) (bool, error) {
 	switch param.Type() {
 	case stackitem.BooleanT, stackitem.IntegerT, stackitem.ByteArrayT:
-		return param.Bool(), nil
+		return param.TryBool()
 	default:
 		return false, errors.Errorf("chain/client: %s is not a bool type", param.Type())
 	}
@@ -174,7 +174,6 @@ func BytesFromStackItem(param stackitem.Item) ([]byte, error) {
 //
 // If passed parameter carries boolean false value, (nil, nil) returns.
 func ArrayFromStackItem(param stackitem.Item) ([]stackitem.Item, error) {
-	// if param.Type()
 	switch param.Type() {
 	case stackitem.AnyT:
 		return nil, nil

--- a/pkg/services/accounting/morph/executor.go
+++ b/pkg/services/accounting/morph/executor.go
@@ -3,49 +3,41 @@ package accounting
 import (
 	"context"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/v2/accounting"
-	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance/wrapper"
 	accountingSvc "github.com/nspcc-dev/neofs-node/pkg/services/accounting"
-	"github.com/pkg/errors"
 )
 
 type morphExecutor struct {
-	// TODO: use client wrapper
-	client *balance.Client
+	client *wrapper.Wrapper
 }
 
-func NewExecutor(client *balance.Client) accountingSvc.ServiceExecutor {
+func NewExecutor(client *wrapper.Wrapper) accountingSvc.ServiceExecutor {
 	return &morphExecutor{
 		client: client,
 	}
 }
 
 func (s *morphExecutor) Balance(ctx context.Context, body *accounting.BalanceRequestBody) (*accounting.BalanceResponseBody, error) {
-	id := body.GetOwnerID()
-
-	idBytes, err := id.StableMarshal(nil)
+	id, err := owner.IDFromV2(body.GetOwnerID())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not marshal wallet owner ID")
+		return nil, err
 	}
 
-	argsBalance := balance.GetBalanceOfArgs{}
-	argsBalance.SetWallet(idBytes)
-
-	vBalance, err := s.client.BalanceOf(argsBalance)
+	amount, err := s.client.BalanceOf(id)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not call BalanceOf method")
+		return nil, err
 	}
 
-	argsDecimals := balance.DecimalsArgs{}
-
-	vDecimals, err := s.client.Decimals(argsDecimals)
+	precision, err := s.client.Decimals()
 	if err != nil {
-		return nil, errors.Wrap(err, "could not call decimals method")
+		return nil, err
 	}
 
 	dec := new(accounting.Decimal)
-	dec.SetValue(vBalance.Amount())
-	dec.SetPrecision(uint32(vDecimals.Decimals()))
+	dec.SetValue(amount)
+	dec.SetPrecision(precision)
 
 	res := new(accounting.BalanceResponseBody)
 	res.SetBalance(dec)


### PR DESCRIPTION
Balance contract now have `Mint` and `Burn` methods to manage asset deposit and withdraw. Inner ring should use these methods instead of transfers from and into `0x0FED` account.  