### PR TITLE
Reduce returned balance precision in accounting.Balance

### DIFF
--- a/pkg/morph/client/balance/balanceOf.go
+++ b/pkg/morph/client/balance/balanceOf.go
@@ -1,6 +1,8 @@
 package balance
 
 import (
+	"math/big"
+
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/pkg/errors"
 )
@@ -14,7 +16,7 @@ type GetBalanceOfArgs struct {
 // GetBalanceOfValues groups the stack parameters
 // returned by "balance of" test invoke.
 type GetBalanceOfValues struct {
-	amount int64 // wallet funds amount
+	amount *big.Int // wallet funds amount
 }
 
 // SetWallet sets the wallet script hash
@@ -24,7 +26,7 @@ func (g *GetBalanceOfArgs) SetWallet(v []byte) {
 }
 
 // Amount returns the amount of funds.
-func (g *GetBalanceOfValues) Amount() int64 {
+func (g *GetBalanceOfValues) Amount() *big.Int {
 	return g.amount
 }
 
@@ -41,7 +43,7 @@ func (c *Client) BalanceOf(args GetBalanceOfArgs) (*GetBalanceOfValues, error) {
 		return nil, errors.Errorf("unexpected stack item count (%s): %d", c.balanceOfMethod, ln)
 	}
 
-	amount, err := client.IntFromStackItem(prms[0])
+	amount, err := client.BigIntFromStackItem(prms[0])
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get integer stack item from stack item (%s)", c.balanceOfMethod)
 	}

--- a/pkg/morph/client/balance/wrapper/balanceOf.go
+++ b/pkg/morph/client/balance/wrapper/balanceOf.go
@@ -1,16 +1,18 @@
 package wrapper
 
 import (
+	"math/big"
+
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance"
 )
 
 // BalanceOf receives the amount of funds in the client's account
 // through the Balance contract call, and returns it.
-func (w *Wrapper) BalanceOf(id *owner.ID) (int64, error) {
+func (w *Wrapper) BalanceOf(id *owner.ID) (*big.Int, error) {
 	v, err := owner.ScriptHashBE(id)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	args := balance.GetBalanceOfArgs{}
@@ -18,7 +20,7 @@ func (w *Wrapper) BalanceOf(id *owner.ID) (int64, error) {
 
 	result, err := w.client.BalanceOf(args)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	return result.Amount(), nil

--- a/pkg/morph/client/util.go
+++ b/pkg/morph/client/util.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/binary"
+	"math/big"
 
 	sc "github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
@@ -155,6 +156,11 @@ func IntFromStackItem(param stackitem.Item) (int64, error) {
 	default:
 		return 0, errors.Errorf("chain/client: %s is not an integer type", param.Type())
 	}
+}
+
+// BigIntFromStackItem receives numerical value from the value of a smart contract parameter.
+func BigIntFromStackItem(param stackitem.Item) (*big.Int, error) {
+	return param.TryInteger()
 }
 
 // BytesFromStackItem receives binary value from the value of a smart contract parameter.

--- a/pkg/morph/client/util_test.go
+++ b/pkg/morph/client/util_test.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
 	sc "github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/stretchr/testify/require"
@@ -50,9 +52,13 @@ var (
 		Value: []sc.Parameter{intParam, byteArrayParam},
 	}
 
+	bigIntValue = new(big.Int).Mul(big.NewInt(math.MaxInt64), big.NewInt(10))
+
 	stringByteItem     = stackitem.NewByteArray([]byte("Hello World"))
 	intItem            = stackitem.NewBigInteger(new(big.Int).SetInt64(1))
+	bigIntItem         = stackitem.NewBigInteger(bigIntValue)
 	byteWithIntItem    = stackitem.NewByteArray([]byte{0x0a})
+	byteWithBigIntItem = stackitem.NewByteArray(bigint.ToBytes(bigIntValue))
 	emptyByteArrayItem = stackitem.NewByteArray([]byte{})
 	trueBoolItem       = stackitem.NewBool(true)
 	falseBoolItem      = stackitem.NewBool(false)
@@ -229,6 +235,27 @@ func TestIntFromStackItem(t *testing.T) {
 
 	t.Run("incorrect assert", func(t *testing.T) {
 		_, err := IntFromStackItem(arrayItem)
+		require.Error(t, err)
+	})
+}
+
+func TestBigIntFromStackItem(t *testing.T) {
+	t.Run("correct assert", func(t *testing.T) {
+		val, err := BigIntFromStackItem(bigIntItem)
+		require.NoError(t, err)
+		require.Equal(t, bigIntValue, val)
+
+		val, err = BigIntFromStackItem(byteWithBigIntItem)
+		require.NoError(t, err)
+		require.Equal(t, bigIntValue, val)
+
+		val, err = BigIntFromStackItem(emptyByteArrayItem)
+		require.NoError(t, err)
+		require.Equal(t, big.NewInt(0), val)
+	})
+
+	t.Run("incorrect assert", func(t *testing.T) {
+		_, err := BigIntFromStackItem(arrayItem)
 		require.Error(t, err)
 	})
 }

--- a/pkg/services/accounting/morph/executor.go
+++ b/pkg/services/accounting/morph/executor.go
@@ -7,11 +7,14 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/accounting"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance/wrapper"
 	accountingSvc "github.com/nspcc-dev/neofs-node/pkg/services/accounting"
+	"github.com/nspcc-dev/neofs-node/pkg/util/precision"
 )
 
 type morphExecutor struct {
 	client *wrapper.Wrapper
 }
+
+const fixed8Precision = 8
 
 func NewExecutor(client *wrapper.Wrapper) accountingSvc.ServiceExecutor {
 	return &morphExecutor{
@@ -25,14 +28,21 @@ func (s *morphExecutor) Balance(ctx context.Context, body *accounting.BalanceReq
 		return nil, err
 	}
 
-	precision, err := s.client.Decimals()
+	balancePrecision, err := s.client.Decimals()
 	if err != nil {
 		return nil, err
 	}
 
+	// Convert amount to Fixed8 precision. This way it will definitely fit
+	// int64 value.
+	// Max Fixed8 decimal integer value that fit into int64: 92 233 720 368.
+	// Max Fixed12 decimal integer value that fit into int64: 9 223 372.
+	// Max Fixed16 decimal integer value that fit into int64: 922.
+	fixed8Amount := precision.Convert(balancePrecision, fixed8Precision, amount)
+
 	dec := new(accounting.Decimal)
-	dec.SetValue(amount)
-	dec.SetPrecision(precision)
+	dec.SetValue(fixed8Amount.Int64())
+	dec.SetPrecision(fixed8Precision)
 
 	res := new(accounting.BalanceResponseBody)
 	res.SetBalance(dec)


### PR DESCRIPTION
Closes #122 

Before patch with `Fixed16` precision in balance smart contract:
1. Deposit 900 GAS
1. Deposit 900 GAS
1. `neofs-cli -c config.yml accounting balance`: -44.6744073709551586

After patch:
1. Deposit 900 GAS
1. Deposit 900 GAS
1. `neofs-cli -c config.yml accounting balance`: 1800.00000000