### PR TITLE
Remaining container commands for CLI

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -12,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/pkg/acl"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
@@ -132,8 +130,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 			return fmt.Errorf("rpc error: %w", err)
 		}
 
-		// todo: use stringers after neofs-api-go#147
-		fmt.Println("container ID:", base58.Encode(id.ToV2().GetValue()))
+		fmt.Println("container ID:", id)
 
 		if containerAwait {
 			fmt.Println("awaiting...")
@@ -233,8 +230,7 @@ func init() {
 
 func prettyPrintContainerList(list []*container.ID) {
 	for i := range list {
-		// todo: use stringers after neofs-api-go#147
-		fmt.Println(base58.Encode(list[i].ToV2().GetValue()))
+		fmt.Println(list[i])
 	}
 }
 
@@ -317,17 +313,12 @@ func parseNonce(nonce string) (uuid.UUID, error) {
 }
 
 func parseContainerID(cid string) (*container.ID, error) {
-	// todo: use decoders after neofs-api-go#147
-	data, err := base58.Decode(cid)
-	if err != nil || len(data) != sha256.Size {
+	id := container.NewID()
+
+	err := id.Parse(cid)
+	if err != nil {
 		return nil, errors.New("can't decode container ID value")
 	}
-
-	var buf [sha256.Size]byte
-	copy(buf[:], data)
-
-	id := container.NewID()
-	id.SetSHA256(buf)
 
 	return id, nil
 }

--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	attributeDelimiter = ":"
+	attributeDelimiter = "="
 
 	awaitTimeout = 120 // in seconds
 )
@@ -333,8 +333,8 @@ func init() {
 		"hex encoded basic ACL value or keywords 'public', 'private', 'readonly'")
 	createContainerCmd.Flags().StringVarP(&containerPolicy, "policy", "p", "",
 		"QL-encoded or JSON-encoded placement policy or path to file with it")
-	createContainerCmd.Flags().StringArrayVarP(&containerAttributes, "attribute", "a", nil,
-		"colon separated pair of container attribute key and value, e.g. `target:cats`")
+	createContainerCmd.Flags().StringSliceVarP(&containerAttributes, "attributes", "a", nil,
+		"comma separated pairs of container attributes in form of Key1=Value1,Key2=Value2")
 	createContainerCmd.Flags().StringVarP(&containerNonce, "nonce", "n", "", "UUIDv4 nonce value for container")
 	createContainerCmd.Flags().BoolVar(&containerAwait, "await", false, "block execution until container is persisted")
 
@@ -479,7 +479,7 @@ func prettyPrintContainer(cnr *container.Container) {
 	}
 
 	for _, attribute := range cnr.GetAttributes() {
-		fmt.Printf("attribute: `%s:%s`\n", attribute.GetKey(), attribute.GetValue())
+		fmt.Printf("attribute: %s=%s\n", attribute.GetKey(), attribute.GetValue())
 	}
 
 	nonce, err := uuid.FromBytes(cnr.GetNonce())

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	crypto "github.com/nspcc-dev/neofs-crypto"
@@ -165,20 +164,14 @@ func getSDKClient() (*client.Client, error) {
 
 // ownerFromString converts string with NEO3 wallet address to neofs owner ID.
 func ownerFromString(s string) (*owner.ID, error) {
-	var w owner.NEO3Wallet
+	result := owner.NewID()
 
-	// todo: move this into neofs-api-go `owner.NEO3WalletFromString` function
-	binaryWallet, err := base58.Decode(s)
-	if err != nil || len(binaryWallet) != len(w) {
+	err := result.Parse(s)
+	if err != nil {
 		return nil, errors.New("can't decode owner ID wallet address")
 	}
 
-	copy(w[:], binaryWallet)
-
-	id := owner.NewID()
-	id.SetNeo3Wallet(&w)
-
-	return id, nil
+	return result, nil
 }
 
 func printVerbose(format string, a ...interface{}) {

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,6 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nBXK8uDY/JZaxIZzAUfkzfaotVw2FbnHxO4aZI=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b h1:P/riND6RkFU6xv895sdTBYqjtRh7jDSvKC1+tzP3LcQ=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201015080537-4e6350f6d438 h1:Rw3h9BnYzGiDtZX7YPb/7NCFtykE+PqTX7mRL9pqNv0=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201015080537-4e6350f6d438/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/pkg/policy/encode.go
+++ b/pkg/policy/encode.go
@@ -1,0 +1,163 @@
+package policy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+)
+
+func Encode(p *netmap.PlacementPolicy) []string {
+	if p == nil {
+		return nil
+	}
+
+	var (
+		replicas  = p.GetReplicas()
+		selectors = p.GetSelectors()
+		filters   = p.GetFilters()
+	)
+
+	// 1 for container backup factor
+	result := make([]string, 0, len(replicas)+len(selectors)+len(filters)+1)
+
+	// first print replicas
+	encodeReplicas(replicas, &result)
+
+	// then backup factor
+	if backupFactor := p.GetContainerBackupFactor(); backupFactor != 0 {
+		result = append(result, fmt.Sprintf("CBF %d", backupFactor))
+	}
+
+	// then selectors
+	encodeSelectors(selectors, &result)
+
+	// then filters
+	encodeFilters(filters, &result)
+
+	return result
+}
+
+func encodeReplicas(replicas []*netmap.Replica, dst *[]string) {
+	builder := new(strings.Builder)
+
+	for _, replica := range replicas {
+		builder.WriteString("REP ")
+		builder.WriteString(strconv.FormatUint(uint64(replica.GetCount()), 10))
+
+		if s := replica.GetSelector(); s != "" {
+			builder.WriteString(" IN ")
+			builder.WriteString(s)
+		}
+
+		*dst = append(*dst, builder.String())
+		builder.Reset()
+	}
+}
+
+func encodeSelectors(selectors []*netmap.Selector, dst *[]string) {
+	builder := new(strings.Builder)
+
+	for _, selector := range selectors {
+		builder.WriteString("SELECT ")
+		builder.WriteString(strconv.FormatUint(uint64(selector.GetCount()), 10))
+
+		if a := selector.GetAttribute(); a != "" {
+			builder.WriteString(" IN")
+
+			switch selector.GetClause() {
+			case netmap.Same:
+				builder.WriteString(" SAME ")
+			case netmap.Distinct:
+				builder.WriteString(" DISTINCT ")
+			default:
+				builder.WriteString(" ")
+			}
+
+			builder.WriteString(a)
+		}
+
+		if f := selector.GetFilter(); f != "" {
+			builder.WriteString(" FROM ")
+			builder.WriteString(f)
+		}
+
+		if n := selector.GetName(); n != "" {
+			builder.WriteString(" AS ")
+			builder.WriteString(n)
+		}
+
+		*dst = append(*dst, builder.String())
+		builder.Reset()
+	}
+}
+
+func encodeFilters(filters []*netmap.Filter, dst *[]string) {
+	builder := new(strings.Builder)
+
+	for _, filter := range filters {
+		builder.WriteString("FILTER ")
+
+		builder.WriteString(encodeFilter(filter))
+
+		*dst = append(*dst, builder.String())
+		builder.Reset()
+	}
+}
+
+func operationString(operation netmap.Operation) string {
+	switch operation {
+	case netmap.EQ:
+		return "EQ"
+	case netmap.NE:
+		return "NE"
+	case netmap.GT:
+		return "GT"
+	case netmap.GE:
+		return "GE"
+	case netmap.LT:
+		return "LT"
+	case netmap.LE:
+		return "LE"
+	case netmap.OR:
+		return "OR"
+	case netmap.AND:
+		return "AND"
+	default:
+		return ""
+	}
+}
+
+func encodeFilter(filter *netmap.Filter) string {
+	builder := new(strings.Builder)
+	unspecified := filter.GetOp() == netmap.UnspecifiedOperation
+
+	if k := filter.GetKey(); k != "" {
+		builder.WriteString(k)
+		builder.WriteString(" ")
+		builder.WriteString(operationString(filter.GetOp()))
+		builder.WriteString(" ")
+		builder.WriteString(filter.GetValue())
+	} else if n := filter.GetName(); unspecified && n != "" {
+		builder.WriteString("@")
+		builder.WriteString(n)
+	}
+
+	for i, subfilter := range filter.GetFilters() {
+		if i != 0 {
+			builder.WriteString(" ")
+			builder.WriteString(operationString(filter.GetOp()))
+			builder.WriteString(" ")
+		}
+
+		builder.WriteString(encodeFilter(subfilter))
+	}
+
+	if n := filter.GetName(); n != "" && !unspecified {
+		builder.WriteString(" AS ")
+		builder.WriteString(n)
+	}
+
+	return builder.String()
+}

--- a/pkg/policy/encode_test.go
+++ b/pkg/policy/encode_test.go
@@ -1,0 +1,36 @@
+package policy_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/policy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncode(t *testing.T) {
+	testCases := []string{
+		`REP 1 IN X
+CBF 1
+SELECT 2 IN SAME Location FROM * AS X`,
+
+		`REP 1
+SELECT 2 IN City FROM Good
+FILTER Country EQ RU AS FromRU
+FILTER @FromRU AND Rating GT 7 AS Good`,
+
+		`REP 7 IN SPB
+SELECT 1 IN City FROM SPBSSD AS SPB
+FILTER City EQ SPB AND SSD EQ true OR City EQ SPB AND Rating GE 5 AS SPBSSD`,
+	}
+
+	for _, testCase := range testCases {
+		q, err := policy.Parse(testCase)
+		require.NoError(t, err)
+
+		got := policy.Encode(q)
+		fmt.Println(strings.Join(got, "\n"))
+		require.Equal(t, testCase, strings.Join(got, "\n"))
+	}
+}


### PR DESCRIPTION
Closes #25 

PR contains remaining commands from #25. We've decided to skip last command. It will be implemented along with #94. It will provide a way to make a network map dump, since there is no RPC method to get network map.

## List container objects

This command prints user created object IDs (roots) that exist in container. It does not print tombstones, split object IDs or storage groups.

```
./bin/neofs-cli -c config.yml container list-objects --cid 5zUnRy1NgvSB9tjTs9UWzx5DFBsVzU43kH5m7zuxZBpd
B9sLhA1UDCcokx3xxqmFEVPcJCxbycvacsdLLfVp7ZSW
AMjLbCW1aiWnCHmTapyt7HvuNmiWwx59DBUM6yoWEZqD
```

## Get container info

Prints container fields in human readable way. `--to` argument dumps stable marshaled container into the file.

```
./bin/neofs-cli -c config.yml container get --cid 5zUnRy1NgvSB9tjTs9UWzx5DFBsVzU43kH5m7zuxZBpd --to cnr.dump
container ID: 5zUnRy1NgvSB9tjTs9UWzx5DFBsVzU43kH5m7zuxZBpd
version: 2.0
owner ID: NTrezR3C4X8aMLVg7vozt5wguyNfFhwuFx
basic ACL: 18888888 (private)
attribute: hello=world
attribute: store=cats
nonce: 3d5d64c2-1560-42e6-b788-411c9d6833be
placement policy:
REP 1 IN X
CBF 1
SELECT 2 IN SAME Location FROM * AS X
```

`--from` argument allows to read data from local dump without RPC connection. 

```
./bin/neofs-cli container get --from cnr.dump 
container ID: 5zUnRy1NgvSB9tjTs9UWzx5DFBsVzU43kH5m7zuxZBpd
version: 2.0
owner ID: NTrezR3C4X8aMLVg7vozt5wguyNfFhwuFx
basic ACL: 18888888 (private)
attribute: `hello:world`
attribute: `store:cats`
nonce: 3d5d64c2-1560-42e6-b788-411c9d6833be
placement policy:
REP 1 IN X
CBF 1
SELECT 2 IN SAME Location FROM * AS X
```

--- 

Edit 1: now container attributes set up the same way as object attrubutes
```
container create --attributes some=body,once=toldme,theworld=isgonnarollme
```
