### PR TITLE
Provide session token to all produced requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201008123857-a29b6155220a
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nBXK8uDY/JZaxIZzAUfkzfaotVw2FbnHxO4aZI=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201008123857-a29b6155220a h1:D3y9zcmYXf2eDafX6Pg252Ar5kDnkfJQaBf+tDn1RrA=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201008123857-a29b6155220a/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b h1:P/riND6RkFU6xv895sdTBYqjtRh7jDSvKC1+tzP3LcQ=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/pkg/services/object/delete/service.go
+++ b/pkg/services/object/delete/service.go
@@ -20,7 +20,7 @@ type Service struct {
 type Option func(*cfg)
 
 type RelationHeader interface {
-	HeadRelation(context.Context, *objectSDK.Address) (*object.Object, error)
+	HeadRelation(context.Context, *objectSDK.Address, *objutil.CommonPrm) (*object.Object, error)
 }
 
 type cfg struct {
@@ -107,7 +107,7 @@ func (s *Service) Delete(ctx context.Context, prm *Prm) (*Response, error) {
 func (s *Service) getRelations(ctx context.Context, prm *Prm) ([]*objectSDK.Address, error) {
 	var res []*objectSDK.Address
 
-	if linking, err := s.hdrLinking.HeadRelation(ctx, prm.addr); err != nil {
+	if linking, err := s.hdrLinking.HeadRelation(ctx, prm.addr, prm.common); err != nil {
 		cid := prm.addr.GetContainerID()
 
 		for prev := prm.addr.GetObjectID(); prev != nil; {

--- a/pkg/services/object/head/relation.go
+++ b/pkg/services/object/head/relation.go
@@ -5,6 +5,7 @@ import (
 
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
 
@@ -21,8 +22,8 @@ func NewRelationHeader(srch RelationSearcher, svc *Service) *RelationHeader {
 	}
 }
 
-func (h *RelationHeader) HeadRelation(ctx context.Context, addr *objectSDK.Address) (*object.Object, error) {
-	id, err := h.srch.SearchRelation(ctx, addr)
+func (h *RelationHeader) HeadRelation(ctx context.Context, addr *objectSDK.Address, prm *objutil.CommonPrm) (*object.Object, error) {
+	id, err := h.srch.SearchRelation(ctx, addr, prm)
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not find relation", h)
 	}

--- a/pkg/services/object/head/service.go
+++ b/pkg/services/object/head/service.go
@@ -14,7 +14,7 @@ import (
 )
 
 type RelationSearcher interface {
-	SearchRelation(context.Context, *objectSDK.Address) (*objectSDK.ID, error)
+	SearchRelation(context.Context, *objectSDK.Address, *objutil.CommonPrm) (*objectSDK.ID, error)
 }
 
 type Service struct {
@@ -67,7 +67,7 @@ func (s *Service) Head(ctx context.Context, prm *Prm) (*Response, error) {
 	}
 
 	// try to find far right child that carries header of desired object
-	rightChildID, err := s.rightChildSearcher.SearchRelation(ctx, prm.addr)
+	rightChildID, err := s.rightChildSearcher.SearchRelation(ctx, prm.addr, prm.common)
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not find right child", s)
 	}
@@ -76,7 +76,7 @@ func (s *Service) Head(ctx context.Context, prm *Prm) (*Response, error) {
 	addr.SetContainerID(prm.addr.GetContainerID())
 	addr.SetObjectID(rightChildID)
 
-	r, err = s.Head(ctx, new(Prm).WithAddress(addr))
+	r, err = s.Head(ctx, new(Prm).WithAddress(addr).WithCommonPrm(prm.common))
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not get right child header", s)
 	}

--- a/pkg/services/object/search/relation.go
+++ b/pkg/services/object/search/relation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/search/query"
 	queryV1 "github.com/nspcc-dev/neofs-node/pkg/services/object/search/query/v1"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
 
@@ -16,9 +17,9 @@ type RelationSearcher struct {
 	queryGenerator func(*object.Address) query.Query
 }
 
-func (s *RelationSearcher) SearchRelation(ctx context.Context, addr *object.Address) (*object.ID, error) {
+func (s *RelationSearcher) SearchRelation(ctx context.Context, addr *object.Address, prm *util.CommonPrm) (*object.ID, error) {
 	streamer, err := s.svc.Search(ctx, new(Prm).
-		WithContainerID(addr.GetContainerID()).
+		WithContainerID(addr.GetContainerID()).WithCommonPrm(prm).
 		WithSearchQuery(s.queryGenerator(addr)),
 	)
 	if err != nil {


### PR DESCRIPTION
If object service produces new request, the should contain session token. This is the only way for node to grant access for a private container.