### PR TITLE
Bring in some metabase optimizations

### DIFF
--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -1,6 +1,9 @@
 package meta
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
@@ -59,19 +62,19 @@ func (db *DB) Put(obj *object.Object) error {
 					return errors.Wrapf(err, "(%T) could not create bucket for header key", db)
 				}
 
-				// FIXME: here we can get empty slice that could not be the key
-				// Possible solutions:
-				// 1. add prefix byte (0 if empty);
-				v := []byte(indices[i].val)
+				v := nonEmptyKeyBytes([]byte(indices[i].val))
 
-				// create address bucket for the value
-				valBucket, err := keyBucket.CreateBucketIfNotExists(nonEmptyKeyBytes(v))
+				strs, err := decodeAddressList(keyBucket.Get(v))
 				if err != nil {
-					return errors.Wrapf(err, "(%T) could not create bucket for header value", db)
+					return errors.Wrapf(err, "(%T) could not decode address list", db)
 				}
 
-				// put object address to value bucket
-				if err := valBucket.Put(addrKey, nil); err != nil {
+				data, err := encodeAddressList(append(strs, string(addrKey)))
+				if err != nil {
+					return errors.Wrapf(err, "(%T) could not encode address list", db)
+				}
+
+				if err := keyBucket.Put(v, data); err != nil {
 					return errors.Wrapf(err, "(%T) could not put item to header bucket", db)
 				}
 			}
@@ -150,4 +153,31 @@ func objectIndices(obj *object.Object, parent bool) []bucketItem {
 	}
 
 	return res
