### PR TITLE
Implement contanier EACL commands

### DIFF
--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -14,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
@@ -453,30 +451,16 @@ func parseObjectAttrs(cmd *cobra.Command) ([]*object.Attribute, error) {
 
 func getCID(cmd *cobra.Command) (*container.ID, error) {
 	cid := container.NewID()
-	var v [32]byte
-	b, err := base58.Decode(cmd.Flag("cid").Value.String())
-	if err != nil {
-		return nil, err
-	} else if len(b) != sha256.Size {
-		return nil, errors.New("invalid length")
-	}
-	copy(v[:], b)
-	cid.SetSHA256(v)
-	return cid, nil
+	err := cid.Parse(cmd.Flag("cid").Value.String())
+
+	return cid, err
 }
 
 func getOID(cmd *cobra.Command) (*object.ID, error) {
 	oid := object.NewID()
-	var v [32]byte
-	b, err := base58.Decode(cmd.Flag("oid").Value.String())
-	if err != nil {
-		return nil, err
-	} else if len(b) != sha256.Size {
-		return nil, errors.New("invalid length")
-	}
-	copy(v[:], b)
-	oid.SetSHA256(v)
-	return oid, nil
+	err := oid.Parse(cmd.Flag("oid").Value.String())
+
+	return oid, err
 }
 
 func getObjectAddress(cmd *cobra.Command) (*object.Address, error) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020123541-2aa40b0dd3a5
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020152448-c8f46f7d9762
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nBXK8uDY/JZaxIZzAUfkzfaotVw2FbnHxO4aZI=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020123541-2aa40b0dd3a5 h1:6ZsBrLnG0BASIDZ+/mv1Q/Ht6wANCcKlbNpboE7K+yc=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020123541-2aa40b0dd3a5/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020152448-c8f46f7d9762 h1:5pCgsBC8XQHX8U+ZBMsX7+87fw7nSMPBwHrewvKLXlk=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201020152448-c8f46f7d9762/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
## Get extended ACL

Prints to stdout in JSON format. With `--to` options CLI dumps binary encoded (default) container or JSON encoded (with `--json`) container to file.

```
$ ./bin/neofs-cli -c config.yml container get-eacl --cid 8RFEWxo7eEjnykDbHfKUrmeBjLF3Y9afLFc5WSXTZtdn --to got-eacl.json --json
dumping data to file: got-eacl.json

$ cat got-eacl.json | jq "."
{
  "version": {
    "major": 2
  },
  "containerID": {
    "value": "bjfXXJ/Zi2iN1h97Ks4mbZDQ2qagotz3FJRMFG8+dqE="
  },
  "records": [
    {
      "operation": "HEAD",
      "action": "DENY",
      "filters": [
        {
          "headerType": "OBJECT",
          "matchType": "STRING_EQUAL",
          "headerName": "_CID",
          "value": "6e37d75c9fd98b688dd61f7b2ace266d90d0daa6a0a2dcf714944c146f3e76a1"
        }
      ],
      "targets": [
        {
          "role": "OTHERS",
          "keys": [
            "AvsoSsocqV0AUpV3SlXnarvmLUTdmn4vke/8FjlEePgV"
          ]
        }
      ]
    }
  ]
}
```

It also prints message if extended ACL was not set.

```
$ ./bin/neofs-cli -c config.yml container get-eacl --cid 8RFEWxo7eEjnykDbHfKUrmeBjLF3Y9afLFc5WSXTZtdn 
extended ACL table is not set for this container
```

## Set extended ACL

Extended ACL can be set up from binary encoded file or JSON encoded file. `Version` and `ContainerID` fields are overrided by CLI, so they can be omitted in file. `--await` flag locks execution until extended ACL will be persisted on chain.

```
$ cat eacl.json 
{
  "records": [
    {
      "operation": "HEAD",
      "action": "DENY",
      "filters": [
        {
          "headerType": "OBJECT",
          "matchType": "STRING_EQUAL",
          "headerName": "_CID",
          "value": "6e37d75c9fd98b688dd61f7b2ace266d90d0daa6a0a2dcf714944c146f3e76a1"
        }
      ],
      "targets": [
        {
          "role": "OTHERS",
          "keys": [
            "AvsoSsocqV0AUpV3SlXnarvmLUTdmn4vke/8FjlEePgV"
          ]
        }
      ]
    }
  ]
}

$ ./bin/neofs-cli -c config.yml container set-eacl --cid 8RFEWxo7eEjnykDbHfKUrmeBjLF3Y9afLFc5WSXTZtdn --table ./eacl.json --await
awaiting...                                                                                                                                                        
EACL has been persisted on sidechain                    
```

## Get container in JSON format
With `--json` flag container get command prints and dumps output in JSON format

```
$ ./bin/neofs-cli -c config.yml container get --cid 8RFEWxo7eEjnykDbHfKUrmeBjLF3Y9afLFc5WSXTZtdn --json
{
  "version": {
    "major": 2
  },
  "ownerID": {
    "value": "NVcgkcwyXGV7SxngxxBLrgYierkSmk7iYw=="
  },
  "nonce": "Srbs9HgHRbepn5cBjTQkTw==",
  "basicACL": 411601032,
  "placementPolicy": {
    "replicas": [
      {
        "count": 1,
        "selector": "X"
      }
    ],
    "containerBackupFactor": 1,
    "selectors": [
      {
        "name": "X",
        "count": 2,
        "clause": "SAME",
        "attribute": "Location",
        "filter": "*"
      }
    ]
  }
}
```