### PR TITLE
Gracefully shutdown inner ring node at RPC node fail

### DIFF
--- a/pkg/morph/subscriber/subscriber.go
+++ b/pkg/morph/subscriber/subscriber.go
@@ -104,7 +104,14 @@ func (s *subscriber) routeNotifications(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case notification := <-s.client.Notifications:
+		case notification, ok := <-s.client.Notifications:
+			if !ok {
+				s.log.Warn("remote channel has been closed")
+				close(s.notify)
+
+				return
+			}
+
 			switch notification.Type {
 			case response.NotificationEventID:
 				notification, ok := notification.Value.(*result.NotificationEvent)


### PR DESCRIPTION
Closes #72 

If mainnet or sidechain RPC node fails, inner ring node will be gracefully shutdown. Later on we can make something like reconnect after a timeout, but this **must** reinitialize the whole inner ring application state. For example neofs-contract removes node from inner ring list while its RPC node was inactive. Thus if node was not reinitialized, then it will remain active local state. 

The easiest way to reinitialize application is to restart it. That's why for now inner ring node just shutdowns on RPC node fail. 