### PR TITLE
Add util keyer to CLI

### DIFF
--- a/pkg/util/keyer/dashboard.go
+++ b/pkg/util/keyer/dashboard.go
@@ -1,0 +1,122 @@
+package keyer
+
+import (
+	"crypto/elliptic"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+type (
+	Dashboard struct {
+		privKey     *keys.PrivateKey
+		pubKey      *keys.PublicKey
+		scriptHash3 util.Uint160
+
+		multisigKeys keys.PublicKeys
+	}
+)
+
+func (d Dashboard) PrettyPrint(uncompressed, useHex bool) {
+	var (
+		data []byte
+
+		privKey, pubKey, wif, wallet3, sh3, shBE3, multiSigAddr string
+	)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+
+	if d.privKey != nil {
+		privKey = d.privKey.String()
+
+		wif = d.privKey.WIF()
+		if useHex {
+			wif = base58ToHex(wif)
+		}
+	}
+
+	if d.pubKey != nil {
+		if uncompressed {
+			data = elliptic.Marshal(elliptic.P256(), d.pubKey.X, d.pubKey.Y)
+		} else {
+			data = d.pubKey.Bytes()
+		}
+
+		pubKey = hex.EncodeToString(data)
+	}
+
+	if !d.scriptHash3.Equals(util.Uint160{}) {
+		sh3 = d.scriptHash3.StringLE()
+		shBE3 = d.scriptHash3.StringBE()
+		wallet3 = address.Uint160ToString(d.scriptHash3)
+
+		if useHex {
+			wallet3 = base58ToHex(wallet3)
+		}
+	}
+
+	if len(d.multisigKeys) != 0 {
+		u160, err := scriptHashFromMultikey(d.multisigKeys)
+		if err != nil {
+			panic("can't create multisig redeem script")
+		}
+
+		multiSigAddr = address.Uint160ToString(u160)
+	}
+
+	if privKey != "" {
+		fmt.Fprintf(w, "PrivateKey\t%s\n", privKey)
+	}
+
+	if pubKey != "" {
+		fmt.Fprintf(w, "PublicKey\t%s\n", pubKey)
+	}
+
+	if wif != "" {
+		fmt.Fprintf(w, "WIF\t%s\n", wif)
+	}
+
+	if wallet3 != "" {
+		fmt.Fprintf(w, "Wallet3.0\t%s\n", wallet3)
+	}
+
+	if sh3 != "" {
+		fmt.Fprintf(w, "ScriptHash3.0\t%s\n", sh3)
+	}
+
+	if shBE3 != "" {
+		fmt.Fprintf(w, "ScriptHash3.0BE\t%s\n", shBE3)
+	}
+
+	if multiSigAddr != "" {
+		fmt.Fprintf(w, "MultiSigAddress\t%s\n", multiSigAddr)
+	}
+
+	w.Flush()
+}
+
+func base58ToHex(data string) string {
+	val, err := base58.Decode(data)
+	if err != nil {
+		panic("produced incorrect base58 value")
+	}
+
+	return hex.EncodeToString(val)
+}
+
+func scriptHashFromMultikey(k keys.PublicKeys) (util.Uint160, error) {
+	script, err := smartcontract.CreateDefaultMultiSigRedeemScript(k)
+	if err != nil {
+		return util.Uint160{}, fmt.Errorf("can't create multisig redeem script: %w", err)
+	}
+
+	return hash.Hash160(script), nil
+}

--- a/pkg/util/keyer/parser.go
+++ b/pkg/util/keyer/parser.go
@@ -1,0 +1,118 @@
+package keyer
+
+import (
+	"crypto/elliptic"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+const (
+	NeoPrivateKeySize = 32
+
+	scriptHashSize            = 20
+	addressSize               = 25
+	publicKeyCompressedSize   = 33
+	wifSize                   = 38
+	publicKeyUncompressedSize = 65
+)
+
+var errInputType = errors.New("unknown input type")
+
+func (d *Dashboard) ParseString(data string) error {
+	// just in case remove 0x prefixes if there are some
+	data = strings.TrimPrefix(data, "0x")
+	data = strings.TrimPrefix(data, "0X")
+
+	var (
+		rawData []byte
+		err     error
+	)
+
+	// data could be encoded in base58 or hex formats, try both
+	rawData, err = base58.Decode(data)
+	if err != nil {
+		rawData, err = hex.DecodeString(data)
+		if err != nil {
+			return fmt.Errorf("data is not hex or base58 encoded: %w", err)
+		}
+	}
+
+	return d.ParseBinary(rawData)
+}
+
+func (d *Dashboard) ParseBinary(data []byte) error {
+	var err error
+
+	switch len(data) {
+	case NeoPrivateKeySize:
+		d.privKey, err = keys.NewPrivateKeyFromBytes(data)
+		if err != nil {
+			return fmt.Errorf("can't parse private key: %w", err)
+		}
+	case wifSize:
+		d.privKey, err = keys.NewPrivateKeyFromWIF(base58.Encode(data))
+		if err != nil {
+			return fmt.Errorf("can't parse WIF: %w", err)
+		}
+	case publicKeyCompressedSize, publicKeyUncompressedSize:
+		d.pubKey, err = keys.NewPublicKeyFromBytes(data, elliptic.P256())
+		if err != nil {
+			return fmt.Errorf("can't parse public key: %w", err)
+		}
+	case addressSize:
+		d.scriptHash3, err = address.StringToUint160(base58.Encode(data))
+		if err != nil {
+			return fmt.Errorf("can't parse address: %w", err)
+		}
+	case scriptHashSize:
+		sc, err := util.Uint160DecodeBytesLE(data)
+		if err != nil {
+			return fmt.Errorf("can't parse script hash: %w", err)
+		}
+
+		d.scriptHash3 = sc
+	default:
+		return errInputType
+	}
+
+	d.fill()
+
+	return nil
+}
+
+func (d *Dashboard) ParseMultiSig(data []string) error {
+	d.multisigKeys = make(keys.PublicKeys, 0, len(data))
+
+	for i := range data {
+		data, err := hex.DecodeString(data[i])
+		if err != nil {
+			return fmt.Errorf("pass only hex encoded public keys: %w", err)
+		}
+
+		key, err := keys.NewPublicKeyFromBytes(data, elliptic.P256())
+		if err != nil {
+			return fmt.Errorf("pass only hex encoded public keys: %w", err)
+		}
+
+		d.multisigKeys = append(d.multisigKeys, key)
+	}
+
+	return nil
+}
+
+func (d *Dashboard) fill() {
+	if d.privKey != nil {
+		d.pubKey = d.privKey.PublicKey()
+	}
+
+	if d.pubKey != nil {
+		d.scriptHash3 = d.pubKey.GetScriptHash()
+	}
+}


### PR DESCRIPTION
Keyer prints provided key in all available formats. You can specify hex endoded public or private keys, WIF, script hash or wallet address. With `-g` key it generates new key. 

```
$ ./bin/neofs-cli util keyer L3o221BojgcCPYgdbXsm6jn7ayTZ72xwREvBHXKknR8VJ3G4WmjB
PrivateKey      c428b4a06f166fde9f8afcf918194acdde35aa2612ecf42fe0c94273425ded21
PublicKey       03012d47e76210aec73be39ab3d186e0a40fe8d86bfa3d4fabfda57ba13b88f96a
WIF             L3o221BojgcCPYgdbXsm6jn7ayTZ72xwREvBHXKknR8VJ3G4WmjB
Wallet3.0       NiRqSd5MtRZT5yUhgWd7oG11brkDG76Jim
ScriptHash3.0   8f0ecd714c31c5624b6647e5fd661e5031c8f8f6
ScriptHash3.0BE f6f8c831501e66fde547664b62c5314c71cd0e8f

$ ./bin/neofs-cli util keyer -g new.key
PrivateKey      bc41088451bbd51895ee955b79fa80f46264c46a5921788d2dcdbd1b9ff280c0
PublicKey       028eccef41fb0c387f8de3c3a0bbaaea4b2330468c9fb20be8f72cc93bc24e3c8d
WIF             L3Xen1bXG72oVr4mciWUUKNAATxRAdmhYgmy2QyopWycu25pgG73
Wallet3.0       NWAvRg5bwSEsPdne9qJh6mktVXTTbxpj8H
ScriptHash3.0   8d2f861a4c447945542f47131e2b15f97c318570
ScriptHash3.0BE 7085317cf9152b1e13472f544579444c1a862f8d
$ xxd new.key 
00000000: bc41 0884 51bb d518 95ee 955b 79fa 80f4  .A..Q......[y...
00000010: 6264 c46a 5921 788d 2dcd bd1b 9ff2 80c0  bd.jY!x.-.......
```