+}
+
+// FIXME: gob is a temporary solution, use protobuf.
+func decodeAddressList(data []byte) ([]string, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var strs []string
+
+	decoder := gob.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&strs); err != nil {
+		return nil, err
+	}
+
+	return strs, nil
+}
+
+func encodeAddressList(l []string) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	encoder := gob.NewEncoder(buf)
+
+	if err := encoder.Encode(l); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -66,18 +66,23 @@ func (db *DB) Select(fs object.SearchFilters) ([]*object.Address, error) {
 			fVal := f.Value()
 
 			// iterate over all existing values for the key
-			if err := keyBucket.ForEach(func(k, _ []byte) error {
+			if err := keyBucket.ForEach(func(k, v []byte) error {
 				include := matchFunc(string(key), string(cutKeyBytes(k)), fVal)
 
-				return keyBucket.Bucket(k).ForEach(func(k, _ []byte) error {
-					if include {
-						mAddr[string(k)] = struct{}{}
-					} else {
-						delete(mAddr, string(k))
-					}
+				strs, err := decodeAddressList(v)
+				if err != nil {
+					return errors.Wrapf(err, "(%T) could not decode address list", db)
+				}
 
-					return nil
-				})
+				for i := range strs {
+					if include {
+						mAddr[strs[i]] = struct{}{}
+					} else {
+						delete(mAddr, strs[i])
+					}
+				}
+
+				return nil
 			}); err != nil {
 				return errors.Wrapf(err, "(%T) could not iterate bucket %s", db, key)
 			}

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -18,7 +18,34 @@ func (db *DB) Select(fs object.SearchFilters) ([]*object.Address, error) {
 			return nil
 		}
 
-		// keep addresses that does not match some filter
+		if len(fs) == 0 {
+			// get primary bucket
+			primaryBucket := tx.Bucket(primaryBucket)
+			if primaryBucket == nil {
+				// empty storage
+				return nil
+			}
+
+			// iterate over all stored addresses
+			return primaryBucket.ForEach(func(k, v []byte) error {
+				// check if object marked as deleted
+				if objectRemoved(tx, k) {
+					return nil
+				}
+
+				addr := object.NewAddress()
+				if err := addr.Parse(string(k)); err != nil {
+					// TODO: storage was broken, so we need to handle it
+					return err
+				}
+
+				res = append(res, addr)
+
+				return nil
+			})
+		}
+
+		// keep processed addresses
 		mAddr := make(map[string]struct{})
 
 		for _, f := range fs {
@@ -40,49 +67,38 @@ func (db *DB) Select(fs object.SearchFilters) ([]*object.Address, error) {
 
 			// iterate over all existing values for the key
 			if err := keyBucket.ForEach(func(k, _ []byte) error {
-				if !matchFunc(string(key), string(cutKeyBytes(k)), fVal) {
-					// exclude all addresses with this value
-					return keyBucket.Bucket(k).ForEach(func(k, _ []byte) error {
+				include := matchFunc(string(key), string(cutKeyBytes(k)), fVal)
+
+				return keyBucket.Bucket(k).ForEach(func(k, _ []byte) error {
+					if include {
 						mAddr[string(k)] = struct{}{}
+					} else {
+						delete(mAddr, string(k))
+					}
 
-						return nil
-					})
-				}
-
-				return nil
+					return nil
+				})
 			}); err != nil {
 				return errors.Wrapf(err, "(%T) could not iterate bucket %s", db, key)
 			}
 		}
 
-		// get primary bucket
-		primaryBucket := tx.Bucket(primaryBucket)
-		if primaryBucket == nil {
-			// empty storage
-			return nil
-		}
-
-		// iterate over all stored addresses
-		return primaryBucket.ForEach(func(k, v []byte) error {
-			if _, ok := mAddr[string(k)]; ok {
-				return nil
-			}
-
+		for a := range mAddr {
 			// check if object marked as deleted
-			if objectRemoved(tx, k) {
+			if objectRemoved(tx, []byte(a)) {
 				return nil
 			}
 
 			addr := object.NewAddress()
-			if err := addr.Parse(string(k)); err != nil {
+			if err := addr.Parse(a); err != nil {
 				// TODO: storage was broken, so we need to handle it
 				return err
 			}
 
 			res = append(res, addr)
+		}
 
-			return nil
-		})
+		return nil
 	})
 
 	return res, err

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -97,7 +97,7 @@ func (db *DB) Select(fs object.SearchFilters) ([]*object.Address, error) {
 
 			// check if object marked as deleted
 			if objectRemoved(tx, []byte(a)) {
-				return nil
+				continue
 			}
 
 			addr := object.NewAddress()

--- a/pkg/local_object_storage/metabase/select_test.go
+++ b/pkg/local_object_storage/metabase/select_test.go
@@ -88,3 +88,26 @@ func BenchmarkDB_Select(b *testing.B) {
 		})
 	}
 }
+
+func TestMismatchAfterMatch(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	obj := generateObject(t, testPrm{
+		attrNum: 1,
+	})
+
+	require.NoError(t, db.Put(obj))
+
+	a := obj.GetAttributes()[0]
+
+	fs := objectSDK.SearchFilters{}
+
+	// 1st - mismatching filter
+	fs.AddFilter(a.GetKey(), a.GetValue()+"1", objectSDK.MatchStringEqual)
+
+	// 2nd - matching filter
+	fs.AddFilter(a.GetKey(), a.GetValue(), objectSDK.MatchStringEqual)
+
+	testSelect(t, db, fs)
+}

--- a/pkg/local_object_storage/metabase/select_test.go
+++ b/pkg/local_object_storage/metabase/select_test.go
@@ -152,3 +152,35 @@ func TestSelectRemoved(t *testing.T) {
 
 	testSelect(t, db, fs, obj2.Address())
 }
+
+func TestMissingObjectAttribute(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	// add object w/o attribute
+	obj1 := generateObject(t, testPrm{
+		attrNum: 1,
+	})
+
+	// add object w/o attribute
+	obj2 := generateObject(t, testPrm{})
+
+	a1 := obj1.GetAttributes()[0]
+
+	// add common attribute
+	aCommon := addCommonAttribute(obj1, obj2)
+
+	// write to DB
+	require.NoError(t, db.Put(obj1))
+	require.NoError(t, db.Put(obj2))
+
+	fs := objectSDK.SearchFilters{}
+
+	// 1st filter by common attribute
+	fs.AddFilter(aCommon.GetKey(), aCommon.GetValue(), objectSDK.MatchStringEqual)
+
+	// next filter by attribute from 1st object only
+	fs.AddFilter(a1.GetKey(), a1.GetValue(), objectSDK.MatchStringEqual)
+
+	testSelect(t, db, fs, obj1.Address())
+}


### PR DESCRIPTION
## Summary
### Disk space
Storage of the address list as a bucket in the header index is replaced by storage as a leaf with a serialized list of addresses. This significantly reduces the space consumption for indexes (`~350MB` vs `~4.5GB` in same scenario).
### Select type
Inclusive selection (at which objects are included as index traversal) outperformed the exclusive one (in which objects are excluded from the set of all stored objects after index traversal) in most tests performed.