### PR TITLE
Update neofs-api-go to latest version

### DIFF
--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -624,11 +624,11 @@ func getBearerToken(cmd *cobra.Command, flagname string) (*token.BearerToken, er
 		return nil, fmt.Errorf("can't read bearer token file: %w", err)
 	}
 
-	v2token := v2ACL.BearerTokenFromJSON(data)
-	if v2token == nil {
+	v2token, err := v2ACL.BearerTokenFromJSON(data)
+	if err != nil {
 		msg := new(grpcACL.BearerToken)
 		if proto.Unmarshal(data, msg) != nil {
-			return nil, errors.New("can't decode bearer token")
+			return nil, fmt.Errorf("can't decode beare token: %w", err)
 		}
 
 		v2token = v2ACL.BearerTokenFromGRPCMessage(msg)

--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -89,14 +89,14 @@ func signBearerToken(cmd *cobra.Command, _ []string) error {
 
 	var data []byte
 	if jsonFlag || len(to) == 0 {
-		data = v2ACL.BearerTokenToJSON(btok.ToV2())
-		if len(data) == 0 {
-			return errors.New("can't JSON encode bearer token")
+		data, err = v2ACL.BearerTokenToJSON(btok.ToV2())
+		if err != nil {
+			return fmt.Errorf("can't JSON encode bearer token: %w", err)
 		}
 	} else {
 		data, err = btok.ToV2().StableMarshal(nil)
 		if err != nil {
-			return errors.New("can't binary encode bearer token")
+			return fmt.Errorf("can't binary encode bearer token: %w", err)
 		}
 	}
 
@@ -128,14 +128,14 @@ func convertEACLTable(cmd *cobra.Command, _ []string) error {
 
 	var data []byte
 	if jsonFlag || len(to) == 0 {
-		data = v2ACL.TableToJSON(table.ToV2())
-		if len(data) == 0 {
-			return errors.New("can't JSON encode extended ACL table")
+		data, err = v2ACL.TableToJSON(table.ToV2())
+		if err != nil {
+			return fmt.Errorf("can't JSON encode extended ACL table: %w", err)
 		}
 	} else {
 		data, err = table.ToV2().StableMarshal(nil)
 		if err != nil {
-			return errors.New("can't binary encode extended ACL table")
+			return fmt.Errorf("can't binary encode extended ACL table: %w", err)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201028111149-ac38d13f04ff
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201029071528-352e99d9b91a
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78 h1:stIa+nB
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20200827184617-7560aa345a78/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201028111149-ac38d13f04ff h1:TBybhFCjTdSgpw0zGLw7ucjA3gTTLZDfp4D2trcSyT4=
 github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201028111149-ac38d13f04ff/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201029071528-352e99d9b91a h1:+fYK6dnV+ty2p/PoVLTgN2OgOeyFgl/fFYfIPXdvJYI=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201029071528-352e99d9b91a/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
Handle errors provided by JSON encoders. Closes #129 