### PR TITLE
Fix double emission on asset mint

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -85,4 +85,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("netmap_cleaner.threshold", 3)
 
 	cfg.SetDefault("emit.storage.amount", 0)
+	cfg.SetDefault("emit.mint.cache_size", 1000)
+	cfg.SetDefault("emit.mint.threshold", 1)
+	cfg.SetDefault("emit.mint.value", 20000000) // 0.2 Fixed8
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/participle v0.6.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mr-tron/base58 v1.1.3
 	github.com/multiformats/go-multiaddr v0.2.0

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -231,15 +231,18 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 
 	// create mainnnet neofs processor
 	neofsProcessor, err := neofs.New(&neofs.Params{
-		Log:             log,
-		PoolSize:        cfg.GetInt("workers.neofs"),
-		NeoFSContract:   server.contracts.neofs,
-		BalanceContract: server.contracts.balance,
-		NetmapContract:  server.contracts.netmap,
-		MorphClient:     server.morphClient,
-		EpochState:      server,
-		ActiveState:     server,
-		Converter:       &server.precision,
+		Log:               log,
+		PoolSize:          cfg.GetInt("workers.neofs"),
+		NeoFSContract:     server.contracts.neofs,
+		BalanceContract:   server.contracts.balance,
+		NetmapContract:    server.contracts.netmap,
+		MorphClient:       server.morphClient,
+		EpochState:        server,
+		ActiveState:       server,
+		Converter:         &server.precision,
+		MintEmitCacheSize: cfg.GetInt("emit.mint.cache_size"),
+		MintEmitThreshold: cfg.GetUint64("emit.mint.threshold"),
+		MintEmitValue:     util.Fixed8(cfg.GetInt64("emit.mint.value")),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
LRU cache is used as storage of previous sidechain GAS emissions at asset mint. It will purge old records and those accounts will be able to emit some sidechain GAS once again after `threshold` epochs. 