### PR TITLE
Get nework map snapshots

### DIFF
--- a/pkg/morph/client/netmap/client.go
+++ b/pkg/morph/client/netmap/client.go
@@ -34,6 +34,7 @@ type cfg struct {
 	addPeerMethod, // add peer method name for invocation
 	newEpochMethod, // new epoch method name for invocation
 	netMapMethod, // get network map method name
+	snapshotMethod, // get network map snapshot method name
 	updateStateMethod, // update state method name for invocation
 	innerRingListMethod string // IR list method name for invocation
 }
@@ -42,6 +43,7 @@ const (
 	defaultAddPeerMethod       = "addPeer"       // default add peer method name
 	defaultNewEpochMethod      = "newEpoch"      // default new epoch method name
 	defaultNetMapMethod        = "netmap"        // default get network map method name
+	defaultSnapshotMethod      = "snapshot"      // default get network map snapshot method name
 	defaultUpdateStateMethod   = "updateState"   // default update state method name
 	defaultInnerRIngListMethod = "innerRingList" // default IR list method name
 )
@@ -51,6 +53,7 @@ func defaultConfig() *cfg {
 		addPeerMethod:       defaultAddPeerMethod,
 		newEpochMethod:      defaultNewEpochMethod,
 		netMapMethod:        defaultNetMapMethod,
+		snapshotMethod:      defaultSnapshotMethod,
 		updateStateMethod:   defaultUpdateStateMethod,
 		innerRingListMethod: defaultInnerRIngListMethod,
 	}

--- a/pkg/morph/client/netmap/wrapper/netmap.go
+++ b/pkg/morph/client/netmap/wrapper/netmap.go
@@ -1,12 +1,43 @@
 package wrapper
 
-// NetMap represents the NeoFS network map.
-// FIXME: correct the definition.
-type NetMap struct{}
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	grpcNetmap "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
+	client "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
+	"github.com/pkg/errors"
+)
 
 // GetNetMap receives information list about storage nodes
 // through the Netmap contract call, composes network map
-// from them and returns it.
-func (w *Wrapper) GetNetMap() (*NetMap, error) {
-	panic("implement me")
+// from them and returns it. With diff == 0 returns current
+// network map, else return snapshot of previous network map.
+func (w Wrapper) GetNetMap(diff uint64) (*netmap.Netmap, error) {
+	args := client.GetSnapshotArgs{}
+	args.SetDiff(diff)
+
+	peers, err := w.client.Snapshot(args)
+	if err != nil {
+		return nil, err
+	}
+
+	rawPeers := peers.Peers() // slice of serialized node infos
+	infos := make([]v2netmap.NodeInfo, 0, len(rawPeers))
+
+	for _, peer := range rawPeers {
+		grpcNodeInfo := new(grpcNetmap.NodeInfo) // transport representation of struct
+		err = grpcNodeInfo.Unmarshal(peer)
+		if err != nil {
+			// consider unmarshalling into different major versions
+			// of NodeInfo structure, if there any
+			return nil, errors.Wrap(err, "can't unmarshal peer info")
+		}
+
+		v2 := v2netmap.NodeInfoFromGRPCMessage(grpcNodeInfo)
+		infos = append(infos, *v2)
+	}
+
+	nodes := netmap.NodesFromV2(infos)
+
+	return netmap.NewNetmap(nodes)
 }


### PR DESCRIPTION
Node can get network snapshots with `snapshot` method invocation in `netmap` smart contract. Netmap wrapper implements `netmap.Source` interface to use wrapper as network map storage in object service.