### PR TITLE
Add `--ttl` argument in CLI

### DIFF
--- a/cmd/neofs-cli/modules/accounting.go
+++ b/cmd/neofs-cli/modules/accounting.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/accounting"
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/spf13/cobra"
 )
@@ -41,14 +42,14 @@ var accountingBalanceCmd = &cobra.Command{
 
 		switch balanceOwner {
 		case "":
-			response, err = cli.GetSelfBalance(ctx)
+			response, err = cli.GetSelfBalance(ctx, client.WithTTL(getTTL()))
 		default:
 			oid, err = ownerFromString(balanceOwner)
 			if err != nil {
 				return err
 			}
 
-			response, err = cli.GetBalance(ctx, oid)
+			response, err = cli.GetBalance(ctx, oid, client.WithTTL(getTTL()))
 		}
 
 		if err != nil {

--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -84,14 +84,14 @@ var listContainersCmd = &cobra.Command{
 
 		switch containerOwner {
 		case "":
-			response, err = cli.ListSelfContainers(ctx)
+			response, err = cli.ListSelfContainers(ctx, client.WithTTL(getTTL()))
 		default:
 			oid, err = ownerFromString(containerOwner)
 			if err != nil {
 				return err
 			}
 
-			response, err = cli.ListContainers(ctx, oid)
+			response, err = cli.ListContainers(ctx, oid, client.WithTTL(getTTL()))
 		}
 
 		if err != nil {
@@ -144,7 +144,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 		cnr.SetAttributes(attributes)
 		cnr.SetNonce(nonce[:])
 
-		id, err := cli.PutContainer(ctx, cnr)
+		id, err := cli.PutContainer(ctx, cnr, client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -157,7 +157,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 			for i := 0; i < awaitTimeout; i++ {
 				time.Sleep(1 * time.Second)
 
-				_, err := cli.GetContainer(ctx, id)
+				_, err := cli.GetContainer(ctx, id, client.WithTTL(getTTL()))
 				if err == nil {
 					fmt.Println("container has been persisted on sidechain")
 					return nil
@@ -189,7 +189,7 @@ Only owner of the container has a permission to remove container.`,
 			return err
 		}
 
-		err = cli.DeleteContainer(ctx, id)
+		err = cli.DeleteContainer(ctx, id, client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -202,7 +202,7 @@ Only owner of the container has a permission to remove container.`,
 			for i := 0; i < awaitTimeout; i++ {
 				time.Sleep(1 * time.Second)
 
-				_, err := cli.GetContainer(ctx, id)
+				_, err := cli.GetContainer(ctx, id, client.WithTTL(getTTL()))
 				if err != nil {
 					fmt.Println("container has been removed:", containerID)
 					return nil
@@ -245,7 +245,9 @@ var listContainerObjectsCmd = &cobra.Command{
 		searchQuery.WithContainerID(id)
 		searchQuery.WithSearchFilters(*filters)
 
-		objectIDs, err := cli.SearchObject(ctx, searchQuery, client.WithSession(sessionToken))
+		objectIDs, err := cli.SearchObject(ctx, searchQuery,
+			client.WithTTL(getTTL()),
+			client.WithSession(sessionToken))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -295,7 +297,7 @@ var getContainerInfoCmd = &cobra.Command{
 				return err
 			}
 
-			cnr, err = cli.GetContainer(ctx, id)
+			cnr, err = cli.GetContainer(ctx, id, client.WithTTL(getTTL()))
 			if err != nil {
 				return fmt.Errorf("rpc error: %w", err)
 			}
@@ -348,7 +350,7 @@ var getExtendedACLCmd = &cobra.Command{
 			return err
 		}
 
-		eaclTable, err := cli.GetEACL(ctx, id)
+		eaclTable, err := cli.GetEACL(ctx, id, client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -409,7 +411,7 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 
 		eaclTable.SetCID(id)
 
-		err = cli.SetEACL(ctx, eaclTable)
+		err = cli.SetEACL(ctx, eaclTable, client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -425,7 +427,7 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 			for i := 0; i < awaitTimeout; i++ {
 				time.Sleep(1 * time.Second)
 
-				table, err := cli.GetEACL(ctx, id)
+				table, err := cli.GetEACL(ctx, id, client.WithTTL(getTTL()))
 				if err == nil {
 					// compare binary values because EACL could have been set already
 					got, err := table.ToV2().StableMarshal(nil)

--- a/cmd/neofs-cli/modules/netmap.go
+++ b/cmd/neofs-cli/modules/netmap.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,7 @@ var getEpochCmd = &cobra.Command{
 			return err
 		}
 
-		e, err := cli.Epoch(context.Background())
+		e, err := cli.Epoch(context.Background(), client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}
@@ -67,7 +68,7 @@ var localNodeInfoCmd = &cobra.Command{
 			return err
 		}
 
-		nodeInfo, err := cli.EndpointInfo(context.Background())
+		nodeInfo, err := cli.EndpointInfo(context.Background(), client.WithTTL(getTTL()))
 		if err != nil {
 			return fmt.Errorf("rpc error: %w", err)
 		}

--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -199,6 +199,7 @@ func putObject(cmd *cobra.Command, _ []string) error {
 		new(client.PutObjectParams).
 			WithObject(obj.Object()).
 			WithPayloadReader(f),
+		client.WithTTL(getTTL()),
 		client.WithSession(tok),
 		client.WithBearer(btok))
 	if err != nil {
@@ -227,6 +228,7 @@ func deleteObject(cmd *cobra.Command, _ []string) error {
 	}
 	err = cli.DeleteObject(ctx,
 		new(client.DeleteObjectParams).WithAddress(objAddr),
+		client.WithTTL(getTTL()),
 		client.WithSession(tok),
 		client.WithBearer(btok))
 	if err != nil {
@@ -270,6 +272,7 @@ func getObject(cmd *cobra.Command, _ []string) error {
 		new(client.GetObjectParams).
 			WithAddress(objAddr).
 			WithPayloadWriter(out),
+		client.WithTTL(getTTL()),
 		client.WithSession(tok),
 		client.WithBearer(btok))
 	if err != nil {
@@ -308,6 +311,7 @@ func getObjectHeader(cmd *cobra.Command, _ []string) error {
 		ps = ps.WithMainFields()
 	}
 	obj, err := cli.GetObjectHeader(ctx, ps,
+		client.WithTTL(getTTL()),
 		client.WithSession(tok),
 		client.WithBearer(btok))
 	if err != nil {
@@ -339,6 +343,7 @@ func searchObject(cmd *cobra.Command, _ []string) error {
 	}
 	ps := new(client.SearchObjectParams).WithContainerID(cid).WithSearchFilters(sf)
 	ids, err := cli.SearchObject(ctx, ps,
+		client.WithTTL(getTTL()),
 		client.WithSession(tok),
 		client.WithBearer(btok))
 	if err != nil {
@@ -377,6 +382,7 @@ func getObjectHash(cmd *cobra.Command, _ []string) error {
 	if len(ranges) == 0 { // hash of full payload
 		obj, err := cli.GetObjectHeader(ctx,
 			new(client.ObjectHeaderParams).WithAddress(objAddr),
+			client.WithTTL(getTTL()),
 			client.WithSession(tok),
 			client.WithBearer(btok))
 		if err != nil {
@@ -395,6 +401,7 @@ func getObjectHash(cmd *cobra.Command, _ []string) error {
 	switch typ {
 	case hashSha256:
 		res, err := cli.ObjectPayloadRangeSHA256(ctx, ps,
+			client.WithTTL(getTTL()),
 			client.WithSession(tok),
 			client.WithBearer(btok))
 		if err != nil {
@@ -406,6 +413,7 @@ func getObjectHash(cmd *cobra.Command, _ []string) error {
 		}
 	case hashTz:
 		res, err := cli.ObjectPayloadRangeTZ(ctx, ps,
+			client.WithTTL(getTTL()),
 			client.WithSession(tok),
 			client.WithBearer(btok))
 		if err != nil {

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -21,6 +21,8 @@ const (
 	envPrefix = "NEOFS_CLI"
 
 	generateKeyConst = "new"
+
+	ttlDefaultValue = 2
 )
 
 // Global scope flags.
@@ -72,6 +74,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringP("rpc-endpoint", "r", "", "remote node address (as 'multiaddr' or '<host>:<port>')")
 	_ = viper.BindPFlag("rpc", rootCmd.PersistentFlags().Lookup("rpc-endpoint"))
+
+	rootCmd.PersistentFlags().Uint32("ttl", ttlDefaultValue, "TTL value in request meta header")
+	_ = viper.BindPFlag("ttl", rootCmd.PersistentFlags().Lookup("ttl"))
 
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
@@ -163,6 +168,13 @@ func getSDKClient() (*client.Client, error) {
 	}
 
 	return client.New(key, client.WithAddress(ipAddr))
+}
+
+func getTTL() uint32 {
+	ttl := viper.GetUint32("ttl")
+	printVerbose("TTL: %d", ttl)
+
+	return ttl
 }
 
 // ownerFromString converts string with NEO3 wallet address to neofs owner ID.


### PR DESCRIPTION
Closes #169 

Example:
```
$ ./bin/neofs-cli -c config.yml --verbose --ttl 1 object search --cid CWqN1qb7HgC98v1ozBc5ER2u6EcMWwK1gNPCEzRgRrrY
Using config file: config.yml
TTL: 1
Found 1 objects.
77X76kVa35AyXk6LmWKf7w7C4LEPKiapMHaPtFVCYhGF
```