### PR TITLE
Support well-known application attributes in CLI

### DIFF
--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strconv"
+	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/token"
@@ -177,4 +179,15 @@ func prettyPrintJSON(cmd *cobra.Command, data []byte) {
 	}
 
 	cmd.Println(buf)
+}
+
+func prettyPrintUnixTime(s string) string {
+	unixTime, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return "malformed"
+	}
+
+	timestamp := time.Unix(unixTime, 0)
+
+	return timestamp.String()
 }


### PR DESCRIPTION
Closes #117 

## Container attributes
Use `--name` argument to set container nicename

```
$ ./bin/neofs-cli -c config.yml container create --policy ./rule.ql --name "ABC" --await
container ID: 4Uy1tGStwxnVzkcDzxUNba6bUV6bQ1FakHrLPCFPpqZh
awaiting...
container has been persisted on sidechain
$ ./bin/neofs-cli -c config.yml container get --cid 4Uy1tGStwxnVzkcDzxUNba6bUV6bQ1FakHrLPCFPpqZh
container ID: 4Uy1tGStwxnVzkcDzxUNba6bUV6bQ1FakHrLPCFPpqZh
version: 2.0
...
attribute: Timestamp=1604411491 (2020-11-03 16:51:31 +0300 MSK)
attribute: Name=ABC
...
```

Use `--disable-timestamp` flag to not set timestamp attribute automatically. 

## Object attributes

```
$ ./bin/neofs-cli -c config.yml object put --cid 3mskf4dJJ2GHxYpEmkvL9Xt67ZYS6GBLyCGtZU52VS2E --file LICENSE
[LICENSE] Object successfully stored
  ID: 7yptiT6NGCK56K4MrFohtDvT8uVc8awhaH3qwhBx5KaH
  CID: 3mskf4dJJ2GHxYpEmkvL9Xt67ZYS6GBLyCGtZU52VS2E
$ ./bin/neofs-cli -c config.yml object head --cid 3mskf4dJJ2GHxYpEmkvL9Xt67ZYS6GBLyCGtZU52VS2E --oid 7yptiT6NGCK56K4MrFohtDvT8uVc8awhaH3qwhBx5KaH
ID: 7yptiT6NGCK56K4MrFohtDvT8uVc8awhaH3qwhBx5KaH
CID: 3mskf4dJJ2GHxYpEmkvL9Xt67ZYS6GBLyCGtZU52VS2E
...                                                                  
Attributes:
  FileName=LICENSE
  Timestamp=1604413708 (2020-11-03 17:28:28 +0300 MSK)
```

Use `--disable-filename` and `--disable-timestamp` flags to not set these attributes automatically. 