### PR TITLE
Set split header in left object

### DIFF
--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -79,9 +79,6 @@ func (s *payloadSizeLimiter) initialize() {
 			s.parent.ResetRelations()
 			s.parentHashers = s.currentHashers
 			s.current = fromObject(s.parent)
-
-			// initialize blank split header
-			s.current.InitRelations()
 		}
 
 		// set previous object to the last previous identifier
@@ -220,6 +217,11 @@ func (s *payloadSizeLimiter) initializeLinking() {
 func (s *payloadSizeLimiter) writeChunk(chunk []byte) error {
 	// statement is true if the previous write of bytes reached exactly the boundary.
 	if s.written > 0 && s.written%s.maxSize == 0 {
+		if s.written == s.maxSize {
+			// initialize blank split header on first object in chain
+			s.current.InitRelations()
+		}
+
 		// we need to release current object
 		if _, err := s.release(false); err != nil {
 			return errors.Wrap(err, "could not release object")


### PR DESCRIPTION
## Issue
Left object in chain does not have split header. Therefore this object identified as `root` object, which is incorrect.

## Description
Payload splitter split objects into smaller ones with `maxPayloadSize`. However it sets split header for all objects except first one
```go
func (s *payloadSizeLimiter) initialize() {
	// if it is an object after the 1st
	if ln := len(s.previous); ln > 0 {
		// initialize parent object once (after 1st object)
		if ln == 1 {
			. . .
			// initialize blank split header
			s.current.InitRelations()
		}
```
While this is correct for non-split object, first object in chain treated the same way, which is wrong.

## Proposed solution

Lets set split header at `writeChunk()` method. If chunk has more data than `maxPayloadSize` then we should set split header. However chunks can be aligned with `maxObjectSize`. In this case `writeChunk()` does not know if there are more
data to set split header or not. 

To fix that we **do not finalize** object until there are **more** than `maxObjectSize` data. If it was non-split object, then it will be finalized at `Close()` call. If it was split-object, then `writeChunk()` will be called once more and it will have more than `maxObjectSize` data. There is a trade-off: in this worst case we will store payloads of at two objects in memory.

---

Edit 1: There is a simple fix, since `writeChunk()` method already releases objects only when there are extra data to write.