### PR TITLE
Fix no-root search matcher

### DIFF
--- a/pkg/services/object/search/query/v1/v1.go
+++ b/pkg/services/object/search/query/v1/v1.go
@@ -45,8 +45,8 @@ func (q *Query) Match(obj *object.Object, handler func(*objectSDK.ID)) {
 				default:
 					match = headerEqual(obj, key, q.filters[i].Value())
 				case objectSDK.KeyRoot:
-					match = (q.filters[i].Value() == objectSDK.ValRoot) == !obj.HasParent() &&
-						obj.GetType() == objectSDK.TypeRegular
+					match = (q.filters[i].Value() == objectSDK.ValRoot) == (!obj.HasParent() &&
+						obj.GetType() == objectSDK.TypeRegular)
 				case objectSDK.KeyLeaf:
 					match = (q.filters[i].Value() == objectSDK.ValLeaf) == (par == nil)
 				}


### PR DESCRIPTION
Wrong boolean operation order made matcher return false on `non-root` search query with non-regular objects. Instead it should return true for `non-root` query and false for `root` query.