### PR TITLE
Support FS bucket and BoltDB bucket

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -149,7 +149,10 @@ func (s *objectSvc) GetRangeHash(ctx context.Context, req *object.GetRangeHashRe
 }
 
 func initObjectService(c *cfg) {
-	ls := localstore.New(newBucket(), newBucket())
+	ls := localstore.New(
+		c.cfgObject.blobstorage,
+		c.cfgObject.metastorage,
+	)
 	keyStorage := util.NewKeyStorage(c.key, c.privateTokenStore)
 	nodeOwner := owner.NewID()
 

--- a/pkg/local_object_storage/bucket/boltdb/boltdb.go
+++ b/pkg/local_object_storage/bucket/boltdb/boltdb.go
@@ -31,7 +31,7 @@ const defaultFilePermission = 0777
 
 var errEmptyPath = errors.New("database empty path")
 
-const name = "boltbucket"
+const Name = "boltdb"
 
 func makeCopy(val []byte) []byte {
 	tmp := make([]byte, len(val))
@@ -41,7 +41,9 @@ func makeCopy(val []byte) []byte {
 }
 
 // NewOptions prepares options for badger instance.
-func NewOptions(v *viper.Viper) (opts Options, err error) {
+func NewOptions(prefix string, v *viper.Viper) (opts Options, err error) {
+	prefix = prefix + "." + Name
+
 	opts = Options{
 		Options: bbolt.Options{
 			// set defaults:
@@ -49,30 +51,30 @@ func NewOptions(v *viper.Viper) (opts Options, err error) {
 			FreelistType: bbolt.DefaultOptions.FreelistType,
 
 			// set config options:
-			NoSync:         v.GetBool(name + ".no_sync"),
-			ReadOnly:       v.GetBool(name + ".read_only"),
-			NoGrowSync:     v.GetBool(name + ".no_grow_sync"),
-			NoFreelistSync: v.GetBool(name + ".no_freelist_sync"),
+			NoSync:         v.GetBool(prefix + ".no_sync"),
+			ReadOnly:       v.GetBool(prefix + ".read_only"),
+			NoGrowSync:     v.GetBool(prefix + ".no_grow_sync"),
+			NoFreelistSync: v.GetBool(prefix + ".no_freelist_sync"),
 
-			PageSize:        v.GetInt(name + ".page_size"),
-			MmapFlags:       v.GetInt(name + ".mmap_flags"),
-			InitialMmapSize: v.GetInt(name + ".initial_mmap_size"),
+			PageSize:        v.GetInt(prefix + ".page_size"),
+			MmapFlags:       v.GetInt(prefix + ".mmap_flags"),
+			InitialMmapSize: v.GetInt(prefix + ".initial_mmap_size"),
 		},
 
-		Name: []byte(name),
+		Name: []byte(Name),
 		Perm: defaultFilePermission,
-		Path: v.GetString(name + ".path"),
+		Path: v.GetString(prefix + ".path"),
 	}
 
 	if opts.Path == "" {
 		return opts, errEmptyPath
 	}
 
-	if tmp := v.GetDuration(name + ".lock_timeout"); tmp > 0 {
+	if tmp := v.GetDuration(prefix + ".lock_timeout"); tmp > 0 {
 		opts.Timeout = tmp
 	}
 
-	if perm := v.GetUint32(name + ".perm"); perm != 0 {
+	if perm := v.GetUint32(prefix + ".perm"); perm != 0 {
 		opts.Perm = os.FileMode(perm)
 	}
 

--- a/pkg/local_object_storage/bucket/fsbucket/bucket.go
+++ b/pkg/local_object_storage/bucket/fsbucket/bucket.go
@@ -26,7 +26,7 @@ type (
 	}
 )
 
-const name = "fsbucket"
+const Name = "filesystem"
 
 const (
 	defaultDirectory   = "fsbucket"
@@ -51,7 +51,8 @@ func decodeKey(key string) []byte {
 }
 
 // NewBucket creates new file system bucket instance.
-func NewBucket(v *viper.Viper) (bucket.Bucket, error) {
+func NewBucket(prefix string, v *viper.Viper) (bucket.Bucket, error) {
+	prefix = prefix + "." + Name
 	var (
 		dir  string
 		perm os.FileMode
@@ -60,27 +61,27 @@ func NewBucket(v *viper.Viper) (bucket.Bucket, error) {
 		depth     int
 	)
 
-	if dir = v.GetString(name + ".directory"); dir == "" {
+	if dir = v.GetString(prefix + ".directory"); dir == "" {
 		dir = defaultDirectory
 	}
 
-	if perm = os.FileMode(v.GetInt(name + ".permissions")); perm == 0 {
+	if perm = os.FileMode(v.GetInt(prefix + ".permissions")); perm == 0 {
 		perm = defaultPermissions
 	}
 
-	if depth = v.GetInt(name + ".depth"); depth <= 0 {
+	if depth = v.GetInt(prefix + ".depth"); depth <= 0 {
 		depth = defaultDepth
 	}
 
-	if prefixLen = v.GetInt(name + ".prefix_len"); prefixLen <= 0 {
+	if prefixLen = v.GetInt(prefix + ".prefix_len"); prefixLen <= 0 {
 		prefixLen = defaultPrefixLen
 	}
 
 	if err := os.MkdirAll(dir, perm); err != nil {
-		return nil, errors.Wrapf(err, "could not create bucket %s", name)
+		return nil, errors.Wrapf(err, "could not create bucket %s", Name)
 	}
 
-	if v.GetBool(name + ".tree_enabled") {
+	if v.GetBool(prefix + ".tree_enabled") {
 		b := &treeBucket{
 			dir:          dir,
 			perm:         perm,


### PR DESCRIPTION
Backport of storage buckets. Should be removed with new `blobstor` and `metabase`. 

These buckets can be used to store blobs and metadata. They will be removed as enhanced blob storage will be implemented for neofs-node. To setup storage type use `storage.object.type` and `storage.meta.type` parameters.

Available options:

  - `inmemory` (default)
  - `boltdb`
  - `filesystem`