### PR TITLE
Update neofs-api-go to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201015080537-4e6350f6d438
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nB
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b h1:P/riND6RkFU6xv895sdTBYqjtRh7jDSvKC1+tzP3LcQ=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201014180956-7b3736567c0b/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201015080537-4e6350f6d438 h1:Rw3h9BnYzGiDtZX7YPb/7NCFtykE+PqTX7mRL9pqNv0=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201015080537-4e6350f6d438/go.mod h1:FsFd1z4YzoEgPlltsUgnqna9qhcF87RHYjot0pby2L4=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
This version support stringers and parsers for identity types.