### PR TITLE
Bring in some metabase optimizations

### DIFF
--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -1,6 +1,9 @@
 package meta
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
@@ -22,55 +25,60 @@ var (
 // Object payload expected to be cut.
 func (db *DB) Put(obj *object.Object) error {
 	return db.boltDB.Update(func(tx *bbolt.Tx) error {
-		// create primary bucket (addr: header)
-		primaryBucket, err := tx.CreateBucketIfNotExists(primaryBucket)
-		if err != nil {
-			return errors.Wrapf(err, "(%T) could not create primary bucket", db)
-		}
+		par := false
 
-		data, err := obj.ToV2().StableMarshal(nil)
-		if err != nil {
-			return errors.Wrapf(err, "(%T) could not marshal the object", db)
-		}
-
-		addrKey := addressKey(obj.Address())
-
-		// put header to primary bucket
-		if err := primaryBucket.Put(addrKey, data); err != nil {
-			return errors.Wrapf(err, "(%T) could not put item to primary bucket", db)
-		}
-
-		// create bucket for indices
-		indexBucket, err := tx.CreateBucketIfNotExists(indexBucket)
-		if err != nil {
-			return errors.Wrapf(err, "(%T) could not create index bucket", db)
-		}
-
-		// calculate indexed values for object
-		indices := objectIndices(obj)
-
-		for i := range indices {
-			// create index bucket
-			keyBucket, err := indexBucket.CreateBucketIfNotExists([]byte(indices[i].key))
+		for ; obj != nil; obj, par = obj.GetParent(), true {
+			// create primary bucket (addr: header)
+			primaryBucket, err := tx.CreateBucketIfNotExists(primaryBucket)
 			if err != nil {
-				return errors.Wrapf(err, "(%T) could not create bucket for header key", db)
+				return errors.Wrapf(err, "(%T) could not create primary bucket", db)
 			}
 
-			// FIXME: here we can get empty slice that could not be the key
-			// Possible solutions:
-			// 1. add prefix byte (0 if empty);
-			v := []byte(indices[i].val)
-
-			// create address bucket for the value
-			valBucket, err := keyBucket.CreateBucketIfNotExists(nonEmptyKeyBytes(v))
+			data, err := obj.ToV2().StableMarshal(nil)
 			if err != nil {
-				return errors.Wrapf(err, "(%T) could not create bucket for header value", db)
+				return errors.Wrapf(err, "(%T) could not marshal the object", db)
 			}
 
-			// put object address to value bucket
-			if err := valBucket.Put(addrKey, nil); err != nil {
-				return errors.Wrapf(err, "(%T) could not put item to header bucket", db)
+			addrKey := addressKey(obj.Address())
+
+			// put header to primary bucket
+			if err := primaryBucket.Put(addrKey, data); err != nil {
+				return errors.Wrapf(err, "(%T) could not put item to primary bucket", db)
 			}
+
+			// create bucket for indices
+			indexBucket, err := tx.CreateBucketIfNotExists(indexBucket)
+			if err != nil {
+				return errors.Wrapf(err, "(%T) could not create index bucket", db)
+			}
+
+			// calculate indexed values for object
+			indices := objectIndices(obj, par)
+
+			for i := range indices {
+				// create index bucket
+				keyBucket, err := indexBucket.CreateBucketIfNotExists([]byte(indices[i].key))
+				if err != nil {
+					return errors.Wrapf(err, "(%T) could not create bucket for header key", db)
+				}
+
+				v := nonEmptyKeyBytes([]byte(indices[i].val))
+
+				strs, err := decodeAddressList(keyBucket.Get(v))
+				if err != nil {
+					return errors.Wrapf(err, "(%T) could not decode address list", db)
+				}
+
+				data, err := encodeAddressList(append(strs, string(addrKey)))
+				if err != nil {
+					return errors.Wrapf(err, "(%T) could not encode address list", db)
+				}
+
+				if err := keyBucket.Put(v, data); err != nil {
+					return errors.Wrapf(err, "(%T) could not put item to header bucket", db)
+				}
+			}
+
 		}
 
 		return nil
@@ -89,10 +97,25 @@ func addressKey(addr *objectSDK.Address) []byte {
 	return []byte(addr.String())
 }
 
-func objectIndices(obj *object.Object) []bucketItem {
+func objectIndices(obj *object.Object, parent bool) []bucketItem {
 	as := obj.GetAttributes()
 
-	res := make([]bucketItem, 0, 3+len(as))
+	res := make([]bucketItem, 0, 5+len(as))
+
+	rootVal := v2object.BooleanPropertyValueTrue
+	if obj.HasParent() {
+		rootVal = ""
+	}
+
+	leafVal := v2object.BooleanPropertyValueTrue
+	if parent {
+		leafVal = ""
+	}
+
+	childfreeVal := v2object.BooleanPropertyValueTrue
+	if len(obj.GetChildren()) > 0 {
+		childfreeVal = ""
+	}
 
 	res = append(res,
 		bucketItem{
@@ -107,6 +130,18 @@ func objectIndices(obj *object.Object) []bucketItem {
 			key: v2object.FilterHeaderOwnerID,
 			val: obj.GetOwnerID().String(),
 		},
+		bucketItem{
+			key: v2object.FilterPropertyRoot,
+			val: rootVal,
+		},
+		bucketItem{
+			key: v2object.FilterPropertyLeaf,
+			val: leafVal,
+		},
+		bucketItem{
+			key: v2object.FilterPropertyChildfree,
+			val: childfreeVal,
+		},
 		// TODO: add remaining fields after neofs-api#72
 	)
 
@@ -118,4 +153,31 @@ func objectIndices(obj *object.Object) []bucketItem {
 	}
 
 	return res
+}
+
+// FIXME: gob is a temporary solution, use protobuf.
+func decodeAddressList(data []byte) ([]string, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var strs []string
+
+	decoder := gob.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&strs); err != nil {
+		return nil, err
+	}
+
+	return strs, nil
+}
+
+func encodeAddressList(l []string) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	encoder := gob.NewEncoder(buf)
+
+	if err := encoder.Encode(l); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
## Summary
### Disk space
Storage of the address list as a bucket in the header index is replaced by storage as a leaf with a serialized list of addresses. This significantly reduces the space consumption for indexes (`~350MB` vs `~4.5GB` in same scenario).
### Select type
Inclusive selection (at which objects are included as index traversal) outperformed the exclusive one (in which objects are excluded from the set of all stored objects after index traversal) in most tests performed.