### PR TITLE
Check session token validity

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -86,6 +86,7 @@ type accessErr struct {
 
 var (
 	ErrMalformedRequest = errors.New("malformed request")
+	ErrInternal         = errors.New("internal error")
 	ErrUnknownRole      = errors.New("can't classify request sender")
 	ErrUnknownContainer = errors.New("can't fetch container info")
 )
@@ -387,7 +388,11 @@ func (b Service) findRequestInfo(
 	}
 
 	// find request role and key
-	role, key := b.sender.Classify(req, cid, cnr)
+	role, key, err := b.sender.Classify(req, cid, cnr)
+	if err != nil {
+		return info, err
+	}
+
 	if role == acl.RoleUnknown {
 		return info, ErrUnknownRole
 	}


### PR DESCRIPTION
There is a bug when client can reuse other token and won't get any error. Steps to reproduce:
1. Create private container
2. Create session token with container owner key
3. Upload object
4. Create new client with new random key
5. Make request with new client and previously created token.

It should fail, because token will be signed by non-owner user, however there is no such check. This commit fixes the issue.