### PR TITLE
Run node without network mocks

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -154,17 +154,7 @@ func initCfg(path string) *cfg {
 	log, err := logger.NewLogger(viperCfg)
 	fatalOnErr(err)
 
-	viperCfg.GetString(cfgListenAddress)
-
-	endpoint, port, err := net.SplitHostPort(viperCfg.GetString(cfgListenAddress))
-	fatalOnErr(err)
-
-	netAddr, err := network.AddressFromString(strings.Join([]string{
-		"/ip4",
-		endpoint,
-		"tcp",
-		port,
-	}, "/"))
+	netAddr, err := network.AddressFromString(viperCfg.GetString(cfgBootstrapAddress))
 	fatalOnErr(err)
 
 	return &cfg{

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	netmapCore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	nmwrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	tokenStorage "github.com/nspcc-dev/neofs-node/pkg/services/session/storage"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
@@ -108,6 +109,7 @@ type cfgContainer struct {
 
 type cfgNetmap struct {
 	scriptHash util.Uint160
+	wrapper    *nmwrapper.Wrapper
 
 	fee util.Fixed8
 }

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -53,6 +53,8 @@ const (
 	// config keys for cfgContainer
 	cfgContainerContract = "container.scripthash"
 	cfgContainerFee      = "container.fee"
+
+	cfgMaxObjectSize = "node.maxobjectsize" // get value from chain
 )
 
 type cfg struct {
@@ -125,6 +127,8 @@ type cfgObject struct {
 	netMapStorage netmapCore.Source
 
 	cnrStorage container.Source
+
+	maxObjectSize uint64
 }
 
 const (
@@ -179,6 +183,9 @@ func initCfg(path string) *cfg {
 			bootType:   StorageNode,
 			attributes: parseAttributes(viperCfg),
 		},
+		cfgObject: cfgObject{
+			maxObjectSize: viperCfg.GetUint64(cfgMaxObjectSize),
+		},
 		localAddr: netAddr,
 	}
 }
@@ -207,7 +214,8 @@ func initViper(path string) *viper.Viper {
 func defaultConfiguration(v *viper.Viper) {
 	// fixme: all hardcoded private keys must be removed
 	v.SetDefault(cfgNodeKey, "Kwk6k2eC3L3QuPvD8aiaNyoSXgQ2YL1bwS5CP1oKoA9waeAze97s")
-	v.SetDefault(cfgBootstrapAddress, "") // address to bootstrap with
+	v.SetDefault(cfgBootstrapAddress, "")     // address to bootstrap with
+	v.SetDefault(cfgMaxObjectSize, 1024*1024) // default max object size 1 megabyte
 
 	v.SetDefault(cfgMorphRPCAddress, "http://morph_chain.localtest.nspcc.ru:30333/")
 	v.SetDefault(cfgListenAddress, "127.0.0.1:50501") // listen address

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/misc"
+	"github.com/nspcc-dev/neofs-node/pkg/core/container"
+	netmapCore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	tokenStorage "github.com/nspcc-dev/neofs-node/pkg/services/session/storage"
@@ -78,6 +80,8 @@ type cfg struct {
 	cfgNodeInfo cfgNodeInfo
 
 	localAddr *network.Address
+
+	cfgObject cfgObject
 }
 
 type cfgGRPC struct {
@@ -113,6 +117,12 @@ type BootstrapType uint32
 type cfgNodeInfo struct {
 	bootType   BootstrapType
 	attributes []*netmap.Attribute
+}
+
+type cfgObject struct {
+	netMapStorage netmapCore.Source
+
+	cnrStorage container.Source
 }
 
 const (

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	containerTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/container/grpc"
 	containerService "github.com/nspcc-dev/neofs-node/pkg/services/container"
 	containerMorph "github.com/nspcc-dev/neofs-node/pkg/services/container/morph"
@@ -20,6 +21,11 @@ func initContainerService(c *cfg) {
 
 	cnrClient, err := container.New(staticClient)
 	fatalOnErr(err)
+
+	wrap, err := wrapper.New(cnrClient)
+	fatalOnErr(err)
+
+	c.cfgObject.cnrStorage = wrap // use RPC node as source of containers
 
 	metaHdr := new(session.ResponseMetaHeader)
 	xHdr := new(session.XHeader)

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -22,6 +22,14 @@ type inMemBucket struct {
 	items map[string][]byte
 }
 
+type maxSzSrc struct {
+	v uint64
+}
+
+func (s *maxSzSrc) MaxObjectSize() uint64 {
+	return s.v
+}
+
 func newBucket() bucket.Bucket {
 	return &inMemBucket{
 		RWMutex: new(sync.RWMutex),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -6,22 +6,45 @@ import (
 	"sync"
 
 	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	objectGRPC "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/bucket"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	objectTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/object/grpc"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
-	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head/v2"
-	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put/v2"
-	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search/v2"
+	deletesvc "github.com/nspcc-dev/neofs-node/pkg/services/object/delete"
+	deletesvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/delete/v2"
+	getsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/get"
+	getsvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/get/v2"
+	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head"
+	headsvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/head/v2"
+	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put"
+	putsvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/put/v2"
+	rangesvc "github.com/nspcc-dev/neofs-node/pkg/services/object/range"
+	rangesvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/range/v2"
+	rangehashsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/rangehash"
+	rangehashsvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/rangehash/v2"
+	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
+	searchsvcV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/search/v2"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
+	"github.com/panjf2000/ants/v2"
 )
 
 type objectSvc struct {
-	put *putsvc.Service
+	put *putsvcV2.Service
 
-	search *searchsvc.Service
+	search *searchsvcV2.Service
 
-	head *headsvc.Service
+	head *headsvcV2.Service
+
+	get *getsvcV2.Service
+
+	rng *rangesvcV2.Service
+
+	rngHash *rangehashsvcV2.Service
+
+	delete *deletesvcV2.Service
 }
 
 type inMemBucket struct {
@@ -109,30 +132,136 @@ func (s *objectSvc) Search(ctx context.Context, req *object.SearchRequest) (obje
 	return s.search.Search(ctx, req)
 }
 
-func (*objectSvc) Get(context.Context, *object.GetRequest) (object.GetObjectStreamer, error) {
-	return nil, errors.New("unimplemented service call")
+func (s *objectSvc) Get(ctx context.Context, req *object.GetRequest) (object.GetObjectStreamer, error) {
+	return s.get.Get(ctx, req)
 }
 
-func (*objectSvc) Delete(context.Context, *object.DeleteRequest) (*object.DeleteResponse, error) {
-	return nil, errors.New("unimplemented service call")
+func (s *objectSvc) Delete(ctx context.Context, req *object.DeleteRequest) (*object.DeleteResponse, error) {
+	return s.delete.Delete(ctx, req)
 }
 
-func (*objectSvc) GetRange(context.Context, *object.GetRangeRequest) (object.GetRangeObjectStreamer, error) {
-	return nil, errors.New("unimplemented service call")
+func (s *objectSvc) GetRange(ctx context.Context, req *object.GetRangeRequest) (object.GetRangeObjectStreamer, error) {
+	return s.rng.GetRange(ctx, req)
 }
 
-func (*objectSvc) GetRangeHash(context.Context, *object.GetRangeHashRequest) (*object.GetRangeHashResponse, error) {
-	return nil, errors.New("unimplemented service call")
+func (s *objectSvc) GetRangeHash(ctx context.Context, req *object.GetRangeHashRequest) (*object.GetRangeHashResponse, error) {
+	return s.rngHash.GetRangeHash(ctx, req)
 }
 
 func initObjectService(c *cfg) {
-	svc := new(objectSvc)
+	ls := localstore.New(newBucket(), newBucket())
+	keyStorage := util.NewKeyStorage(c.key, c.privateTokenStore)
+	nodeOwner := owner.NewID()
+
+	neo3Wallet, err := owner.NEO3WalletFromPublicKey(&c.key.PublicKey)
+	fatalOnErr(err)
+
+	nodeOwner.SetNeo3Wallet(neo3Wallet)
+
+	sPut := putsvc.NewService(
+		putsvc.WithKeyStorage(keyStorage),
+		putsvc.WithMaxSizeSource(&maxSzSrc{3}),
+		putsvc.WithLocalStorage(ls),
+		putsvc.WithContainerSource(c.cfgObject.cnrStorage),
+		putsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),
+		putsvc.WithLocalAddressSource(c),
+	)
+
+	sPutV2 := putsvcV2.NewService(
+		putsvcV2.WithInternalService(sPut),
+	)
+
+	sSearch := searchsvc.NewService(
+		searchsvc.WithKeyStorage(keyStorage),
+		searchsvc.WithLocalStorage(ls),
+		searchsvc.WithContainerSource(c.cfgObject.cnrStorage),
+		searchsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),
+		searchsvc.WithLocalAddressSource(c),
+	)
+
+	sSearchV2 := searchsvcV2.NewService(
+		searchsvcV2.WithInternalService(sSearch),
+	)
+
+	sHead := headsvc.NewService(
+		headsvc.WithKeyStorage(keyStorage),
+		headsvc.WithLocalStorage(ls),
+		headsvc.WithContainerSource(c.cfgObject.cnrStorage),
+		headsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),
+		headsvc.WithLocalAddressSource(c),
+		headsvc.WithRightChildSearcher(searchsvc.NewRightChildSearcher(sSearch)),
+	)
+
+	sHeadV2 := headsvcV2.NewService(
+		headsvcV2.WithInternalService(sHead),
+	)
+
+	pool, err := ants.NewPool(10)
+	fatalOnErr(err)
+
+	sRange := rangesvc.NewService(
+		rangesvc.WithKeyStorage(keyStorage),
+		rangesvc.WithLocalStorage(ls),
+		rangesvc.WithContainerSource(c.cfgObject.cnrStorage),
+		rangesvc.WithNetworkMapSource(c.cfgObject.netMapStorage),
+		rangesvc.WithLocalAddressSource(c),
+		rangesvc.WithWorkerPool(pool),
+		rangesvc.WithHeadService(sHead),
+	)
+
+	sRangeV2 := rangesvcV2.NewService(
+		rangesvcV2.WithInternalService(sRange),
+	)
+
+	sGet := getsvc.NewService(
+		getsvc.WithRangeService(sRange),
+	)
+
+	sGetV2 := getsvcV2.NewService(
+		getsvcV2.WithInternalService(sGet),
+	)
+
+	sRangeHash := rangehashsvc.NewService(
+		rangehashsvc.WithKeyStorage(keyStorage),
+		rangehashsvc.WithLocalStorage(ls),
+		rangehashsvc.WithContainerSource(c.cfgObject.cnrStorage),
+		rangehashsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),
+		rangehashsvc.WithLocalAddressSource(c),
+		rangehashsvc.WithHeadService(sHead),
+		rangehashsvc.WithRangeService(sRange),
+	)
+
+	sRangeHashV2 := rangehashsvcV2.NewService(
+		rangehashsvcV2.WithInternalService(sRangeHash),
+	)
+
+	sDelete := deletesvc.NewService(
+		deletesvc.WithKeyStorage(keyStorage),
+		deletesvc.WitHeadService(sHead),
+		deletesvc.WithPutService(sPut),
+		deletesvc.WithOwnerID(nodeOwner),
+		deletesvc.WithLinkingHeader(
+			headsvc.NewRelationHeader(searchsvc.NewLinkingSearcher(sSearch), sHead),
+		),
+	)
+
+	sDeleteV2 := deletesvcV2.NewService(
+		deletesvcV2.WithInternalService(sDelete),
+	)
 
 	objectGRPC.RegisterObjectServiceServer(c.cfgGRPC.server,
 		objectTransportGRPC.New(
 			objectService.NewSignService(
 				c.key,
-				svc,
+				&objectSvc{
+					put:     sPutV2,
+					search:  sSearchV2,
+					head:    sHeadV2,
+					rng:     sRangeV2,
+					get:     sGetV2,
+					rngHash: sRangeHashV2,
+					delete:  sDeleteV2,
+				},
 			),
 		),
 	)

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -2,150 +2,43 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"io"
+	"errors"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	objectGRPC "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
-	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	objectTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/object/grpc"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
 )
 
-type simpleSearchBodyStreamer struct {
-	count int
-}
-
-type simpleGetBodyStreamer struct {
-	count int
-}
-
-type simplePutBodyStreamer struct{}
-
-type simpleRangeBodyStreamer struct {
-	count int
-}
-
 type objectExecutor struct{}
 
-func (s *simpleGetBodyStreamer) Recv() (*object.GetResponseBody, error) {
-	body := new(object.GetResponseBody)
-
-	id := new(refs.ObjectID)
-	id.SetValue([]byte{1, 2, 3})
-
-	if s.count == 0 {
-		in := new(object.GetObjectPartInit)
-		in.SetObjectID(id)
-
-		body.SetObjectPart(in)
-	} else if s.count == 1 {
-		c := new(object.GetObjectPartChunk)
-		c.SetChunk([]byte{8, 8, 0, 0, 5, 5, 5, 3, 5, 3, 5})
-
-		body.SetObjectPart(c)
-	} else {
-		return nil, io.EOF
-	}
-
-	s.count++
-
-	return body, nil
-}
-
 func (*objectExecutor) Get(context.Context, *object.GetRequestBody) (objectService.GetObjectBodyStreamer, error) {
-	return new(simpleGetBodyStreamer), nil
-}
-
-func (s *simplePutBodyStreamer) Send(body *object.PutRequestBody) error {
-	fmt.Printf("object part received %T\n", body.GetObjectPart())
-	return nil
-}
-
-func (s *simplePutBodyStreamer) CloseAndRecv() (*object.PutResponseBody, error) {
-	body := new(object.PutResponseBody)
-	oid := new(refs.ObjectID)
-
-	body.SetObjectID(oid)
-
-	oid.SetValue([]byte{6, 7, 8})
-
-	return body, nil
+	return nil, errors.New("unimplemented service call")
 }
 
 func (*objectExecutor) Put(context.Context) (objectService.PutObjectBodyStreamer, error) {
-	return new(simplePutBodyStreamer), nil
+	return nil, errors.New("unimplemented service call")
 }
 
-func (*objectExecutor) Head(_ context.Context, body *object.HeadRequestBody) (*object.HeadResponseBody, error) {
-	res := new(object.HeadResponseBody)
-
-	hdrPart := new(object.GetHeaderPartShort)
-	shHdr := new(object.ShortHeader)
-	hdrPart.SetShortHeader(shHdr)
-
-	shHdr.SetPayloadLength(100)
-
-	res.SetHeaderPart(hdrPart)
-
-	return res, nil
+func (*objectExecutor) Head(context.Context, *object.HeadRequestBody) (*object.HeadResponseBody, error) {
+	return nil, errors.New("unimplemented service call")
 }
 
-func (s *objectExecutor) Search(ctx context.Context, body *object.SearchRequestBody) (objectService.SearchObjectBodyStreamer, error) {
-	return new(simpleSearchBodyStreamer), nil
+func (s *objectExecutor) Search(context.Context, *object.SearchRequestBody) (objectService.SearchObjectBodyStreamer, error) {
+	return nil, errors.New("unimplemented service call")
 }
 
 func (*objectExecutor) Delete(_ context.Context, body *object.DeleteRequestBody) (*object.DeleteResponseBody, error) {
-	return new(object.DeleteResponseBody), nil
-}
-
-func (s *simpleRangeBodyStreamer) Recv() (*object.GetRangeResponseBody, error) {
-	body := new(object.GetRangeResponseBody)
-
-	if s.count == 0 {
-		body.SetChunk([]byte{1, 2, 2, 1})
-	} else if s.count == 1 {
-		body.SetChunk([]byte{4, 2, 4, 2})
-	} else {
-		return nil, io.EOF
-	}
-
-	s.count++
-
-	return body, nil
+	return nil, errors.New("unimplemented service call")
 }
 
 func (*objectExecutor) GetRange(_ context.Context, body *object.GetRangeRequestBody) (objectService.GetRangeObjectBodyStreamer, error) {
-	return new(simpleRangeBodyStreamer), nil
+	return nil, errors.New("unimplemented service call")
 }
 
-func (*objectExecutor) GetRangeHash(_ context.Context, body *object.GetRangeHashRequestBody) (*object.GetRangeHashResponseBody, error) {
-	fmt.Println(body.GetRanges()[0])
-
-	res := new(object.GetRangeHashResponseBody)
-	res.SetHashList([][]byte{{1, 2, 3}, {4, 5, 6}})
-
-	return res, nil
-}
-
-func (s *simpleSearchBodyStreamer) Recv() (*object.SearchResponseBody, error) {
-	body := new(object.SearchResponseBody)
-
-	id := new(refs.ObjectID)
-	body.SetIDList([]*refs.ObjectID{id})
-
-	if s.count == 0 {
-		id.SetValue([]byte{1})
-	} else if s.count == 1 {
-		id.SetValue([]byte{2})
-	} else {
-		return nil, io.EOF
-	}
-
-	s.count++
-
-	return body, nil
+func (*objectExecutor) GetRangeHash(context.Context, *object.GetRangeHashRequestBody) (*object.GetRangeHashResponseBody, error) {
+	return nil, errors.New("unimplemented service call")
 }
 
 func initObjectService(c *cfg) {

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -160,7 +160,7 @@ func initObjectService(c *cfg) {
 
 	sPut := putsvc.NewService(
 		putsvc.WithKeyStorage(keyStorage),
-		putsvc.WithMaxSizeSource(&maxSzSrc{3}),
+		putsvc.WithMaxSizeSource(&maxSzSrc{c.cfgObject.maxObjectSize}),
 		putsvc.WithLocalStorage(ls),
 		putsvc.WithContainerSource(c.cfgObject.cnrStorage),
 		putsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -3,15 +3,83 @@ package main
 import (
 	"context"
 	"errors"
+	"sync"
 
+	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	objectGRPC "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/bucket"
 	objectTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/object/grpc"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
 )
 
 type objectExecutor struct{}
+
+type inMemBucket struct {
+	bucket.Bucket
+	*sync.RWMutex
+	items map[string][]byte
+}
+
+func newBucket() bucket.Bucket {
+	return &inMemBucket{
+		RWMutex: new(sync.RWMutex),
+		items:   map[string][]byte{},
+	}
+}
+
+func (b *inMemBucket) Get(key []byte) ([]byte, error) {
+	b.RLock()
+	v, ok := b.items[base58.Encode(key)]
+	b.RUnlock()
+
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return v, nil
+}
+
+func (b *inMemBucket) Set(key, value []byte) error {
+	k := base58.Encode(key)
+
+	b.Lock()
+	b.items[k] = makeCopy(value)
+	b.Unlock()
+
+	return nil
+}
+
+func (b *inMemBucket) Iterate(handler bucket.FilterHandler) error {
+	if handler == nil {
+		return bucket.ErrNilFilterHandler
+	}
+
+	b.RLock()
+	for key, val := range b.items {
+		k, err := base58.Decode(key)
+		if err != nil {
+			panic(err)
+		}
+
+		v := makeCopy(val)
+
+		if !handler(k, v) {
+			return bucket.ErrIteratingAborted
+		}
+	}
+	b.RUnlock()
+
+	return nil
+}
+
+func makeCopy(val []byte) []byte {
+	tmp := make([]byte, len(val))
+	copy(tmp, val)
+
+	return tmp
+}
 
 func (*objectExecutor) Get(context.Context, *object.GetRequestBody) (objectService.GetObjectBodyStreamer, error) {
 	return nil, errors.New("unimplemented service call")

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -1,9 +1,22 @@
 package network
 
 import (
+	"net"
+	"strings"
+
 	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/pkg/errors"
+)
+
+/*
+	HostAddr strings: 	"localhost:8080", ":8080", "192.168.0.1:8080"
+	MultiAddr strings: 	"/dns4/localhost/tcp/8080", "/ip4/192.168.0.1/tcp/8080"
+	IPAddr strings:		"192.168.0.1:8080"
+*/
+
+const (
+	L4Protocol = "tcp"
 )
 
 // Address represents the NeoFS node
@@ -18,12 +31,13 @@ type LocalAddressSource interface {
 	LocalAddress() *Address
 }
 
+// String returns multiaddr string
 func (a Address) String() string {
 	return a.ma.String()
 }
 
-// NetAddr returns network endpoint address in string format.
-func (a Address) NetAddr() (string, error) {
+// IPAddrString returns network endpoint address in string format.
+func (a Address) IPAddrString() (string, error) {
 	ip, err := manet.ToNetAddr(a.ma)
 	if err != nil {
 		return "", errors.Wrap(err, "could not get net addr")
@@ -32,16 +46,48 @@ func (a Address) NetAddr() (string, error) {
 	return ip.String(), nil
 }
 
-// AddressFromString restores address from a string representation.
+// AddressFromString restores address from a multiaddr string representation.
 func AddressFromString(s string) (*Address, error) {
 	ma, err := multiaddr.NewMultiaddr(s)
 	if err != nil {
-		return nil, err
+		s, err = multiaddrStringFromHostAddr(s)
+		if err != nil {
+			return nil, err
+		}
+
+		ma, err = multiaddr.NewMultiaddr(s) // don't want recursion there
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Address{
 		ma: ma,
 	}, nil
+}
+
+// multiaddrStringFromHostAddr converts "localhost:8080" to "/dns4/localhost/tcp/8080"
+func multiaddrStringFromHostAddr(host string) (string, error) {
+	endpoint, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		prefix = "/dns4"
+		addr   = endpoint
+	)
+
+	if ip := net.ParseIP(endpoint); ip != nil {
+		addr = ip.String()
+		if ip.To4() == nil {
+			prefix = "/ip6"
+		} else {
+			prefix = "/ip4"
+		}
+	}
+
+	return strings.Join([]string{prefix, addr, L4Protocol, port}, "/"), nil
 }
 
 // IsLocalAddress returns true if network endpoint from local address

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -23,13 +23,13 @@ func (a Address) String() string {
 }
 
 // NetAddr returns network endpoint address in string format.
-func (a Address) NetAddr() string {
+func (a Address) NetAddr() (string, error) {
 	ip, err := manet.ToNetAddr(a.ma)
 	if err != nil {
-		panic(errors.Wrap(err, "could not get net addr"))
+		return "", errors.Wrap(err, "could not get net addr")
 	}
 
-	return ip.String()
+	return ip.String(), nil
 }
 
 // AddressFromString restores address from a string representation.
@@ -47,5 +47,5 @@ func AddressFromString(s string) (*Address, error) {
 // IsLocalAddress returns true if network endpoint from local address
 // source is equal to network endpoint of passed address.
 func IsLocalAddress(src LocalAddressSource, addr *Address) bool {
-	return src.LocalAddress().NetAddr() == addr.NetAddr()
+	return src.LocalAddress().ma.Equal(addr.ma)
 }

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -24,5 +24,7 @@ func TestAddress_NetAddr(t *testing.T) {
 	addr, err := AddressFromString(ma.String())
 	require.NoError(t, err)
 
-	require.Equal(t, ip+":"+port, addr.NetAddr())
+	netAddr, err := addr.NetAddr()
+	require.NoError(t, err)
+	require.Equal(t, ip+":"+port, netAddr)
 }

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -24,7 +24,7 @@ func TestAddress_NetAddr(t *testing.T) {
 	addr, err := AddressFromString(ma.String())
 	require.NoError(t, err)
 
-	netAddr, err := addr.NetAddr()
+	netAddr, err := addr.IPAddrString()
 	require.NoError(t, err)
 	require.Equal(t, ip+":"+port, netAddr)
 }

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -22,7 +22,7 @@ func (h *remoteHeader) head(ctx context.Context, prm *Prm, handler func(*object.
 		return errors.Wrapf(err, "(%T) could not receive private key", h)
 	}
 
-	addr, err := h.node.NetAddr()
+	addr, err := h.node.IPAddrString()
 	if err != nil {
 		return err
 	}

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -22,7 +22,10 @@ func (h *remoteHeader) head(ctx context.Context, prm *Prm, handler func(*object.
 		return errors.Wrapf(err, "(%T) could not receive private key", h)
 	}
 
-	addr := h.node.NetAddr()
+	addr, err := h.node.NetAddr()
+	if err != nil {
+		return err
+	}
 
 	c, err := client.New(key,
 		client.WithAddress(addr),

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -38,7 +38,10 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		return nil, errors.Wrapf(err, "(%T) could not receive private key", t)
 	}
 
-	addr := t.addr.NetAddr()
+	addr, err := t.addr.NetAddr()
+	if err != nil {
+		return nil, err
+	}
 
 	c, err := client.New(key,
 		client.WithAddress(addr),

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -38,7 +38,7 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		return nil, errors.Wrapf(err, "(%T) could not receive private key", t)
 	}
 
-	addr, err := t.addr.NetAddr()
+	addr, err := t.addr.IPAddrString()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/object/range/remote.go
+++ b/pkg/services/object/range/remote.go
@@ -32,7 +32,10 @@ func (r *remoteRangeWriter) WriteTo(w io.Writer) (int64, error) {
 		return 0, errors.Wrapf(err, "(%T) could not receive private key", r)
 	}
 
-	addr := r.node.NetAddr()
+	addr, err := r.node.NetAddr()
+	if err != nil {
+		return 0, err
+	}
 
 	c, err := client.New(key,
 		client.WithAddress(addr),

--- a/pkg/services/object/range/remote.go
+++ b/pkg/services/object/range/remote.go
@@ -32,7 +32,7 @@ func (r *remoteRangeWriter) WriteTo(w io.Writer) (int64, error) {
 		return 0, errors.Wrapf(err, "(%T) could not receive private key", r)
 	}
 
-	addr, err := r.node.NetAddr()
+	addr, err := r.node.IPAddrString()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/services/object/rangehash/remote.go
+++ b/pkg/services/object/rangehash/remote.go
@@ -23,7 +23,10 @@ func (h *remoteHasher) hashRange(ctx context.Context, prm *Prm, handler func([][
 		return errors.Wrapf(err, "(%T) could not receive private key", h)
 	}
 
-	addr := h.node.NetAddr()
+	addr, err := h.node.NetAddr()
+	if err != nil {
+		return err
+	}
 
 	c, err := client.New(key,
 		client.WithAddress(addr),

--- a/pkg/services/object/rangehash/remote.go
+++ b/pkg/services/object/rangehash/remote.go
@@ -23,7 +23,7 @@ func (h *remoteHasher) hashRange(ctx context.Context, prm *Prm, handler func([][
 		return errors.Wrapf(err, "(%T) could not receive private key", h)
 	}
 
-	addr, err := h.node.NetAddr()
+	addr, err := h.node.IPAddrString()
 	if err != nil {
 		return err
 	}

--- a/pkg/services/object/search/remote.go
+++ b/pkg/services/object/search/remote.go
@@ -24,7 +24,10 @@ func (s *remoteStream) stream(ctx context.Context, ch chan<- []*object.ID) error
 		return errors.Wrapf(err, "(%T) could not receive private key", s)
 	}
 
-	addr := s.addr.NetAddr()
+	addr, err := s.addr.NetAddr()
+	if err != nil {
+		return err
+	}
 
 	c, err := client.New(key,
 		client.WithAddress(addr),

--- a/pkg/services/object/search/remote.go
+++ b/pkg/services/object/search/remote.go
@@ -24,7 +24,7 @@ func (s *remoteStream) stream(ctx context.Context, ch chan<- []*object.ID) error
 		return errors.Wrapf(err, "(%T) could not receive private key", s)
 	}
 
-	addr, err := s.addr.NetAddr()
+	addr, err := s.addr.IPAddrString()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some commits from this PR will be cherry-picked for separate PR, e.g: https://github.com/nspcc-dev/neofs-node/commit/f6e121b85ecdaa7bdef27efab4d22bd15edfe13b https://github.com/nspcc-dev/neofs-node/commit/93531b312ce0123f1be312e2bcf39ffb2b55da0d https://github.com/nspcc-dev/neofs-node/commit/1b6df7340f81053bec6841a811bc299bfe270a5a .

Other network related things will be updated with new object service method implementations in `jindo` branch. When all seven object service methods will be implemented, this PR will be moved from drafts to open.