### PR TITLE
Implement accounting.balance command in CLI

### DIFF
--- a/cmd/neofs-cli/modules/accounting.go
+++ b/cmd/neofs-cli/modules/accounting.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"math"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/accounting"
 	"github.com/spf13/cobra"
 )
 
@@ -11,13 +14,39 @@ var accountingCmd = &cobra.Command{
 	Use:   "accounting",
 	Short: "Operations with accounts and balances",
 	Long:  `Operations with accounts and balances`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("accounting called")
+}
+
+var accountingBalanceCmd = &cobra.Command{
+	Use:   "balance",
+	Short: "Get internal balance of NeoFS account",
+	Long:  `Get internal balance of NeoFS account`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			response *accounting.Decimal
+			err      error
+			ctx      = context.Background()
+		)
+
+		cli, err := getSDKClient()
+		if err != nil {
+			return err
+		}
+
+		response, err = cli.GetSelfBalance(ctx)
+		if err != nil {
+			return fmt.Errorf("rpc error: %w", err)
+		}
+
+		// print to stdout
+		prettyPrintDecimal(response)
+
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(accountingCmd)
+	accountingCmd.AddCommand(accountingBalanceCmd)
 
 	// Here you will define your flags and configuration settings.
 
@@ -28,4 +57,23 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// accountingCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func prettyPrintDecimal(decimal *accounting.Decimal) {
+	if decimal == nil {
+		return
+	}
+
+	if verbose {
+		fmt.Println("value:", decimal.GetValue())
+		fmt.Println("precision:", decimal.GetPrecision())
+	} else {
+		// divider = 10^{precision}; v:365, p:2 => 365 / 10^2 = 3.65
+		divider := math.Pow(10, float64(decimal.GetPrecision()))
+
+		// %0.8f\n for precision 8
+		format := fmt.Sprintf("%%0.%df\n", decimal.GetPrecision())
+
+		fmt.Printf(format, float64(decimal.GetValue())/divider)
+	}
 }

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	crypto "github.com/nspcc-dev/neofs-crypto"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -16,6 +17,7 @@ import (
 var (
 	cfgFile    string
 	privateKey string
+	endpoint   string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -31,7 +33,8 @@ and much more!`,
 }
 
 var (
-	errInvalidKey = errors.New("provided key is incorrect")
+	errInvalidKey      = errors.New("provided key is incorrect")
+	errInvalidEndpoint = errors.New("provided RPC endpoint is incorrect")
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -52,6 +55,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/neofs-cli/config.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&privateKey, "key", "k", "", "private key in hex, WIF or filepath")
+	rootCmd.PersistentFlags().StringVarP(&endpoint, "rpc-endpoint", "r", "", "remote node address (as 'multiaddr' or '<host>:<port>')")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -92,4 +96,15 @@ func getKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	return key, nil
+}
+
+// getEndpointAddress returns network address structure that stores multiaddr
+// inside, parsed from global arguments.
+func getEndpointAddress() (*network.Address, error) {
+	addr, err := network.AddressFromString(endpoint)
+	if err != nil {
+		return nil, errInvalidEndpoint
+	}
+
+	return addr, nil
 }

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -7,7 +7,9 @@ import (
 	"os"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/spf13/cobra"
@@ -131,4 +133,22 @@ func getSDKClient() (*client.Client, error) {
 	}
 
 	return client.New(key, client.WithAddress(ipAddr))
+}
+
+// ownerFromString converts string with NEO3 wallet address to neofs owner ID.
+func ownerFromString(s string) (*owner.ID, error) {
+	var w owner.NEO3Wallet
+
+	// todo: move this into neofs-api-go `owner.NEO3WalletFromString` function
+	binaryWallet, err := base58.Decode(s)
+	if err != nil || len(binaryWallet) != len(w) {
+		return nil, errors.New("can't decode owner ID wallet address")
+	}
+
+	copy(w[:], binaryWallet)
+
+	id := owner.NewID()
+	id.SetNeo3Wallet(&w)
+
+	return id, nil
 }

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -44,7 +44,6 @@ var (
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -18,6 +18,8 @@ var (
 	cfgFile    string
 	privateKey string
 	endpoint   string
+
+	verbose bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -56,6 +58,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/neofs-cli/config.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&privateKey, "key", "k", "", "private key in hex, WIF or filepath")
 	rootCmd.PersistentFlags().StringVarP(&endpoint, "rpc-endpoint", "r", "", "remote node address (as 'multiaddr' or '<host>:<port>')")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/spf13/cobra"
@@ -110,4 +111,25 @@ func getEndpointAddress() (*network.Address, error) {
 	}
 
 	return addr, nil
+}
+
+// getSDKClient returns default neofs-api-go sdk client. Consider using
+// opts... to provide TTL or other global configuration flags.
+func getSDKClient() (*client.Client, error) {
+	key, err := getKey()
+	if err != nil {
+		return nil, err
+	}
+
+	netAddr, err := getEndpointAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	ipAddr, err := netAddr.IPAddrString()
+	if err != nil {
+		return nil, errInvalidEndpoint
+	}
+
+	return client.New(key, client.WithAddress(ipAddr))
 }


### PR DESCRIPTION
This pull request provides several features that has been implemented to provide accounting.balance command implementation.

## Support of `--key` argument
Closes #78 
User can specify key as a hex value, WIF or path to 32-byte binary file.

```bash
./bin/neofs-cli -k ec9bb1e4e4d9b8c8918037891432620a25da0018b41818b0fa4706d824287d01 # 32 byte hex
./bin/neofs-cli -k L59eSJr2FtupmtRAeGy2DwJyoihz5D5Yj1z56v3CCkGdVa5htJLP # WIF
./bin/neofs-cli -k /path/to/neofs.key # path to 32 byte binary file
```

## In-place key generation with `--key new` argument

User can make anonymous requests to access data in public containers. Key can be generated automatically by CLI with `--key new` argument.

```bash
./bin/neofs-cli --key new # generates random private key
```

## Support of `--rpc-endpoint` argument
Closes #77 
Endpoint can be specified as `hostname:port`, `ip:port`, `multiaddr:port`.

```bash
./bin/neofs-cli -r 's01.neofs.devenv:8080'
./bin/neofs-cli -r '192.168.130.71:8080'
./bin/neofs-cli -r '/dns4/s01.neofs.devenv/tcp/8080'
```


## Support of `--verbose` flag
Verbose flag provide extra information. With `--key new` flag it prints out used key

```bash
./bin/neofs-cli -r 's01.neofs.devenv:8080' --key new -v <command>
Generating private key: c51e38c5761c0521026789512614cb31b1ebd5c5b0b2f722375d6dbe44f11dad
...
```

## Implementation of accounting.balance command
Closes #76 

User can look for it's own account (owner ID from provided key) or get balance of specific owner.

```bash
./bin/neofs-cli --key ./user.key -r s01.neofs.devenv:8080 accounting balance
60.0000000000000000

./bin/neofs-cli --key new -r s01.neofs.devenv:8080 accounting balance --oid NTrezR3C4X8aMLVg7vozt5wguyNfFhwuFx
60.0000000000000000
```

Verbose flag prints value and precision without formatting:
```
$ ./bin/neofs-cli --key ./user.key -r s01.neofs.devenv:8080 accounting balance --verbose
value: 600000000000000000
precision: 16
```

## Support of configuration files and envs for key and endpoint arguments

Binding with viper allows to get data from yml config or environment variables. This PR adds support for `key` and `rpc-endpoint` arguments. Environment variables should have `NEOFS_CLI` prefix

```bash
$ cat config.yml 
rpc: s01.neofs.devenv:8080

$ NEOFS_CLI_KEY=KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr ./bin/neofs-cli -c config.yml accounting balance
Using config file: config.yml
60.0000000000000000
```