### PR TITLE
Implement indexing by object properties

### DIFF
--- a/pkg/local_object_storage/metabase/db.go
+++ b/pkg/local_object_storage/metabase/db.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"go.etcd.io/bbolt"
 )
 
@@ -9,17 +10,27 @@ import (
 type DB struct {
 	boltDB *bbolt.DB
 
-	matchers map[object.SearchMatchType]func(string, string) bool
+	matchers map[object.SearchMatchType]func(string, string, string) bool
 }
 
 // NewDB creates, initializes and returns DB instance.
 func NewDB(boltDB *bbolt.DB) *DB {
 	return &DB{
 		boltDB: boltDB,
-		matchers: map[object.SearchMatchType]func(string, string) bool{
-			object.MatchStringEqual: func(s string, s2 string) bool {
-				return s == s2
-			},
+		matchers: map[object.SearchMatchType]func(string, string, string) bool{
+			object.MatchStringEqual: stringEqualMatcher,
 		},
+	}
+}
+
+func stringEqualMatcher(key, objVal, filterVal string) bool {
+	switch key {
+	default:
+		return objVal == filterVal
+	case
+		v2object.FilterPropertyRoot,
+		v2object.FilterPropertyChildfree,
+		v2object.FilterPropertyLeaf:
+		return (filterVal == v2object.BooleanPropertyValueTrue) == (objVal == v2object.BooleanPropertyValueTrue)
 	}
 }

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/util/test"
 	"github.com/stretchr/testify/require"
@@ -152,4 +153,86 @@ func TestDB_Delete(t *testing.T) {
 	require.Error(t, err)
 
 	testSelect(t, db, fs)
+}
+
+func TestDB_SelectProperties(t *testing.T) {
+	path := "test.db"
+
+	bdb, err := bbolt.Open(path, 0600, nil)
+	require.NoError(t, err)
+
+	defer func() {
+		bdb.Close()
+		os.Remove(path)
+	}()
+
+	db := NewDB(bdb)
+
+	parent := object.NewRaw()
+	parent.SetContainerID(testCID())
+	parent.SetID(testOID())
+
+	child := object.NewRaw()
+	child.SetContainerID(testCID())
+	child.SetID(testOID())
+	child.SetParent(parent.Object().SDK())
+
+	parAddr := parent.Object().Address()
+	childAddr := child.Object().Address()
+
+	require.NoError(t, db.Put(child.Object()))
+
+	// root filter
+	fs := objectSDK.SearchFilters{}
+	fs.AddRootFilter()
+	testSelect(t, db, fs, parAddr)
+
+	// non-root filter
+	fs = fs[:0]
+	fs.AddNonRootFilter()
+	testSelect(t, db, fs, childAddr)
+
+	// root filter (with random false value)
+	fs = fs[:0]
+	fs.AddFilter(v2object.FilterPropertyRoot, "some false value", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs, childAddr)
+
+	// leaf filter
+	fs = fs[:0]
+	fs.AddLeafFilter()
+	testSelect(t, db, fs, childAddr)
+
+	// non-leaf filter
+	fs = fs[:0]
+	fs.AddNonLeafFilter()
+	testSelect(t, db, fs, parAddr)
+
+	// leaf filter (with random false value)
+	fs = fs[:0]
+	fs.AddFilter(v2object.FilterPropertyLeaf, "some false value", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs, parAddr)
+
+	lnk := object.NewRaw()
+	lnk.SetContainerID(testCID())
+	lnk.SetID(testOID())
+	lnk.SetChildren(testOID())
+
+	lnkAddr := lnk.Object().Address()
+
+	require.NoError(t, db.Put(lnk.Object()))
+
+	// childfree filter
+	fs = fs[:0]
+	fs.AddChildfreeFilter()
+	testSelect(t, db, fs, childAddr, parAddr)
+
+	// non-childfree filter
+	fs = fs[:0]
+	fs.AddNonChildfreeFilter()
+	testSelect(t, db, fs, lnkAddr)
+
+	// childfree filter (with random false value)
+	fs = fs[:0]
+	fs.AddFilter(v2object.FilterPropertyChildfree, "some false value", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs, lnkAddr)
 }

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -39,7 +39,7 @@ func (db *DB) Select(fs object.SearchFilters) ([]*object.Address, error) {
 
 			// iterate over all existing values for the key
 			if err := keyBucket.ForEach(func(k, _ []byte) error {
-				if !matchFunc(string(cutKeyBytes(k)), fVal) {
+				if !matchFunc(string(key), string(cutKeyBytes(k)), fVal) {
 					// exclude all addresses with this value
 					return keyBucket.Bucket(k).ForEach(func(k, _ []byte) error {
 						mAddr[string(k)] = struct{}{}


### PR DESCRIPTION
Process parent objects in Put method. Headers of parent object are stored as
regular leaf objects in metabase from now. Build indexes for ROOT, LEAF and
CHILDFREE properties.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>