### PR TITLE
Invocatons of alphabet vote method

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -50,6 +50,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("morph.endpoint.client", "")
 	cfg.SetDefault("morph.endpoint.notification", "")
 	cfg.SetDefault("morph.dial_timeout", "10s")
+	cfg.SetDefault("morph.validators", []string{})
 
 	cfg.SetDefault("mainnet.endpoint.client", "")
 	cfg.SetDefault("mainnet.endpoint.notification", "")

--- a/pkg/innerring/invoke/alphabet.go
+++ b/pkg/innerring/invoke/alphabet.go
@@ -1,12 +1,14 @@
 package invoke
 
 import (
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 const (
 	emitMethod = "emit"
+	voteMethod = "vote"
 )
 
 // AlphabetEmit invokes emit method on alphabet contract.
@@ -17,4 +19,14 @@ func AlphabetEmit(cli *client.Client, con util.Uint160) error {
 
 	// there is no signature collecting, so we don't need extra fee
 	return cli.Invoke(con, 0, emitMethod)
+}
+
+// AlphabetVote invokes vote method on alphabet contract.
+func AlphabetVote(cli *client.Client, con util.Uint160, key keys.PublicKey) error {
+	if cli == nil {
+		return client.ErrNilClient
+	}
+
+	// there is no signature collecting, so we don't need extra fee
+	return cli.Invoke(con, 0, voteMethod, key.Bytes())
 }

--- a/pkg/innerring/invoke/alphabet.go
+++ b/pkg/innerring/invoke/alphabet.go
@@ -22,11 +22,15 @@ func AlphabetEmit(cli *client.Client, con util.Uint160) error {
 }
 
 // AlphabetVote invokes vote method on alphabet contract.
-func AlphabetVote(cli *client.Client, con util.Uint160, key keys.PublicKey) error {
+func AlphabetVote(cli *client.Client, con util.Uint160, epoch uint64, keys []keys.PublicKey) error {
 	if cli == nil {
 		return client.ErrNilClient
 	}
 
-	// there is no signature collecting, so we don't need extra fee
-	return cli.Invoke(con, 0, voteMethod, key.Bytes())
+	binaryKeys := make([][]byte, 0, len(keys))
+	for i := range keys {
+		binaryKeys = append(binaryKeys, keys[i].Bytes())
+	}
+
+	return cli.Invoke(con, feeOneGas, voteMethod, int64(epoch), binaryKeys)
 }

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -51,3 +51,15 @@ func (s *Server) voteForSidechainValidator(validators []keys.PublicKey) error {
 
 	return invoke.AlphabetVote(s.morphClient, s.contracts.alphabet[index], candidate)
 }
+
+// InitAndVoteForSidechainValidator is a public function to use outside of
+// inner ring daemon execution. It initialize inner ring structure with data
+// from blockchain and then calls vote method on corresponding alphabet contract.
+func (s *Server) InitAndVoteForSidechainValidator(validators []keys.PublicKey) error {
+	err := s.initConfigFromBlockchain()
+	if err != nil {
+		return err
+	}
+
+	return s.voteForSidechainValidator(validators)
+}

--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -81,7 +81,7 @@ func (c *Client) Invoke(contract util.Uint160, fee util.Fixed8, method string, a
 
 	c.logger.Debug("neo client invoke",
 		zap.String("method", method),
-		zap.Stringer("tx_hash", txHash))
+		zap.Stringer("tx_hash", txHash.Reverse()))
 
 	return nil
 }


### PR DESCRIPTION
Inner ring can invoke `Vote` method on corresponding alphabet contracts. This way it controls side chain. Now inner ring node invokes voting on startup if it is presented in config. This way alphabet contracts are able to produce more GAS for inner ring and storage nodes.

You can setup list of predefined validators in `config.yml`
```yml
morph:
  validators:
    - 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2
    - 0228b3b86d632a755da1e1f226bd782038acbe48e1f14e256b0afa58e32a45695e
```

or with environment variable (whitespace separated list)
```bash
NEOFS_IR_MORPH_VALIDATORS="02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2 0228b3b86d632a755da1e1f226bd782038acbe48e1f14e256b0afa58e32a45695e"
```

If list is empty, then `vote` won't be invoked on startup.

In runtime node also can vote for validator from the comma-separated list.
```bash
./neofs-ir --config config.yml \
--vote 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2,0228b3b86d632a755da1e1f226bd782038acbe48e1f14e256b0afa58e32a45695e
```