### PR TITLE
object/transformer: Fix incorrect relation init stage

### DIFF
--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -79,6 +79,9 @@ func (s *payloadSizeLimiter) initialize() {
 			s.parent.ResetRelations()
 			s.parentHashers = s.currentHashers
 			s.current = fromObject(s.parent)
+
+			// initialize blank split header
+			s.current.InitRelations()
 		}
 
 		// set previous object to the last previous identifier
@@ -217,9 +220,6 @@ func (s *payloadSizeLimiter) initializeLinking() {
 func (s *payloadSizeLimiter) writeChunk(chunk []byte) error {
 	// statement is true if the previous write of bytes reached exactly the boundary.
 	if s.written > 0 && s.written%s.maxSize == 0 {
-		// initialize blank split header
-		s.current.InitRelations()
-
 		// we need to release current object
 		if _, err := s.release(false); err != nil {
 			return errors.Wrap(err, "could not release object")


### PR DESCRIPTION
In previous implementation InitRelations call in payload size limiter was
called in write chunk method. This provoked clearing the split header in
children starting from the second.

Replace InitRelations call to the 1st child allocating stage.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>