### PR TITLE
Add EACL table converter to CLI

### DIFF
--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -29,19 +29,38 @@ var (
 		Short: "sign bearer token to use it in requests",
 		RunE:  signBearerToken,
 	}
+
+	convertCmd = &cobra.Command{
+		Use:   "convert",
+		Short: "convert representation of NeoFS structures",
+	}
+
+	convertEACLCmd = &cobra.Command{
+		Use:   "eacl",
+		Short: "convert representation of extended ACL table",
+		RunE:  convertEACLTable,
+	}
 )
 
 func init() {
 	rootCmd.AddCommand(utilCmd)
 
 	utilCmd.AddCommand(signCmd)
+	utilCmd.AddCommand(convertCmd)
 
 	signCmd.AddCommand(signBearerCmd)
 	signBearerCmd.Flags().String("from", "", "File with JSON or binary encoded bearer token to sign")
 	_ = signBearerCmd.MarkFlagFilename("from")
 	_ = signBearerCmd.MarkFlagRequired("from")
-	signBearerCmd.Flags().String("to", "", "File to dump signed bearer token")
+	signBearerCmd.Flags().String("to", "", "File to dump signed bearer token (default: binary encoded)")
 	signBearerCmd.Flags().Bool("json", false, "Dump bearer token in JSON encoding")
+
+	convertCmd.AddCommand(convertEACLCmd)
+	convertEACLCmd.Flags().String("from", "", "File with JSON or binary encoded extended ACL table")
+	_ = convertEACLCmd.MarkFlagFilename("from")
+	_ = convertEACLCmd.MarkFlagRequired("from")
+	convertEACLCmd.Flags().String("to", "", "File to dump extended ACL table (default: binary encoded)")
+	convertEACLCmd.Flags().Bool("json", false, "Dump extended ACL table in JSON encoding")
 }
 
 func signBearerToken(cmd *cobra.Command, _ []string) error {
@@ -93,6 +112,45 @@ func signBearerToken(cmd *cobra.Command, _ []string) error {
 	}
 
 	cmd.Printf("signed bearer token was successfully dumped to %s\n", to)
+
+	return nil
+}
+
+func convertEACLTable(cmd *cobra.Command, _ []string) error {
+	pathFrom := cmd.Flag("from").Value.String()
+	to := cmd.Flag("to").Value.String()
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	table, err := parseEACL(pathFrom)
+	if err != nil {
+		return err
+	}
+
+	var data []byte
+	if jsonFlag || len(to) == 0 {
+		data = v2ACL.TableToJSON(table.ToV2())
+		if len(data) == 0 {
+			return errors.New("can't JSON encode extended ACL table")
+		}
+	} else {
+		data, err = table.ToV2().StableMarshal(nil)
+		if err != nil {
+			return errors.New("can't binary encode extended ACL table")
+		}
+	}
+
+	if len(to) == 0 {
+		prettyPrintJSON(cmd, data)
+
+		return nil
+	}
+
+	err = ioutil.WriteFile(to, data, 0644)
+	if err != nil {
+		return fmt.Errorf("can't write exteded ACL table to file: %w", err)
+	}
+
+	cmd.Printf("extended ACL table was successfully dumped to %s\n", to)
 
 	return nil
 }


### PR DESCRIPTION
With https://github.com/nspcc-dev/neofs-node/pull/105 it closes #26 

`util convert eacl` command has the same arguments as bearer token signer command. Use `--from` to specify file with binary or JSON encoded extended ACL table. Then use `--to` to dump binary encoded version of it. Use `--json` to dump in JSON encoding. 

```
$ ./bin/neofs-cli util convert eacl --from eacl.json --to eacl.bin -v
Reading EACL from file: eacl.json
Parsed JSON encoded EACL table
extended ACL table was successfully dumped to eacl.bin

$ ./bin/neofs-cli util convert eacl --from eacl.bin 
{
  "version": {
    "major": 2,
    "minor": 0
  },
  "containerID": null,
  "records": [
    {
      "operation": "HEAD",
      "action": "DENY",
      "filters": [
        {
          "headerType": "OBJECT",
          "matchType": "STRING_EQUAL",
          "headerName": "_CID",
          "value": "6e37d75c9fd98b688dd61f7b2ace266d90d0daa6a0a2dcf714944c146f3e76a1"
        }
      ],
      "targets": [
        {
          "role": "OTHERS",
          "keys": [
            "AvsoSsocqV0AUpV3SlXnarvmLUTdmn4vke/8FjlEePgV"
          ]
        }
      ]
    }
  ]
}

```