### PR TITLE
Bearer token support in object realted commands in CLI

### DIFF
--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/pkg/token"
+	v2ACL "github.com/nspcc-dev/neofs-api-go/v2/acl"
+	"github.com/spf13/cobra"
+)
+
+var (
+	utilCmd = &cobra.Command{
+		Use:   "util",
+		Short: "Utility operations",
+	}
+
+	signCmd = &cobra.Command{
+		Use:   "sign",
+		Short: "sign NeoFS structure",
+	}
+
+	signBearerCmd = &cobra.Command{
+		Use:   "bearer-token",
+		Short: "sign bearer token to use it in requests",
+		RunE:  signBearerToken,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(utilCmd)
+
+	utilCmd.AddCommand(signCmd)
+
+	signCmd.AddCommand(signBearerCmd)
+	signBearerCmd.Flags().String("from", "", "File with JSON or binary encoded bearer token to sign")
+	_ = signBearerCmd.MarkFlagFilename("from")
+	_ = signBearerCmd.MarkFlagRequired("from")
+	signBearerCmd.Flags().String("to", "", "File to dump signed bearer token")
+	signBearerCmd.Flags().Bool("json", false, "Dump bearer token in JSON encoding")
+}
+
+func signBearerToken(cmd *cobra.Command, _ []string) error {
+	btok, err := getBearerToken(cmd, "from")
+	if err != nil {
+		return err
+	}
+
+	key, err := getKey()
+	if err != nil {
+		return err
+	}
+
+	err = completeBearerToken(btok)
+	if err != nil {
+		return err
+	}
+
+	err = btok.SignToken(key)
+	if err != nil {
+		return err
+	}
+
+	to := cmd.Flag("to").Value.String()
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	var data []byte
+	if jsonFlag || len(to) == 0 {
+		data = v2ACL.BearerTokenToJSON(btok.ToV2())
+		if len(data) == 0 {
+			return errors.New("can't JSON encode bearer token")
+		}
+	} else {
+		data, err = btok.ToV2().StableMarshal(nil)
+		if err != nil {
+			return errors.New("can't binary encode bearer token")
+		}
+	}
+
+	if len(to) == 0 {
+		prettyPrintJSON(cmd, data)
+
+		return nil
+	}
+
+	err = ioutil.WriteFile(to, data, 0644)
+	if err != nil {
+		return fmt.Errorf("can't write signed bearer token to file: %w", err)
+	}
+
+	cmd.Printf("signed bearer token was successfully dumped to %s\n", to)
+
+	return nil
+}
+
+func completeBearerToken(btok *token.BearerToken) error {
+	if v2 := btok.ToV2(); v2 != nil {
+		// set eACL table version, because it usually omitted
+		table := v2.GetBody().GetEACL()
+		table.SetVersion(pkg.SDKVersion().ToV2())
+
+		// back to SDK token
+		btok = token.NewBearerTokenFromV2(v2)
+	} else {
+		return errors.New("unsupported bearer token version")
+	}
+
+	return nil
+}
+
+func prettyPrintJSON(cmd *cobra.Command, data []byte) {
+	buf := new(bytes.Buffer)
+	if err := json.Indent(buf, data, "", "  "); err != nil {
+		printVerbose("Can't pretty print json: %w", err)
+	}
+
+	cmd.Println(buf)
+}


### PR DESCRIPTION
This pull request adds support of bearer tokens attached to object service requests. But first you have to sign bearer token with the key of container owner. 

## Sign bearer token

To do so use utility command `sign bearer-token`. Specify path to JSON or binary encoded file with bearer token. It will override version field and set up signature. Use `--to` argument to dump bearer token into the file. Use `--json` argument to do that in JSON format.

```
$ cat bearer.json 
{
  "body": {
    "eaclTable": {
      "containerID": {
        "value": "Q96gd3MnfodO2gp3xkY/8RIaH8TClg/ViE/YuWMEZYE="
      },
      "records": [
        {
          "operation": "PUT",
          "action": "DENY",
          "filters": [
            {
              "headerType": "OBJECT",
              "matchType": "STRING_EQUAL",
              "headerName": "_CID",
              "value": "5ZwD4rCyuNmxq6L6x1xi5xz5ZMg8SLnbzpTWYx8x1vP2"
            }
          ],
          "targets": [
            {
              "role": "USER"
            }
          ]
        }
      ]
    },
    "lifetime": {
      "exp": "100500",
      "nbf": "1",
      "iat": "0"
    }
  }
}

$ ./bin/neofs-cli -c config.yml util sign bearer-token --from bearer.json --to signed_bearer.json --json -v
Using config file: config.yml
Using JSON encoded bearer token
signed bearer token was successfully dumped to signed_bearer.json
```

## Attach bearer token to request

To attach bearer token to object request use `--bearer` argument.
```
$ ./bin/neofs-cli -c config.yml object put --cid 5ZwD4rCyuNmxq6L6x1xi5xz5ZMg8SLnbzpTWYx8x1vP2 --file ./go.mod --bearer signed_bearer.json 
Error: can't put object: could not close *object.putObjectGRPCStream: rpc error: code = Unknown desc = access to operation 3 is denied by extended ACL check
```