### PR TITLE
Add gRPC Reflection service

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -50,8 +50,9 @@ const (
 	cfgMaxObjectSize       = "node.maxobjectsize" // todo: get value from chain
 
 	// config keys for cfgGRPC
-	cfgListenAddress = "grpc.endpoint"
-	cfgMaxMsgSize    = "grpc.maxmessagesize"
+	cfgListenAddress  = "grpc.endpoint"
+	cfgMaxMsgSize     = "grpc.maxmessagesize"
+	cfgReflectService = "grpc.enable_reflect_service"
 
 	// config keys for cfgMorph
 	cfgMorphRPCAddress = "morph.endpoint"
@@ -124,6 +125,8 @@ type cfgGRPC struct {
 	maxChunkSize uint64
 
 	maxAddrAmount uint64
+
+	enableReflectService bool
 }
 
 type cfgMorph struct {
@@ -234,8 +237,9 @@ func initCfg(path string) *cfg {
 			maxObjectSize: viperCfg.GetUint64(cfgMaxObjectSize),
 		},
 		cfgGRPC: cfgGRPC{
-			maxChunkSize:  maxChunkSize,
-			maxAddrAmount: maxAddrAmount,
+			maxChunkSize:         maxChunkSize,
+			maxAddrAmount:        maxAddrAmount,
+			enableReflectService: viperCfg.GetBool(cfgReflectService),
 		},
 		localAddr: netAddr,
 	}

--- a/cmd/neofs-node/grpc.go
+++ b/cmd/neofs-node/grpc.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 func initGRPC(c *cfg) {
@@ -24,6 +25,12 @@ func serveGRPC(c *cfg) {
 		defer func() {
 			c.wg.Done()
 		}()
+
+		// read more about reflect service at
+		// https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md
+		if c.cfgGRPC.enableReflectService {
+			reflection.Register(c.cfgGRPC.server)
+		}
 
 		if err := c.cfgGRPC.server.Serve(c.cfgGRPC.listener); err != nil {
 			fmt.Println("gRPC server error", err)


### PR DESCRIPTION
Proposal to add gRPC Reflection service that can be enabled by settings `grpc.enable_reflect_service`.

By default, service is disabled and can be enabled only by `grpc.enable_reflect_service`

Read more about at
https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md

> gRPC Server Reflection provides information about publicly-accessible gRPC services on a server, and assists clients at runtime to construct RPC requests and responses without precompiled service information. It is used by gRPC CLI, which can be used to introspect server protos and send/receive test RPCs.

Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>