### PR TITLE
Add container wrappers for morph RPC request

### DIFF
--- a/pkg/morph/client/container/wrapper/eacl.go
+++ b/pkg/morph/client/container/wrapper/eacl.go
@@ -1,19 +1,68 @@
 package wrapper
 
-// Table represents extended ACL rule table.
-// FIXME: correct the definition.
-type Table struct{}
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	v2ACL "github.com/nspcc-dev/neofs-api-go/v2/acl"
+	msgACL "github.com/nspcc-dev/neofs-api-go/v2/acl/grpc"
+	client "github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
+	"github.com/pkg/errors"
+)
 
 // GetEACL reads the extended ACL table from NeoFS system
 // through Container contract call.
-func (w *Wrapper) GetEACL(cid CID) (Table, error) {
-	panic("implement me")
+func (w *Wrapper) GetEACL(cid *container.ID) (*eacl.Table, []byte, error) {
+	if cid == nil {
+		return nil, nil, errNilArgument
+	}
+
+	args := client.EACLArgs{}
+
+	if v2 := cid.ToV2(); v2 == nil {
+		return nil, nil, errUnsupported // use other major version if there any
+	} else {
+		args.SetCID(v2.GetValue())
+	}
+
+	rpcAnswer, err := w.client.EACL(args)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	grpcMsg := new(msgACL.EACLTable)
+	err = grpcMsg.Unmarshal(rpcAnswer.EACL())
+	if err != nil {
+		// use other major version if there any
+		return nil, nil, err
+	}
+
+	v2table := v2ACL.TableFromGRPCMessage(grpcMsg)
+
+	return eacl.NewTableFromV2(v2table), rpcAnswer.Signature(), nil
 }
 
 // PutEACL saves the extended ACL table in NeoFS system
 // through Container contract call.
 //
 // Returns any error encountered that caused the saving to interrupt.
-func (w *Wrapper) PutEACL(cid CID, table Table, sig []byte) error {
-	panic("implement me")
+func (w *Wrapper) PutEACL(table *eacl.Table, signature []byte) error {
+	if table == nil || len(signature) == 0 {
+		return errNilArgument
+	}
+
+	args := client.SetEACLArgs{}
+	args.SetSignature(signature)
+
+	if v2 := table.ToV2(); v2 == nil {
+		return errUnsupported // use other major version if there any
+	} else {
+		data, err := v2.StableMarshal(nil)
+		if err != nil {
+			return errors.Wrap(err, "can't marshal eacl table")
+		}
+
+		args.SetEACL(data)
+	}
+
+	return w.client.SetEACL(args)
 }

--- a/pkg/morph/client/container/wrapper/wrapper.go
+++ b/pkg/morph/client/container/wrapper/wrapper.go
@@ -10,10 +10,6 @@ import (
 // github.com/nspcc-dev/neofs-node/pkg/morph/client/container.Client.
 type Client = container.Client
 
-// CID represents the container identifier.
-// FIXME: correct the definition.
-type CID struct{}
-
 // Wrapper is a wrapper over container contract
 // client which implements container storage and
 // eACL storage methods.


### PR DESCRIPTION
Container get wrapper now can be used as container storage (implements `container.Source` interface) in object service. 