### PR TITLE
[#45] object/search: Add filtering parent objects

### DIFF
--- a/pkg/services/object/search/local.go
+++ b/pkg/services/object/search/local.go
@@ -26,8 +26,6 @@ type searchQueryFilter struct {
 }
 
 func (s *localStream) stream(ctx context.Context, ch chan<- []*objectSDK.ID) error {
-	idList := make([]*objectSDK.ID, 0)
-
 	filter := &searchQueryFilter{
 		query: s.query,
 		ch:    ch,
@@ -38,15 +36,11 @@ func (s *localStream) stream(ctx context.Context, ch chan<- []*objectSDK.ID) err
 		case <-ctx.Done():
 			return true
 		default:
-			idList = append(idList, meta.Head().GetID())
-
 			return false
 		}
 	}); err != nil && !errors.Is(errors.Cause(err), bucket.ErrIteratingAborted) {
 		return errors.Wrapf(err, "(%T) could not iterate over local storage", s)
 	}
-
-	ch <- idList
 
 	return nil
 }


### PR DESCRIPTION
In previous implementation object.Search services allowed to search only
physically stored objects. This limitation did not allow getting the ID of
the split object.

Extend search execution logic with parent object filtering. Parent objects
that passed filters are now included in the result

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

Closes #45.