### PR TITLE
Update neofs-api-go with refactored pkg/netmap

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -139,7 +139,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 		}
 
 		cnr := container.New()
-		cnr.SetPlacementPolicy(placementPolicy)
+		cnr.SetPlacementPolicy(placementPolicy.ToV2())
 		cnr.SetBasicACL(basicACL)
 		cnr.SetAttributes(attributes)
 		cnr.SetNonce(nonce[:])
@@ -531,7 +531,7 @@ func parseContainerPolicy(policyString string) (*netmap.PlacementPolicy, error) 
 		return result, nil
 	}
 
-	result, err = policy.FromJSON([]byte(policyString))
+	result, err = netmap.PlacementPolicyFromJSON([]byte(policyString))
 	if err == nil {
 		printVerbose("Parsed JSON encoded policy")
 		return result, nil
@@ -684,7 +684,8 @@ func prettyPrintContainer(cnr *container.Container, jsonEncoding bool) {
 	}
 
 	fmt.Println("placement policy:")
-	fmt.Println(strings.Join(policy.Encode(cnr.GetPlacementPolicy()), "\n"))
+	cnrPolicy := netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy())
+	fmt.Println(strings.Join(policy.Encode(cnrPolicy), "\n"))
 }
 
 func parseEACL(eaclPath string) (*eacl.Table, error) {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201103083623-89a7a946dcd5
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201106062850-d704795dcc7b
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b h1:gk5bZgpWOehaDVKI5vBDkcjXTpRkKqcvIb1h/vHnBH4=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b/go.mod h1:9s7LNp2lMgf0caH2t0sam4+WT2SIauXozwP0AdBqnEo=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201103083623-89a7a946dcd5 h1:V5Yo8EA2S5iAG0hlKwfS7TcZqudPOHp/3MLG5/UpQ74=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201103083623-89a7a946dcd5/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201106062850-d704795dcc7b h1:JYitHXAKvqJc4cgicDgDJY+d2JiKR77xdczGH+CqfUU=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201106062850-d704795dcc7b/go.mod h1:ZKpuPU2eHFyX5Ps4I70k1u/f+x6D2Ceb/t+BH8ll6cA=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/pkg/core/container/fmt_test.go
+++ b/pkg/core/container/fmt_test.go
@@ -18,7 +18,7 @@ func TestCheckFormat(t *testing.T) {
 	require.Error(t, CheckFormat(c))
 
 	policy := new(netmap.PlacementPolicy)
-	c.SetPlacementPolicy(policy)
+	c.SetPlacementPolicy(policy.ToV2())
 
 	require.Error(t, CheckFormat(c))
 

--- a/pkg/innerring/invoke/netmap.go
+++ b/pkg/innerring/invoke/netmap.go
@@ -130,7 +130,7 @@ func NetmapSnapshot(cli *client.Client, con util.Uint160) (*netmap.Netmap, error
 		return nil, err
 	}
 
-	result := make([]netmapv2.NodeInfo, 0, len(rawNodeInfos))
+	result := make([]netmap.NodeInfo, 0, len(rawNodeInfos))
 
 	for i := range rawNodeInfos {
 		nodeInfo, err := peerInfoFromStackItem(rawNodeInfos[i])
@@ -138,10 +138,10 @@ func NetmapSnapshot(cli *client.Client, con util.Uint160) (*netmap.Netmap, error
 			return nil, errors.Wrap(err, "invalid RPC response")
 		}
 
-		result = append(result, *nodeInfo)
+		result = append(result, *netmap.NewNodeInfoFromV2(nodeInfo))
 	}
 
-	return netmap.NewNetmap(netmap.NodesFromV2(result))
+	return netmap.NewNetmap(netmap.NodesFromInfo(result))
 }
 
 func peerInfoFromStackItem(prm stackitem.Item) (*netmapv2.NodeInfo, error) {

--- a/pkg/morph/client/netmap/wrapper/netmap.go
+++ b/pkg/morph/client/netmap/wrapper/netmap.go
@@ -23,7 +23,7 @@ func (w Wrapper) GetNetMap(diff uint64) (*netmap.Netmap, error) {
 	}
 
 	rawPeers := peers.Peers() // slice of serialized node infos
-	infos := make([]v2netmap.NodeInfo, 0, len(rawPeers))
+	infos := make([]netmap.NodeInfo, 0, len(rawPeers))
 
 	for _, peer := range rawPeers {
 		grpcNodeInfo := new(grpcNetmap.NodeInfo) // transport representation of struct
@@ -35,10 +35,10 @@ func (w Wrapper) GetNetMap(diff uint64) (*netmap.Netmap, error) {
 		}
 
 		v2 := v2netmap.NodeInfoFromGRPCMessage(grpcNodeInfo)
-		infos = append(infos, *v2)
+		infos = append(infos, *netmap.NewNodeInfoFromV2(v2))
 	}
 
-	nodes := netmap.NodesFromV2(infos)
+	nodes := netmap.NodesFromInfo(infos)
 
 	return netmap.NewNetmap(nodes)
 }

--- a/pkg/policy/encode.go
+++ b/pkg/policy/encode.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 )
 
 func Encode(p *netmap.PlacementPolicy) []string {
@@ -14,9 +14,9 @@ func Encode(p *netmap.PlacementPolicy) []string {
 	}
 
 	var (
-		replicas  = p.GetReplicas()
-		selectors = p.GetSelectors()
-		filters   = p.GetFilters()
+		replicas  = p.Replicas()
+		selectors = p.Selectors()
+		filters   = p.Filters()
 	)
 
 	// 1 for container backup factor
@@ -26,7 +26,7 @@ func Encode(p *netmap.PlacementPolicy) []string {
 	encodeReplicas(replicas, &result)
 
 	// then backup factor
-	if backupFactor := p.GetContainerBackupFactor(); backupFactor != 0 {
+	if backupFactor := p.ContainerBackupFactor(); backupFactor != 0 {
 		result = append(result, fmt.Sprintf("CBF %d", backupFactor))
 	}
 
@@ -44,9 +44,9 @@ func encodeReplicas(replicas []*netmap.Replica, dst *[]string) {
 
 	for _, replica := range replicas {
 		builder.WriteString("REP ")
-		builder.WriteString(strconv.FormatUint(uint64(replica.GetCount()), 10))
+		builder.WriteString(strconv.FormatUint(uint64(replica.Count()), 10))
 
-		if s := replica.GetSelector(); s != "" {
+		if s := replica.Selector(); s != "" {
 			builder.WriteString(" IN ")
 			builder.WriteString(s)
 		}
@@ -61,15 +61,15 @@ func encodeSelectors(selectors []*netmap.Selector, dst *[]string) {
 
 	for _, selector := range selectors {
 		builder.WriteString("SELECT ")
-		builder.WriteString(strconv.FormatUint(uint64(selector.GetCount()), 10))
+		builder.WriteString(strconv.FormatUint(uint64(selector.Count()), 10))
 
-		if a := selector.GetAttribute(); a != "" {
+		if a := selector.Attribute(); a != "" {
 			builder.WriteString(" IN")
 
-			switch selector.GetClause() {
-			case netmap.Same:
+			switch selector.Clause() {
+			case netmap.ClauseSame:
 				builder.WriteString(" SAME ")
-			case netmap.Distinct:
+			case netmap.ClauseDistinct:
 				builder.WriteString(" DISTINCT ")
 			default:
 				builder.WriteString(" ")
@@ -78,12 +78,12 @@ func encodeSelectors(selectors []*netmap.Selector, dst *[]string) {
 			builder.WriteString(a)
 		}
 
-		if f := selector.GetFilter(); f != "" {
+		if f := selector.Filter(); f != "" {
 			builder.WriteString(" FROM ")
 			builder.WriteString(f)
 		}
 
-		if n := selector.GetName(); n != "" {
+		if n := selector.Name(); n != "" {
 			builder.WriteString(" AS ")
 			builder.WriteString(n)
 		}
@@ -106,55 +106,32 @@ func encodeFilters(filters []*netmap.Filter, dst *[]string) {
 	}
 }
 
-func operationString(operation netmap.Operation) string {
-	switch operation {
-	case netmap.EQ:
-		return "EQ"
-	case netmap.NE:
-		return "NE"
-	case netmap.GT:
-		return "GT"
-	case netmap.GE:
-		return "GE"
-	case netmap.LT:
-		return "LT"
-	case netmap.LE:
-		return "LE"
-	case netmap.OR:
-		return "OR"
-	case netmap.AND:
-		return "AND"
-	default:
-		return ""
-	}
-}
-
 func encodeFilter(filter *netmap.Filter) string {
 	builder := new(strings.Builder)
-	unspecified := filter.GetOp() == netmap.UnspecifiedOperation
+	unspecified := filter.Operation() == 0
 
-	if k := filter.GetKey(); k != "" {
+	if k := filter.Key(); k != "" {
 		builder.WriteString(k)
 		builder.WriteString(" ")
-		builder.WriteString(operationString(filter.GetOp()))
+		builder.WriteString(filter.Operation().String())
 		builder.WriteString(" ")
-		builder.WriteString(filter.GetValue())
-	} else if n := filter.GetName(); unspecified && n != "" {
+		builder.WriteString(filter.Value())
+	} else if n := filter.Name(); unspecified && n != "" {
 		builder.WriteString("@")
 		builder.WriteString(n)
 	}
 
-	for i, subfilter := range filter.GetFilters() {
+	for i, subfilter := range filter.InnerFilters() {
 		if i != 0 {
 			builder.WriteString(" ")
-			builder.WriteString(operationString(filter.GetOp()))
+			builder.WriteString(filter.Operation().String())
 			builder.WriteString(" ")
 		}
 
 		builder.WriteString(encodeFilter(subfilter))
 	}
 
-	if n := filter.GetName(); n != "" && !unspecified {
+	if n := filter.Name(); n != "" && !unspecified {
 		builder.WriteString(" AS ")
 		builder.WriteString(n)
 	}

--- a/pkg/policy/query_test.go
+++ b/pkg/policy/query_test.go
@@ -17,7 +17,7 @@ func TestSimple(t *testing.T) {
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestSimpleWithHRWB(t *testing.T) {
@@ -30,7 +30,7 @@ func TestSimpleWithHRWB(t *testing.T) {
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestFromSelect(t *testing.T) {
@@ -45,7 +45,7 @@ SELECT 1 IN City FROM * AS SPB`
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 // https://github.com/nspcc-dev/neofs-node/issues/46
@@ -61,7 +61,7 @@ func TestFromSelectNoAttribute(t *testing.T) {
 
 		r, err := Parse(q)
 		require.NoError(t, err)
-		require.Equal(t, expected, r)
+		require.EqualValues(t, expected, r)
 
 	})
 
@@ -77,7 +77,7 @@ func TestFromSelectNoAttribute(t *testing.T) {
 
 		r, err := Parse(q)
 		require.NoError(t, err)
-		require.Equal(t, expected, r)
+		require.EqualValues(t, expected, r)
 	})
 }
 
@@ -97,7 +97,7 @@ SELECT 1 IN DISTINCT Continent FROM *`
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestSimpleFilter(t *testing.T) {
@@ -115,7 +115,7 @@ FILTER Rating GT 7 AS Good`
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestFilterReference(t *testing.T) {
@@ -137,7 +137,7 @@ FILTER @FromRU AND Rating GT 7 AS Good`
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestFilterOps(t *testing.T) {
@@ -162,7 +162,7 @@ FILTER A GT 1 AND B GE 2 AND C LT 3 AND D LE 4
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestWithFilterPrecedence(t *testing.T) {
@@ -186,7 +186,7 @@ FILTER City EQ "SPB" AND SSD EQ true OR City EQ "SPB" AND Rating GE 5 AS SPBSSD`
 
 	r, err := Parse(q)
 	require.NoError(t, err)
-	require.Equal(t, expected, r)
+	require.EqualValues(t, expected, r)
 }
 
 func TestValidation(t *testing.T) {

--- a/pkg/services/object/acl/classifier.go
+++ b/pkg/services/object/acl/classifier.go
@@ -174,14 +174,14 @@ func lookupKeyInContainer(
 	owner, cid []byte,
 	cnr *container.Container) (bool, error) {
 
-	cnrNodes, err := nm.GetContainerNodes(cnr.GetPlacementPolicy(), cid)
+	cnrNodes, err := nm.GetContainerNodes(netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy()), cid)
 	if err != nil {
 		return false, err
 	}
 
 	flatCnrNodes := cnrNodes.Flatten() // we need single array to iterate on
 	for i := range flatCnrNodes {
-		if bytes.Equal(flatCnrNodes[i].InfoV2.GetPublicKey(), owner) {
+		if bytes.Equal(flatCnrNodes[i].PublicKey(), owner) {
 			return true, nil
 		}
 	}

--- a/pkg/services/object/util/local.go
+++ b/pkg/services/object/util/local.go
@@ -29,7 +29,7 @@ func (p *localPlacement) BuildPlacement(addr *object.Address, policy *netmap.Pla
 
 	for i := range vs {
 		for j := range vs[i] {
-			addr, err := network.AddressFromString(vs[i][j].NetworkAddress())
+			addr, err := network.AddressFromString(vs[i][j].Address())
 			if err != nil {
 				// TODO: log error
 				continue

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -77,14 +77,14 @@ func NewTraverser(opts ...Option) (*Traverser, error) {
 		return nil, errors.Wrap(err, "could not build placement")
 	}
 
-	rs := cfg.policy.GetReplicas()
+	rs := cfg.policy.Replicas()
 	rem := make([]int, 0, len(rs))
 
 	for i := range rs {
 		cnt := cfg.rem
 
 		if cnt == 0 {
-			cnt = int(rs[i].GetCount())
+			cnt = int(rs[i].Count())
 		}
 
 		rem = append(rem, cnt)
@@ -120,7 +120,7 @@ func (t *Traverser) Next() []*network.Address {
 	addrs := make([]*network.Address, 0, count)
 
 	for i := 0; i < count; i++ {
-		addr, err := network.AddressFromString(t.vectors[0][i].NetworkAddress())
+		addr, err := network.AddressFromString(t.vectors[0][i].Address())
 		if err != nil {
 			// TODO: log error
 			return nil
@@ -181,7 +181,7 @@ func UseBuilder(b Builder) Option {
 // ForContainer is a traversal container setting option.
 func ForContainer(cnr *container.Container) Option {
 	return func(c *cfg) {
-		c.policy = cnr.GetPlacementPolicy()
+		c.policy = netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy())
 		c.addr.SetContainerID(container.CalculateID(cnr))
 	}
 }

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -22,7 +22,7 @@ func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
 		return
 	}
 
-	policy := cnr.GetPlacementPolicy()
+	policy := netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy())
 
 	nn, err := p.placementBuilder.BuildPlacement(addr, policy)
 	if err != nil {
@@ -33,7 +33,7 @@ func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
 		return
 	}
 
-	replicas := policy.GetReplicas()
+	replicas := policy.Replicas()
 
 	for i := range nn {
 		select {
@@ -42,7 +42,7 @@ func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
 		default:
 		}
 
-		p.processNodes(ctx, addr, nn[i], replicas[i].GetCount())
+		p.processNodes(ctx, addr, nn[i], replicas[i].Count())
 	}
 }
 
@@ -56,7 +56,7 @@ func (p *Policer) processNodes(ctx context.Context, addr *object.Address, nodes 
 		default:
 		}
 
-		netAddr := nodes[i].NetworkAddress()
+		netAddr := nodes[i].Address()
 
 		log := p.log.With(zap.String("node", netAddr))
 

--- a/pkg/services/replicator/process.go
+++ b/pkg/services/replicator/process.go
@@ -65,7 +65,7 @@ func (p *Replicator) handleTask(ctx context.Context, task *Task) {
 		default:
 		}
 
-		netAddr := task.nodes[i].NetworkAddress()
+		netAddr := task.nodes[i].Address()
 
 		log := p.log.With(zap.String("node", netAddr))
 


### PR DESCRIPTION
Refactored pkg/netmap package provides JSON converters for `NodeInfo` and `PlacementPolicy` structures, that has been used
by client applications. It also updates `Node` and `NodeInfo` structure itself, which is a part of `grpc <-> v2 <-> pkg` conversion chain now.