### PR TITLE
Fix order of update peer state method arguments

### DIFF
--- a/pkg/innerring/invoke/netmap.go
+++ b/pkg/innerring/invoke/netmap.go
@@ -71,8 +71,8 @@ func UpdatePeerState(cli *client.Client, con util.Uint160, args *UpdatePeerArgs)
 	}
 
 	return cli.Invoke(con, extraFee, updatePeerStateMethod,
-		args.Key.Bytes(),
 		int64(args.Status),
+		args.Key.Bytes(),
 	)
 }
 


### PR DESCRIPTION
This method has node status first and public key second.