### PR TITLE
Increase extra gas on `ApprovePeer` method

### DIFF
--- a/pkg/innerring/invoke/netmap.go
+++ b/pkg/innerring/invoke/netmap.go
@@ -69,7 +69,7 @@ func ApprovePeer(cli *client.Client, con util.Uint160, peer []byte) error {
 		return client.ErrNilClient
 	}
 
-	return cli.Invoke(con, feeHalfGas, approvePeerMethod, peer)
+	return cli.Invoke(con, feeOneGas, approvePeerMethod, peer)
 }
 
 // UpdatePeerState invokes addPeer method.


### PR DESCRIPTION
With latest changes in neo's execution costs, we need more gas to add storage node to netmap.