### PR TITLE
Use morph wrapper to process container service methods

### DIFF
--- a/pkg/morph/client/container/wrapper/container.go
+++ b/pkg/morph/client/container/wrapper/container.go
@@ -71,7 +71,14 @@ func (w *Wrapper) Get(cid *container.ID) (*container.Container, error) {
 	// ask RPC neo node to get serialized container
 	rpcAnswer, err := w.client.Get(args)
 	if err != nil {
-		return nil, errors.Wrap(core.ErrNotFound, err.Error())
+		return nil, err
+	}
+
+	// In #37 we've decided to remove length check, because smart contract would
+	// fail on casting `nil` value from storage to `[]byte` producing FAULT state.
+	// Apparently it does not fail, so we have to check length explicitly.
+	if len(rpcAnswer.Container()) == 0 {
+		return nil, core.ErrNotFound
 	}
 
 	// convert serialized bytes into GRPC structure

--- a/pkg/morph/client/container/wrapper/container.go
+++ b/pkg/morph/client/container/wrapper/container.go
@@ -8,7 +8,6 @@ import (
 	v2container "github.com/nspcc-dev/neofs-api-go/v2/container"
 	msgContainer "github.com/nspcc-dev/neofs-api-go/v2/container/grpc"
 	v2refs "github.com/nspcc-dev/neofs-api-go/v2/refs"
-	msgRefs "github.com/nspcc-dev/neofs-api-go/v2/refs/grpc"
 	core "github.com/nspcc-dev/neofs-node/pkg/core/container"
 	client "github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
 	"github.com/pkg/errors"
@@ -144,16 +143,9 @@ func (w *Wrapper) List(ownerID *owner.ID) ([]*container.ID, error) {
 	result := make([]*container.ID, 0, len(rawIDs))
 
 	for i := range rawIDs {
-		// convert serialized bytes into GRPC structure
-		grpcMsg := new(msgRefs.ContainerID)
-		err = grpcMsg.Unmarshal(rawIDs[i])
-		if err != nil {
-			// use other major version if there any
-			return nil, errors.Wrap(err, "can't unmarshal container id")
-		}
+		v2 := new(v2refs.ContainerID)
+		v2.SetValue(rawIDs[i])
 
-		// convert GRPC structure into SDK structure, used in the code
-		v2 := v2refs.ContainerIDFromGRPCMessage(grpcMsg)
 		cid := container.NewIDFromV2(v2)
 
 		result = append(result, cid)


### PR DESCRIPTION
Also fixes bug when `container.Get` method returned empty container if requested container does not exists. 