### PR TITLE
Update to latest neofs-api-go

### DIFF
--- a/cmd/neofs-cli/modules/accounting.go
+++ b/cmd/neofs-cli/modules/accounting.go
@@ -86,15 +86,15 @@ func prettyPrintDecimal(decimal *accounting.Decimal) {
 	}
 
 	if verbose {
-		fmt.Println("value:", decimal.GetValue())
-		fmt.Println("precision:", decimal.GetPrecision())
+		fmt.Println("value:", decimal.Value())
+		fmt.Println("precision:", decimal.Precision())
 	} else {
 		// divider = 10^{precision}; v:365, p:2 => 365 / 10^2 = 3.65
-		divider := math.Pow(10, float64(decimal.GetPrecision()))
+		divider := math.Pow(10, float64(decimal.Precision()))
 
 		// %0.8f\n for precision 8
-		format := fmt.Sprintf("%%0.%df\n", decimal.GetPrecision())
+		format := fmt.Sprintf("%%0.%df\n", decimal.Precision())
 
-		fmt.Printf(format, float64(decimal.GetValue())/divider)
+		fmt.Printf(format, float64(decimal.Value())/divider)
 	}
 }

--- a/cmd/neofs-cli/modules/netmap.go
+++ b/cmd/neofs-cli/modules/netmap.go
@@ -81,7 +81,7 @@ var localNodeInfoCmd = &cobra.Command{
 
 func prettyPrintNodeInfo(i *netmap.NodeInfo, jsonEncoding bool) {
 	if jsonEncoding {
-		data, err := netmap.NodeInfoToJSON(i)
+		data, err := i.MarshalJSON()
 		if err != nil {
 			printVerbose("Can't convert container to json: %w", err)
 			return

--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -628,9 +627,9 @@ func marshalHeader(cmd *cobra.Command, hdr *object.Object) ([]byte, error) {
 	case toJson && toProto:
 		return nil, errors.New("'--json' and '--proto' flags are mutually exclusive")
 	case toJson:
-		return json.Marshal(hdr) // TODO currently not supported by neofs-api-go
+		return hdr.MarshalJSON()
 	case toProto:
-		return hdr.ToV2().StableMarshal(nil)
+		return hdr.Marshal()
 	default:
 		return nil, nil
 	}

--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/token"
-	v2ACL "github.com/nspcc-dev/neofs-api-go/v2/acl"
 	"github.com/nspcc-dev/neofs-node/pkg/util/keyer"
 	"github.com/spf13/cobra"
 )
@@ -108,7 +107,7 @@ func signBearerToken(cmd *cobra.Command, _ []string) error {
 
 	var data []byte
 	if jsonFlag || len(to) == 0 {
-		data, err = v2ACL.BearerTokenToJSON(btok.ToV2())
+		data, err = btok.MarshalJSON()
 		if err != nil {
 			return fmt.Errorf("can't JSON encode bearer token: %w", err)
 		}
@@ -147,7 +146,7 @@ func convertEACLTable(cmd *cobra.Command, _ []string) error {
 
 	var data []byte
 	if jsonFlag || len(to) == 0 {
-		data, err = v2ACL.TableToJSON(table.ToV2())
+		data, err = table.MarshalJSON()
 		if err != nil {
 			return fmt.Errorf("can't JSON encode extended ACL table: %w", err)
 		}

--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -112,7 +112,7 @@ func signBearerToken(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("can't JSON encode bearer token: %w", err)
 		}
 	} else {
-		data, err = btok.ToV2().StableMarshal(nil)
+		data, err = btok.Marshal()
 		if err != nil {
 			return fmt.Errorf("can't binary encode bearer token: %w", err)
 		}
@@ -151,7 +151,7 @@ func convertEACLTable(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("can't JSON encode extended ACL table: %w", err)
 		}
 	} else {
-		data, err = table.ToV2().StableMarshal(nil)
+		data, err = table.Marshal()
 		if err != nil {
 			return fmt.Errorf("can't binary encode extended ACL table: %w", err)
 		}

--- a/cmd/neofs-node/attributes.go
+++ b/cmd/neofs-node/attributes.go
@@ -3,8 +3,7 @@ package main
 import (
 	"strconv"
 
-	sdk "github.com/nspcc-dev/neofs-api-go/pkg/netmap"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/util/attributes"
 	"github.com/spf13/viper"
 )
@@ -15,7 +14,7 @@ const (
 	defaultPrice    = 0
 )
 
-func parseAttributes(v *viper.Viper) []*netmap.Attribute {
+func parseAttributes(v *viper.Viper) []*netmap.NodeAttribute {
 	stringAttributes := readAttributes(v)
 
 	attrs, err := attributes.ParseV2Attributes(stringAttributes, nil)
@@ -41,14 +40,14 @@ func readAttributes(v *viper.Viper) (attrs []string) {
 	return attrs
 }
 
-func addWellKnownAttributes(attrs []*netmap.Attribute) []*netmap.Attribute {
+func addWellKnownAttributes(attrs []*netmap.NodeAttribute) []*netmap.NodeAttribute {
 	var hasCapacity, hasPrice bool
 
 	// check if user defined capacity and price attributes
 	for i := range attrs {
-		if !hasPrice && attrs[i].GetKey() == sdk.PriceAttr {
+		if !hasPrice && attrs[i].Key() == netmap.PriceAttr {
 			hasPrice = true
-		} else if !hasCapacity && attrs[i].GetKey() == sdk.CapacityAttr {
+		} else if !hasCapacity && attrs[i].Key() == netmap.CapacityAttr {
 			hasCapacity = true
 		}
 	}
@@ -56,15 +55,15 @@ func addWellKnownAttributes(attrs []*netmap.Attribute) []*netmap.Attribute {
 	// do not override user defined capacity and price attributes
 
 	if !hasCapacity {
-		capacity := new(netmap.Attribute)
-		capacity.SetKey(sdk.CapacityAttr)
+		capacity := netmap.NewNodeAttribute()
+		capacity.SetKey(netmap.CapacityAttr)
 		capacity.SetValue(strconv.FormatUint(defaultCapacity, 10))
 		attrs = append(attrs, capacity)
 	}
 
 	if !hasPrice {
-		price := new(netmap.Attribute)
-		price.SetKey(sdk.PriceAttr)
+		price := netmap.NewNodeAttribute()
+		price.SetKey(netmap.PriceAttr)
 		price.SetValue(strconv.FormatUint(defaultPrice, 10))
 		attrs = append(attrs, price)
 	}

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-api-go/pkg"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/misc"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
@@ -194,7 +194,7 @@ type BootstrapType uint32
 type cfgNodeInfo struct {
 	// values from config
 	bootType   BootstrapType
-	attributes []*netmap.Attribute
+	attributes []*netmap.NodeAttribute
 
 	// values at runtime
 	info *netmap.NodeInfo

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	netmapGRPC "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -36,7 +36,7 @@ func initNetmapService(c *cfg) {
 	peerInfo := new(netmap.NodeInfo)
 	peerInfo.SetAddress(c.localAddr.String())
 	peerInfo.SetPublicKey(crypto.MarshalPublicKey(&c.key.PublicKey))
-	peerInfo.SetAttributes(c.cfgNodeInfo.attributes)
+	peerInfo.SetAttributes(c.cfgNodeInfo.attributes...)
 
 	c.cfgNodeInfo.info = peerInfo
 
@@ -46,7 +46,7 @@ func initNetmapService(c *cfg) {
 				c.key,
 				netmapService.NewResponseService(
 					netmapService.NewExecutionService(
-						c.cfgNodeInfo.info,
+						c.cfgNodeInfo.info.ToV2(),
 						c.apiVersion,
 					),
 					c.respSvc,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28
+	github.com/nspcc-dev/neofs-api-go v1.20.0
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b
-	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201111110701-789474906015
+	github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0
@@ -36,7 +36,6 @@ require (
 	golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5 // indirect
 	golang.org/x/tools v0.0.0-20200123022218-593de606220b // indirect
 	google.golang.org/grpc v1.29.1
-	google.golang.org/protobuf v1.23.0
 )
 
 // Used for debug reasons

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b h1:gk5bZgpWOehaDVKI5vBDkcjXTpRkKqcvIb1h/vHnBH4=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b/go.mod h1:9s7LNp2lMgf0caH2t0sam4+WT2SIauXozwP0AdBqnEo=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28 h1:FPS4eJx50eFnyfhiHCVmaOdv3q60duAuUZMVosILXX4=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.20.0 h1:su+2Q3KxqHGAfuHBbSOOuJdbQpbvDFcenv6LXjZz2Ik=
+github.com/nspcc-dev/neofs-api-go v1.20.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b h1:gk5bZgpWOehaDVKI5vBDkcjXTpRkKqcvIb1h/vHnBH4=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b/go.mod h1:9s7LNp2lMgf0caH2t0sam4+WT2SIauXozwP0AdBqnEo=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201111110701-789474906015 h1:scQjRBJo35QrIl18CtiWTED1IpSX+ejPt32jEUYa8Og=
-github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201111110701-789474906015/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28 h1:FPS4eJx50eFnyfhiHCVmaOdv3q60duAuUZMVosILXX4=
+github.com/nspcc-dev/neofs-api-go v1.3.1-0.20201116094437-fe336fd5ba28/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/pkg/core/container/fmt.go
+++ b/pkg/core/container/fmt.go
@@ -23,8 +23,8 @@ func CheckFormat(c *container.Container) error {
 		return errors.Wrap(err, "incorrect version")
 	}
 
-	if len(c.OwnerID().ToV2().GetValue()) != owner.NEO3WalletSize {
-		return errors.Wrap(owner.ErrBadID, "incorrect owner identifier")
+	if ln := len(c.OwnerID().ToV2().GetValue()); ln != owner.NEO3WalletSize {
+		return errors.Errorf("incorrect owner identifier: expected length %d != %d", owner.NEO3WalletSize, ln)
 	}
 
 	if _, err := uuid.FromBytes(c.Nonce()); err != nil {

--- a/pkg/core/container/fmt.go
+++ b/pkg/core/container/fmt.go
@@ -10,24 +10,24 @@ import (
 
 var errNilPolicy = errors.New("placement policy is nil")
 
-// CheckFormat conducts an initial check of the container data.
+// CheckFormat conducts an initial check of the v2 container data.
 //
 // It is expected that if a container fails this test,
 // it will not be inner-ring approved.
 func CheckFormat(c *container.Container) error {
-	if c.GetPlacementPolicy() == nil {
+	if c.PlacementPolicy() == nil {
 		return errNilPolicy
 	}
 
-	if err := pkg.IsSupportedVersion(pkg.NewVersionFromV2(c.GetVersion())); err != nil {
+	if err := pkg.IsSupportedVersion(c.Version()); err != nil {
 		return errors.Wrap(err, "incorrect version")
 	}
 
-	if len(c.GetOwnerID().GetValue()) != owner.NEO3WalletSize {
+	if len(c.OwnerID().ToV2().GetValue()) != owner.NEO3WalletSize {
 		return errors.Wrap(owner.ErrBadID, "incorrect owner identifier")
 	}
 
-	if _, err := uuid.FromBytes(c.GetNonce()); err != nil {
+	if _, err := uuid.FromBytes(c.Nonce()); err != nil {
 		return errors.Wrap(err, "incorrect nonce")
 	}
 

--- a/pkg/core/container/fmt_test.go
+++ b/pkg/core/container/fmt_test.go
@@ -17,19 +17,19 @@ func TestCheckFormat(t *testing.T) {
 
 	require.Error(t, CheckFormat(c))
 
-	policy := new(netmap.PlacementPolicy)
-	c.SetPlacementPolicy(policy.ToV2())
+	policy := netmap.NewPlacementPolicy()
+	c.SetPlacementPolicy(policy)
 
 	require.Error(t, CheckFormat(c))
 
-	c.SetVersion(pkg.SDKVersion().ToV2())
+	c.SetVersion(pkg.SDKVersion())
 
 	require.Error(t, CheckFormat(c))
 
 	wallet, err := owner.NEO3WalletFromPublicKey(&test.DecodeKey(-1).PublicKey)
 	require.NoError(t, err)
 
-	c.SetOwnerID(owner.NewIDFromNeo3Wallet(wallet).ToV2())
+	c.SetOwnerID(owner.NewIDFromNeo3Wallet(wallet))
 
 	c.SetNonce(nil)
 

--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -57,9 +57,9 @@ func NewFormatValidator(opts ...FormatValidatorOption) *FormatValidator {
 func (v *FormatValidator) Validate(obj *Object) error {
 	if obj == nil {
 		return errNilObject
-	} else if obj.GetID() == nil {
+	} else if obj.ID() == nil {
 		return errNilID
-	} else if obj.GetContainerID() == nil {
+	} else if obj.ContainerID() == nil {
 		return errNilCID
 	}
 
@@ -77,11 +77,11 @@ func (v *FormatValidator) Validate(obj *Object) error {
 }
 
 func (v *FormatValidator) validateSignatureKey(obj *Object) error {
-	token := obj.GetSessionToken()
-	key := obj.GetSignature().GetKey()
+	token := obj.SessionToken()
+	key := obj.Signature().Key()
 
 	if token == nil || !bytes.Equal(token.SessionKey(), key) {
-		return v.checkOwnerKey(obj.GetOwnerID(), obj.GetSignature().GetKey())
+		return v.checkOwnerKey(obj.OwnerID(), obj.Signature().Key())
 	}
 
 	// FIXME: perform token verification
@@ -123,7 +123,7 @@ func (v *FormatValidator) ValidateContent(t object.Type, payload []byte) error {
 		addrList := content.GetAddressList()
 
 		for _, addr := range addrList {
-			if addr.GetContainerID() == nil || addr.GetObjectID() == nil {
+			if addr.ContainerID() == nil || addr.ObjectID() == nil {
 				return errors.Errorf("(%T) empty address reference in tombstone", v)
 			}
 		}

--- a/pkg/core/object/object.go
+++ b/pkg/core/object/object.go
@@ -19,8 +19,8 @@ type Object struct {
 func (o *Object) Address() *object.Address {
 	if o != nil {
 		aV2 := new(refs.Address)
-		aV2.SetObjectID(o.GetID().ToV2())
-		aV2.SetContainerID(o.GetContainerID().ToV2())
+		aV2.SetObjectID(o.ID().ToV2())
+		aV2.SetContainerID(o.ContainerID().ToV2())
 
 		return object.NewAddressFromV2(aV2)
 	}
@@ -56,22 +56,10 @@ func New() *Object {
 	return NewFromSDK(object.New())
 }
 
-// FromBytes restores Object from binary format.
-func FromBytes(data []byte) (*Object, error) {
-	o, err := object.FromBytes(data)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Object{
-		Object: o,
-	}, nil
-}
-
 // GetParent returns parent object.
 func (o *Object) GetParent() *Object {
 	if o != nil {
-		if par := o.Object.GetParent(); par != nil {
+		if par := o.Object.Parent(); par != nil {
 			return &Object{
 				Object: par,
 			}

--- a/pkg/core/object/tombstone.go
+++ b/pkg/core/object/tombstone.go
@@ -122,7 +122,7 @@ func (c *TombstoneContentV2) StableUnmarshal(data []byte) error {
 		data = data[ln:]
 
 		addr := new(refs.Address)
-		if err := addr.StableUnmarshal(data[:sz]); err != nil {
+		if err := addr.Unmarshal(data[:sz]); err != nil {
 			fmt.Println(err)
 			return err
 		}

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -1,10 +1,7 @@
 package container
 
 import (
-	"github.com/golang/protobuf/proto"
 	containerSDK "github.com/nspcc-dev/neofs-api-go/pkg/container"
-	v2container "github.com/nspcc-dev/neofs-api-go/v2/container"
-	containerGRPC "github.com/nspcc-dev/neofs-api-go/v2/container/grpc"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/invoke"
 	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
@@ -22,19 +19,14 @@ func (cp *Processor) processContainerPut(put *containerEvent.Put) {
 	cnrData := put.Container()
 
 	// unmarshal container structure
-	// FIXME: temp solution, replace after neofs-api-go#168
-	cnrProto := new(containerGRPC.Container)
-	if err := proto.Unmarshal(cnrData, cnrProto); err != nil {
+	cnr := containerSDK.New()
+	if err := cnr.Unmarshal(cnrData); err != nil {
 		cp.log.Info("could not unmarshal container structure",
 			zap.String("error", err.Error()),
 		)
 
 		return
 	}
-
-	cnr := containerSDK.NewContainerFromV2(
-		v2container.ContainerFromGRPCMessage(cnrProto),
-	)
 
 	// perform format check
 	if err := container.CheckFormat(cnr); err != nil {

--- a/pkg/innerring/processors/netmap/process_cleanup.go
+++ b/pkg/innerring/processors/netmap/process_cleanup.go
@@ -2,7 +2,7 @@ package netmap
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/invoke"
 	"go.uber.org/zap"
 )
@@ -27,7 +27,7 @@ func (np *Processor) processNetmapCleanupTick(epoch uint64) {
 
 		err = invoke.UpdatePeerState(np.morphClient, np.netmapContract, &invoke.UpdatePeerArgs{
 			Key:    key,
-			Status: uint32(netmap.Offline),
+			Status: netmap.NodeStateOffline,
 		})
 		if err != nil {
 			np.log.Error("can't invoke netmap.UpdateState", zap.Error(err))

--- a/pkg/local_object_storage/localstore/methods.go
+++ b/pkg/local_object_storage/localstore/methods.go
@@ -8,11 +8,11 @@ import (
 )
 
 func addressBytes(a *objectSDK.Address) ([]byte, error) {
-	return a.ToV2().StableMarshal(nil)
+	return a.Marshal()
 }
 
 func objectBytes(o *object.Object) ([]byte, error) {
-	return o.ToV2().StableMarshal(nil)
+	return o.Marshal()
 }
 
 func (s *Storage) Put(obj *object.Object) error {

--- a/pkg/local_object_storage/localstore/methods.go
+++ b/pkg/local_object_storage/localstore/methods.go
@@ -67,7 +67,9 @@ func (s *Storage) Get(addr *objectSDK.Address) (*object.Object, error) {
 		return nil, errors.Wrap(err, "could not get object from BLOB storage")
 	}
 
-	return object.FromBytes(objBytes)
+	obj := object.New()
+
+	return obj, obj.Unmarshal(objBytes)
 }
 
 func (s *Storage) Head(addr *objectSDK.Address) (*object.Object, error) {

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -128,7 +128,7 @@ func TestDB_Delete(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := objectSDK.SearchFilters{}
-	fs.AddObjectContainerIDFilter(objectSDK.MatchStringEqual, o.GetContainerID())
+	fs.AddObjectContainerIDFilter(objectSDK.MatchStringEqual, o.ContainerID())
 
 	testSelect(t, db, fs, o.Address())
 

--- a/pkg/local_object_storage/metabase/get.go
+++ b/pkg/local_object_storage/metabase/get.go
@@ -34,7 +34,9 @@ func (db *DB) Get(addr *objectSDK.Address) (*object.Object, error) {
 
 		var err error
 
-		obj, err = object.FromBytes(data)
+		obj = object.New()
+
+		err = obj.Unmarshal(data)
 
 		return err
 	}); err != nil {

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -31,7 +31,7 @@ func (db *DB) Put(obj *object.Object) error {
 				return errors.Wrapf(err, "(%T) could not create primary bucket", db)
 			}
 
-			data, err := obj.ToV2().StableMarshal(nil)
+			data, err := obj.Marshal()
 			if err != nil {
 				return errors.Wrapf(err, "(%T) could not marshal the object", db)
 			}

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -94,27 +94,27 @@ func addressKey(addr *objectSDK.Address) []byte {
 }
 
 func objectIndices(obj *object.Object, parent bool) []bucketItem {
-	as := obj.GetAttributes()
+	as := obj.Attributes()
 
 	res := make([]bucketItem, 0, 7+len(as)) // 7 predefined buckets and object attributes
 
 	childfreeVal := v2object.BooleanPropertyValueTrue
-	if len(obj.GetChildren()) > 0 {
+	if len(obj.Children()) > 0 {
 		childfreeVal = ""
 	}
 
 	res = append(res,
 		bucketItem{
 			key: v2object.FilterHeaderVersion,
-			val: obj.GetVersion().String(),
+			val: obj.Version().String(),
 		},
 		bucketItem{
 			key: v2object.FilterHeaderContainerID,
-			val: obj.GetContainerID().String(),
+			val: obj.ContainerID().String(),
 		},
 		bucketItem{
 			key: v2object.FilterHeaderOwnerID,
-			val: obj.GetOwnerID().String(),
+			val: obj.OwnerID().String(),
 		},
 		bucketItem{
 			key: v2object.FilterPropertyChildfree,
@@ -122,12 +122,12 @@ func objectIndices(obj *object.Object, parent bool) []bucketItem {
 		},
 		bucketItem{
 			key: v2object.FilterHeaderParent,
-			val: obj.GetParentID().String(),
+			val: obj.ParentID().String(),
 		},
 		// TODO: add remaining fields after neofs-api#72
 	)
 
-	if obj.GetType() == objectSDK.TypeRegular && !obj.HasParent() {
+	if obj.Type() == objectSDK.TypeRegular && !obj.HasParent() {
 		res = append(res, bucketItem{
 			key: v2object.FilterPropertyRoot,
 		})
@@ -141,8 +141,8 @@ func objectIndices(obj *object.Object, parent bool) []bucketItem {
 
 	for _, a := range as {
 		res = append(res, bucketItem{
-			key: a.GetKey(),
-			val: a.GetValue(),
+			key: a.Key(),
+			val: a.Value(),
 		})
 	}
 

--- a/pkg/local_object_storage/metabase/select_test.go
+++ b/pkg/local_object_storage/metabase/select_test.go
@@ -100,15 +100,15 @@ func TestMismatchAfterMatch(t *testing.T) {
 
 	require.NoError(t, db.Put(obj))
 
-	a := obj.GetAttributes()[0]
+	a := obj.Attributes()[0]
 
 	fs := objectSDK.SearchFilters{}
 
 	// 1st - mismatching filter
-	fs.AddFilter(a.GetKey(), a.GetValue()+"1", objectSDK.MatchStringEqual)
+	fs.AddFilter(a.Key(), a.Value()+"1", objectSDK.MatchStringEqual)
 
 	// 2nd - matching filter
-	fs.AddFilter(a.GetKey(), a.GetValue(), objectSDK.MatchStringEqual)
+	fs.AddFilter(a.Key(), a.Value(), objectSDK.MatchStringEqual)
 
 	testSelect(t, db, fs)
 }
@@ -120,7 +120,7 @@ func addCommonAttribute(objs ...*object.Object) *objectSDK.Attribute {
 
 	for _, o := range objs {
 		object.NewRawFromObject(o).SetAttributes(
-			append(o.GetAttributes(), aCommon)...,
+			append(o.Attributes(), aCommon)...,
 		)
 	}
 
@@ -143,7 +143,7 @@ func TestSelectRemoved(t *testing.T) {
 	require.NoError(t, db.Put(obj2))
 
 	fs := objectSDK.SearchFilters{}
-	fs.AddFilter(a.GetKey(), a.GetValue(), objectSDK.MatchStringEqual)
+	fs.AddFilter(a.Key(), a.Value(), objectSDK.MatchStringEqual)
 
 	testSelect(t, db, fs, obj1.Address(), obj2.Address())
 
@@ -165,7 +165,7 @@ func TestMissingObjectAttribute(t *testing.T) {
 	// add object w/o attribute
 	obj2 := generateObject(t, testPrm{})
 
-	a1 := obj1.GetAttributes()[0]
+	a1 := obj1.Attributes()[0]
 
 	// add common attribute
 	aCommon := addCommonAttribute(obj1, obj2)
@@ -177,10 +177,10 @@ func TestMissingObjectAttribute(t *testing.T) {
 	fs := objectSDK.SearchFilters{}
 
 	// 1st filter by common attribute
-	fs.AddFilter(aCommon.GetKey(), aCommon.GetValue(), objectSDK.MatchStringEqual)
+	fs.AddFilter(aCommon.Key(), aCommon.Value(), objectSDK.MatchStringEqual)
 
 	// next filter by attribute from 1st object only
-	fs.AddFilter(a1.GetKey(), a1.GetValue(), objectSDK.MatchStringEqual)
+	fs.AddFilter(a1.Key(), a1.Value(), objectSDK.MatchStringEqual)
 
 	testSelect(t, db, fs, obj1.Address())
 }

--- a/pkg/morph/client/netmap/client.go
+++ b/pkg/morph/client/netmap/client.go
@@ -3,7 +3,7 @@ package netmap
 import (
 	"errors"
 
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 

--- a/pkg/morph/client/netmap/wrapper/add_peer.go
+++ b/pkg/morph/client/netmap/wrapper/add_peer.go
@@ -12,7 +12,7 @@ func (w *Wrapper) AddPeer(nodeInfo *netmap.NodeInfo) error {
 		return errors.New("nil node info")
 	}
 
-	rawNodeInfo, err := nodeInfo.StableMarshal(nil)
+	rawNodeInfo, err := nodeInfo.Marshal()
 	if err != nil {
 		return err
 	}

--- a/pkg/morph/event/netmap/update_peer.go
+++ b/pkg/morph/event/netmap/update_peer.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/pkg/errors"
@@ -12,13 +14,13 @@ import (
 
 type UpdatePeer struct {
 	publicKey *keys.PublicKey
-	status    uint32
+	status    netmap.NodeState
 }
 
 // MorphEvent implements Neo:Morph Event interface.
 func (UpdatePeer) MorphEvent() {}
 
-func (s UpdatePeer) Status() uint32 {
+func (s UpdatePeer) Status() netmap.NodeState {
 	return s.status
 }
 
@@ -53,7 +55,7 @@ func ParseUpdatePeer(prms []stackitem.Item) (event.Event, error) {
 		return nil, errors.Wrap(err, "could not get node status")
 	}
 
-	ev.status = uint32(st)
+	ev.status = netmap.NodeStateFromV2(v2netmap.NodeState(st))
 
 	return ev, nil
 }

--- a/pkg/morph/event/netmap/update_peer_test.go
+++ b/pkg/morph/event/netmap/update_peer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-crypto/test"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -15,8 +16,8 @@ import (
 
 func TestParseUpdatePeer(t *testing.T) {
 	var (
-		publicKey       = &test.DecodeKey(-1).PublicKey
-		state     int64 = 1
+		publicKey = &test.DecodeKey(-1).PublicKey
+		state     = netmap.NodeStateOffline
 	)
 
 	t.Run("wrong number of parameters", func(t *testing.T) {
@@ -48,7 +49,7 @@ func TestParseUpdatePeer(t *testing.T) {
 	t.Run("correct behavior", func(t *testing.T) {
 		ev, err := ParseUpdatePeer([]stackitem.Item{
 			stackitem.NewByteArray(crypto.MarshalPublicKey(publicKey)),
-			stackitem.NewBigInteger(new(big.Int).SetInt64(state)),
+			stackitem.NewBigInteger(new(big.Int).SetInt64(int64(state.ToV2()))),
 		})
 		require.NoError(t, err)
 
@@ -57,7 +58,7 @@ func TestParseUpdatePeer(t *testing.T) {
 
 		require.Equal(t, UpdatePeer{
 			publicKey: expectedKey,
-			status:    uint32(state),
+			status:    state,
 		}, ev)
 	})
 }

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -399,7 +399,7 @@ func (b Service) findRequestInfo(
 
 	// fetch actual container
 	cnr, err := b.containers.Get(cid)
-	if err != nil || cnr.GetOwnerID() == nil {
+	if err != nil || cnr.OwnerID() == nil {
 		return info, ErrUnknownContainer
 	}
 
@@ -417,10 +417,10 @@ func (b Service) findRequestInfo(
 	verb := sourceVerbOfRequest(req, op)
 	// todo: check verb sanity, if it was generated correctly. Do we need it ?
 
-	info.basicACL = basicACLHelper(cnr.GetBasicACL())
+	info.basicACL = basicACLHelper(cnr.BasicACL())
 	info.requestRole = role
 	info.operation = verb
-	info.owner = owner.NewIDFromV2(cnr.GetOwnerID())
+	info.owner = cnr.OwnerID()
 	info.cid = cid
 
 	// it is assumed that at the moment the key will be valid,

--- a/pkg/services/object/acl/classifier.go
+++ b/pkg/services/object/acl/classifier.go
@@ -62,7 +62,7 @@ func (c SenderClassifier) Classify(
 	// todo: get owner from neofs.id if present
 
 	// if request owner is the same as container owner, return RoleUser
-	if bytes.Equal(cnr.GetOwnerID().GetValue(), ownerID.ToV2().GetValue()) {
+	if bytes.Equal(cnr.OwnerID().ToV2().GetValue(), ownerID.ToV2().GetValue()) {
 		return acl.RoleUser, ownerKeyInBytes, nil
 	}
 
@@ -101,7 +101,7 @@ func requestOwner(req metaWithToken) (*owner.ID, *ecdsa.PublicKey, error) {
 		return nil, nil, errors.Wrap(ErrMalformedRequest, "nil at body signature")
 	}
 
-	key := crypto.UnmarshalPublicKey(bodySignature.GetKey())
+	key := crypto.UnmarshalPublicKey(bodySignature.Key())
 	neo3wallet, err := owner.NEO3WalletFromPublicKey(key)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "can't create neo3 wallet")
@@ -174,7 +174,7 @@ func lookupKeyInContainer(
 	owner, cid []byte,
 	cnr *container.Container) (bool, error) {
 
-	cnrNodes, err := nm.GetContainerNodes(netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy()), cid)
+	cnrNodes, err := nm.GetContainerNodes(cnr.PlacementPolicy(), cid)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/services/object/acl/eacl/types.go
+++ b/pkg/services/object/acl/eacl/types.go
@@ -18,8 +18,8 @@ type Storage interface {
 
 // Header is an interface of string key-value header.
 type Header interface {
-	GetKey() string
-	GetValue() string
+	Key() string
+	Value() string
 }
 
 // TypedHeaderSource is the interface that wraps

--- a/pkg/services/object/acl/eacl/v2/eacl_test.go
+++ b/pkg/services/object/acl/eacl/v2/eacl_test.go
@@ -40,7 +40,7 @@ func (s *testEACLStorage) GetEACL(id *container.ID) (*eacl.Table, error) {
 }
 
 func (s *testLocalStorage) Head(addr *objectSDK.Address) (*object.Object, error) {
-	require.True(s.t, addr.GetContainerID().Equal(addr.GetContainerID()) && addr.GetObjectID().Equal(addr.GetObjectID()))
+	require.True(s.t, addr.ContainerID().Equal(addr.ContainerID()) && addr.ObjectID().Equal(addr.ObjectID()))
 
 	return s.obj, nil
 }
@@ -139,7 +139,7 @@ func TestHeadRequest(t *testing.T) {
 		obj:     obj.Object(),
 	}
 
-	cid := addr.GetContainerID()
+	cid := addr.ContainerID()
 	unit := new(eacl2.ValidationUnit).
 		WithContainerID(cid).
 		WithOperation(eacl.OperationHead).

--- a/pkg/services/object/acl/eacl/v2/headers.go
+++ b/pkg/services/object/acl/eacl/v2/headers.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg"
 	eaclSDK "github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
@@ -71,7 +72,7 @@ func requestHeaders(msg xHeaderSource) []eacl.Header {
 	res := make([]eacl.Header, 0, len(xHdrs))
 
 	for i := range xHdrs {
-		res = append(res, xHdrs[i])
+		res = append(res, pkg.NewXHeaderFromV2(xHdrs[i]))
 	}
 
 	return res

--- a/pkg/services/object/acl/eacl/v2/object.go
+++ b/pkg/services/object/acl/eacl/v2/object.go
@@ -15,11 +15,11 @@ type sysObjHdr struct {
 	k, v string
 }
 
-func (s *sysObjHdr) GetKey() string {
+func (s *sysObjHdr) Key() string {
 	return s.k
 }
 
-func (s *sysObjHdr) GetValue() string {
+func (s *sysObjHdr) Value() string {
 	return s.v
 }
 
@@ -48,27 +48,27 @@ func headersFromObject(obj *object.Object) []eacl.Header {
 			// container ID
 			&sysObjHdr{
 				k: acl.FilterObjectContainerID,
-				v: cidValue(obj.GetContainerID()),
+				v: cidValue(obj.ContainerID()),
 			},
 			// owner ID
 			&sysObjHdr{
 				k: acl.FilterObjectOwnerID,
-				v: ownerIDValue(obj.GetOwnerID()),
+				v: ownerIDValue(obj.OwnerID()),
 			},
 			// creation epoch
 			&sysObjHdr{
 				k: acl.FilterObjectCreationEpoch,
-				v: u64Value(obj.GetCreationEpoch()),
+				v: u64Value(obj.CreationEpoch()),
 			},
 			// payload size
 			&sysObjHdr{
 				k: acl.FilterObjectPayloadLength,
-				v: u64Value(obj.GetPayloadSize()),
+				v: u64Value(obj.PayloadSize()),
 			},
 			// TODO: add others fields after neofs-api#84
 		)
 
-		attrs := obj.GetAttributes()
+		attrs := obj.Attributes()
 		hs := make([]eacl.Header, 0, len(attrs))
 
 		for i := range attrs {

--- a/pkg/services/object/acl/eacl/validator.go
+++ b/pkg/services/object/acl/eacl/validator.go
@@ -107,7 +107,7 @@ func tableAction(unit *ValidationUnit, table *eacl.Table) eacl.Action {
 //  - positive value if no matching header is found for at least one filter;
 //  - zero if at least one suitable header is found for all filters;
 //  - negative value if the headers of at least one filter cannot be obtained.
-func matchFilters(hdrSrc TypedHeaderSource, filters []eacl.Filter) int {
+func matchFilters(hdrSrc TypedHeaderSource, filters []*eacl.Filter) int {
 	matched := 0
 
 	for _, filter := range filters {
@@ -151,7 +151,7 @@ func matchFilters(hdrSrc TypedHeaderSource, filters []eacl.Filter) int {
 
 // returns true if one of ExtendedACLTarget has
 // suitable target OR suitable public key.
-func targetMatches(unit *ValidationUnit, record eacl.Record) bool {
+func targetMatches(unit *ValidationUnit, record *eacl.Record) bool {
 	for _, target := range record.Targets() {
 		// check public key match
 		for _, key := range target.Keys() {
@@ -170,12 +170,12 @@ func targetMatches(unit *ValidationUnit, record eacl.Record) bool {
 }
 
 // Maps match type to corresponding function.
-var mMatchFns = map[eacl.Match]func(Header, eacl.Filter) bool{
-	eacl.MatchStringEqual: func(header Header, filter eacl.Filter) bool {
+var mMatchFns = map[eacl.Match]func(Header, *eacl.Filter) bool{
+	eacl.MatchStringEqual: func(header Header, filter *eacl.Filter) bool {
 		return header.Value() == filter.Value()
 	},
 
-	eacl.MatchStringNotEqual: func(header Header, filter eacl.Filter) bool {
+	eacl.MatchStringNotEqual: func(header Header, filter *eacl.Filter) bool {
 		return header.Value() != filter.Value()
 	},
 }

--- a/pkg/services/object/acl/eacl/validator.go
+++ b/pkg/services/object/acl/eacl/validator.go
@@ -124,7 +124,7 @@ func matchFilters(hdrSrc TypedHeaderSource, filters []eacl.Filter) int {
 			}
 
 			// check header name
-			if header.GetKey() != filter.Key() {
+			if header.Key() != filter.Key() {
 				continue
 			}
 
@@ -172,10 +172,10 @@ func targetMatches(unit *ValidationUnit, record eacl.Record) bool {
 // Maps match type to corresponding function.
 var mMatchFns = map[eacl.Match]func(Header, eacl.Filter) bool{
 	eacl.MatchStringEqual: func(header Header, filter eacl.Filter) bool {
-		return header.GetValue() == filter.Value()
+		return header.Value() == filter.Value()
 	},
 
 	eacl.MatchStringNotEqual: func(header Header, filter eacl.Filter) bool {
-		return header.GetValue() != filter.Value()
+		return header.Value() != filter.Value()
 	},
 }

--- a/pkg/services/object/delete/service.go
+++ b/pkg/services/object/delete/service.go
@@ -84,7 +84,7 @@ func (s *Service) Delete(ctx context.Context, prm *Prm) (*Response, error) {
 	// content address storage (CAS) and one tombstone for several split
 	// objects.
 	if err := r.Init(new(putsvc.PutInitPrm).
-		WithObject(newTombstone(ownerID, prm.addr.GetContainerID())).
+		WithObject(newTombstone(ownerID, prm.addr.ContainerID())).
 		WithCommonPrm(prm.common).
 		WithTraverseOption(placement.WithoutSuccessTracking()), // broadcast tombstone, maybe one
 	); err != nil {
@@ -108,9 +108,9 @@ func (s *Service) getRelations(ctx context.Context, prm *Prm) ([]*objectSDK.Addr
 	var res []*objectSDK.Address
 
 	if linking, err := s.hdrLinking.HeadRelation(ctx, prm.addr, prm.common); err != nil {
-		cid := prm.addr.GetContainerID()
+		cid := prm.addr.ContainerID()
 
-		for prev := prm.addr.GetObjectID(); prev != nil; {
+		for prev := prm.addr.ObjectID(); prev != nil; {
 			addr := objectSDK.NewAddress()
 			addr.SetObjectID(prev)
 			addr.SetContainerID(cid)
@@ -124,12 +124,12 @@ func (s *Service) getRelations(ctx context.Context, prm *Prm) ([]*objectSDK.Addr
 			}
 
 			hdr := headResult.Header()
-			id := hdr.GetID()
-			prev = hdr.GetPreviousID()
+			id := hdr.ID()
+			prev = hdr.PreviousID()
 
 			if rightChild := headResult.RightChild(); rightChild != nil {
-				id = rightChild.GetID()
-				prev = rightChild.GetPreviousID()
+				id = rightChild.ID()
+				prev = rightChild.PreviousID()
 			}
 
 			addr.SetObjectID(id)
@@ -137,20 +137,20 @@ func (s *Service) getRelations(ctx context.Context, prm *Prm) ([]*objectSDK.Addr
 			res = append(res, addr)
 		}
 	} else {
-		childList := linking.GetChildren()
+		childList := linking.Children()
 		res = make([]*objectSDK.Address, 0, len(childList)+2) // 1 for parent, 1 for linking
 
 		for i := range childList {
 			addr := objectSDK.NewAddress()
 			addr.SetObjectID(childList[i])
-			addr.SetContainerID(prm.addr.GetContainerID())
+			addr.SetContainerID(prm.addr.ContainerID())
 
 			res = append(res, addr)
 		}
 
 		addr := objectSDK.NewAddress()
-		addr.SetObjectID(linking.GetID())
-		addr.SetContainerID(prm.addr.GetContainerID())
+		addr.SetObjectID(linking.ID())
+		addr.SetContainerID(prm.addr.ContainerID())
 
 		res = append(res, addr)
 	}

--- a/pkg/services/object/head/distributed.go
+++ b/pkg/services/object/head/distributed.go
@@ -37,7 +37,7 @@ func (h *distributedHeader) prepare(ctx context.Context, prm *Prm) error {
 	}
 
 	// get container to store the object
-	cnr, err := h.cnrSrc.Get(prm.addr.GetContainerID())
+	cnr, err := h.cnrSrc.Get(prm.addr.ContainerID())
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not get container by ID", h)
 	}
@@ -54,7 +54,7 @@ func (h *distributedHeader) prepare(ctx context.Context, prm *Prm) error {
 		placement.SuccessAfter(1),
 
 		// set identifier of the processing object
-		placement.ForObject(prm.addr.GetObjectID()),
+		placement.ForObject(prm.addr.ObjectID()),
 	)
 
 	// create placement builder from network map

--- a/pkg/services/object/head/relation.go
+++ b/pkg/services/object/head/relation.go
@@ -29,7 +29,7 @@ func (h *RelationHeader) HeadRelation(ctx context.Context, addr *objectSDK.Addre
 	}
 
 	a := objectSDK.NewAddress()
-	a.SetContainerID(addr.GetContainerID())
+	a.SetContainerID(addr.ContainerID())
 	a.SetObjectID(id)
 
 	r, err := h.svc.Head(ctx, new(Prm).

--- a/pkg/services/object/head/service.go
+++ b/pkg/services/object/head/service.go
@@ -75,7 +75,7 @@ func (s *Service) Head(ctx context.Context, prm *Prm) (*Response, error) {
 	}
 
 	addr := objectSDK.NewAddress()
-	addr.SetContainerID(prm.addr.GetContainerID())
+	addr.SetContainerID(prm.addr.ContainerID())
 	addr.SetObjectID(rightChildID)
 
 	r, err = s.Head(ctx, new(Prm).WithAddress(addr).WithCommonPrm(prm.common))

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -41,7 +41,7 @@ func (t *distributedTarget) Write(p []byte) (n int, err error) {
 
 func (t *distributedTarget) Close() (*transformer.AccessIdentifiers, error) {
 	traverser, err := placement.NewTraverser(
-		append(t.traverseOpts, placement.ForObject(t.obj.GetID()))...,
+		append(t.traverseOpts, placement.ForObject(t.obj.ID()))...,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not create object placement traverser", t)
@@ -59,7 +59,7 @@ func (t *distributedTarget) Close() (*transformer.AccessIdentifiers, error) {
 		payload = append(payload, t.chunks[i]...)
 	}
 
-	if err := t.fmt.ValidateContent(t.obj.GetType(), payload); err != nil {
+	if err := t.fmt.ValidateContent(t.obj.Type(), payload); err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not validate payload content", t)
 	}
 
@@ -108,5 +108,5 @@ loop:
 	}
 
 	return new(transformer.AccessIdentifiers).
-		WithSelfID(t.obj.GetID()), nil
+		WithSelfID(t.obj.ID()), nil
 }

--- a/pkg/services/object/put/local.go
+++ b/pkg/services/object/put/local.go
@@ -18,7 +18,7 @@ type localTarget struct {
 func (t *localTarget) WriteHeader(obj *object.RawObject) error {
 	t.obj = obj
 
-	t.payload = make([]byte, 0, obj.GetPayloadSize())
+	t.payload = make([]byte, 0, obj.PayloadSize())
 
 	return nil
 }
@@ -35,5 +35,5 @@ func (t *localTarget) Close() (*transformer.AccessIdentifiers, error) {
 	}
 
 	return new(transformer.AccessIdentifiers).
-		WithSelfID(t.obj.GetID()), nil
+		WithSelfID(t.obj.ID()), nil
 }

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -96,7 +96,7 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 	}
 
 	// get container to store the object
-	cnr, err := p.cnrSrc.Get(prm.hdr.GetContainerID())
+	cnr, err := p.cnrSrc.Get(prm.hdr.ContainerID())
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not get container by ID", p)
 	}
@@ -107,7 +107,7 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 		placement.ForContainer(cnr),
 
 		// set identifier of the processing object
-		placement.ForObject(prm.hdr.GetID()),
+		placement.ForObject(prm.hdr.ID()),
 	)
 
 	// create placement builder from network map

--- a/pkg/services/object/put/validation.go
+++ b/pkg/services/object/put/validation.go
@@ -23,8 +23,8 @@ type validatingTarget struct {
 }
 
 func (t *validatingTarget) WriteHeader(obj *object.RawObject) error {
-	cs := obj.GetPayloadChecksum()
-	switch typ := cs.GetType(); typ {
+	cs := obj.PayloadChecksum()
+	switch typ := cs.Type(); typ {
 	default:
 		return errors.Errorf("(%T) unsupported payload checksum type %v", t, typ)
 	case pkg.ChecksumSHA256:
@@ -33,7 +33,7 @@ func (t *validatingTarget) WriteHeader(obj *object.RawObject) error {
 		t.hash = tz.New()
 	}
 
-	t.checksum = cs.GetSum()
+	t.checksum = cs.Sum()
 
 	if err := t.fmt.Validate(obj.Object()); err != nil {
 		return errors.Wrapf(err, "(%T) coult not validate object format", t)

--- a/pkg/services/object/range/chain.go
+++ b/pkg/services/object/range/chain.go
@@ -35,14 +35,14 @@ type rangeChain struct {
 func newRangeTraverser(originSize uint64, rightElement *object.Object, rngSeek *objectSDK.Range) *rangeTraverser {
 	right := &rangeChain{
 		bounds: &rangeBounds{
-			left:  originSize - rightElement.GetPayloadSize(),
+			left:  originSize - rightElement.PayloadSize(),
 			right: originSize,
 		},
-		id: rightElement.GetID(),
+		id: rightElement.ID(),
 	}
 
 	left := &rangeChain{
-		id: rightElement.GetPreviousID(),
+		id: rightElement.PreviousID(),
 	}
 
 	left.next, right.prev = right, left
@@ -83,12 +83,12 @@ func min(a, b uint64) uint64 {
 }
 
 func (c *rangeTraverser) pushHeader(obj *object.Object) {
-	id := obj.GetID()
+	id := obj.ID()
 	if !id.Equal(c.chain.prev.id) {
 		panic(fmt.Sprintf("(%T) unexpected identifier in header", c))
 	}
 
-	sz := obj.GetPayloadSize()
+	sz := obj.PayloadSize()
 
 	c.chain.prev.bounds = &rangeBounds{
 		left:  c.chain.bounds.left - sz,
@@ -97,7 +97,7 @@ func (c *rangeTraverser) pushHeader(obj *object.Object) {
 
 	c.chain = c.chain.prev
 
-	if prev := obj.GetPreviousID(); prev != nil {
+	if prev := obj.PreviousID(); prev != nil {
 		c.chain.prev = &rangeChain{
 			next: c.chain,
 			id:   prev,

--- a/pkg/services/object/range/local.go
+++ b/pkg/services/object/range/local.go
@@ -22,7 +22,7 @@ func (l *localRangeWriter) WriteTo(w io.Writer) (int64, error) {
 		return 0, errors.Wrapf(err, "(%T) could not get object from local storage", l)
 	}
 
-	payload := obj.GetPayload()
+	payload := obj.Payload()
 	left := l.rng.GetOffset()
 	right := left + l.rng.GetLength()
 

--- a/pkg/services/object/range/service.go
+++ b/pkg/services/object/range/service.go
@@ -66,7 +66,7 @@ func (s *Service) GetRange(ctx context.Context, prm *Prm) (*Result, error) {
 
 	origin := headResult.Header()
 
-	originSize := origin.GetPayloadSize()
+	originSize := origin.PayloadSize()
 
 	if prm.full {
 		prm.rng = new(object.Range)
@@ -101,7 +101,7 @@ func (s *Service) GetRange(ctx context.Context, prm *Prm) (*Result, error) {
 
 func (s *Service) fillTraverser(ctx context.Context, prm *Prm, traverser *objutil.RangeTraverser) error {
 	addr := object.NewAddress()
-	addr.SetContainerID(prm.addr.GetContainerID())
+	addr.SetContainerID(prm.addr.ContainerID())
 
 	for {
 		nextID, nextRng := traverser.Next()

--- a/pkg/services/object/range/streamer.go
+++ b/pkg/services/object/range/streamer.go
@@ -81,7 +81,7 @@ func (p *streamer) switchToObject(id *object.ID) error {
 	}
 
 	// get container to read payload range
-	cnr, err := p.cnrSrc.Get(p.prm.addr.GetContainerID())
+	cnr, err := p.cnrSrc.Get(p.prm.addr.ContainerID())
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not get container by ID", p)
 	}
@@ -124,7 +124,7 @@ func (p *streamer) start() {
 	defer close(p.ch)
 
 	objAddr := object.NewAddress()
-	objAddr.SetContainerID(p.prm.addr.GetContainerID())
+	objAddr.SetContainerID(p.prm.addr.ContainerID())
 
 loop:
 	for {

--- a/pkg/services/object/rangehash/distributed.go
+++ b/pkg/services/object/rangehash/distributed.go
@@ -35,7 +35,7 @@ func (h *distributedHasher) prepare(ctx context.Context, prm *Prm) error {
 	}
 
 	// get container to read the object
-	cnr, err := h.cnrSrc.Get(prm.addr.GetContainerID())
+	cnr, err := h.cnrSrc.Get(prm.addr.ContainerID())
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not get container by ID", h)
 	}
@@ -52,7 +52,7 @@ func (h *distributedHasher) prepare(ctx context.Context, prm *Prm) error {
 		placement.SuccessAfter(1),
 
 		// set identifier of the processing object
-		placement.ForObject(prm.addr.GetObjectID()),
+		placement.ForObject(prm.addr.ObjectID()),
 	)
 
 	// create placement builder from network map

--- a/pkg/services/object/rangehash/local.go
+++ b/pkg/services/object/rangehash/local.go
@@ -23,7 +23,7 @@ func (h *localHasher) hashRange(ctx context.Context, prm *Prm, handler func([][]
 		return errors.Wrapf(err, "(%T) could not get object from local storage", h)
 	}
 
-	payload := obj.GetPayload()
+	payload := obj.Payload()
 	hashes := make([][]byte, 0, len(prm.rngs))
 
 	var hasher hash.Hash

--- a/pkg/services/object/rangehash/service.go
+++ b/pkg/services/object/rangehash/service.go
@@ -72,7 +72,7 @@ func (s *Service) GetRangeHash(ctx context.Context, prm *Prm) (*Response, error)
 
 	origin := headResult.Header()
 
-	originSize := origin.GetPayloadSize()
+	originSize := origin.PayloadSize()
 
 	var minLeft, maxRight uint64
 	for i := range prm.rngs {
@@ -106,7 +106,7 @@ func (s *Service) GetRangeHash(ctx context.Context, prm *Prm) (*Response, error)
 
 func (s *Service) getHashes(ctx context.Context, prm *Prm, traverser *objutil.RangeTraverser) (*Response, error) {
 	addr := object.NewAddress()
-	addr.SetContainerID(prm.addr.GetContainerID())
+	addr.SetContainerID(prm.addr.ContainerID())
 
 	resp := &Response{
 		hashes: make([][]byte, 0, len(prm.rngs)),

--- a/pkg/services/object/search/local.go
+++ b/pkg/services/object/search/local.go
@@ -30,7 +30,7 @@ func (s *localStream) stream(ctx context.Context, ch chan<- []*objectSDK.ID) err
 	idList := make([]*objectSDK.ID, 0, len(addrList))
 
 	for i := range addrList {
-		idList = append(idList, addrList[i].GetObjectID())
+		idList = append(idList, addrList[i].ObjectID())
 	}
 
 	select {

--- a/pkg/services/object/search/relation.go
+++ b/pkg/services/object/search/relation.go
@@ -21,7 +21,7 @@ var ErrRelationNotFound = errors.New("relation not found")
 
 func (s *RelationSearcher) SearchRelation(ctx context.Context, addr *object.Address, prm *util.CommonPrm) (*object.ID, error) {
 	streamer, err := s.svc.Search(ctx, new(Prm).
-		WithContainerID(addr.GetContainerID()).WithCommonPrm(prm).
+		WithContainerID(addr.ContainerID()).WithCommonPrm(prm).
 		WithSearchQuery(s.queryGenerator(addr)),
 	)
 	if err != nil {
@@ -65,7 +65,7 @@ func NewRightChildSearcher(svc *Service) *RelationSearcher {
 	return &RelationSearcher{
 		svc: svc,
 		queryGenerator: func(addr *object.Address) query.Query {
-			return queryV1.NewRightChildQuery(addr.GetObjectID())
+			return queryV1.NewRightChildQuery(addr.ObjectID())
 		},
 	}
 }
@@ -74,7 +74,7 @@ func NewLinkingSearcher(svc *Service) *RelationSearcher {
 	return &RelationSearcher{
 		svc: svc,
 		queryGenerator: func(addr *object.Address) query.Query {
-			return queryV1.NewLinkingQuery(addr.GetObjectID())
+			return queryV1.NewLinkingQuery(addr.ObjectID())
 		},
 	}
 }

--- a/pkg/services/object/util/chain.go
+++ b/pkg/services/object/util/chain.go
@@ -29,14 +29,14 @@ type rangeChain struct {
 func NewRangeTraverser(originSize uint64, rightElement *object.Object, rngSeek *objectSDK.Range) *RangeTraverser {
 	right := &rangeChain{
 		bounds: &rangeBounds{
-			left:  originSize - rightElement.GetPayloadSize(),
+			left:  originSize - rightElement.PayloadSize(),
 			right: originSize,
 		},
-		id: rightElement.GetID(),
+		id: rightElement.ID(),
 	}
 
 	left := &rangeChain{
-		id: rightElement.GetPreviousID(),
+		id: rightElement.PreviousID(),
 	}
 
 	left.next, right.prev = right, left
@@ -75,12 +75,12 @@ func min(a, b uint64) uint64 {
 }
 
 func (c *RangeTraverser) PushHeader(obj *object.Object) {
-	id := obj.GetID()
+	id := obj.ID()
 	if !id.Equal(c.chain.prev.id) {
 		panic(fmt.Sprintf("(%T) unexpected identifier in header", c))
 	}
 
-	sz := obj.GetPayloadSize()
+	sz := obj.PayloadSize()
 
 	c.chain.prev.bounds = &rangeBounds{
 		left:  c.chain.bounds.left - sz,
@@ -89,7 +89,7 @@ func (c *RangeTraverser) PushHeader(obj *object.Object) {
 
 	c.chain = c.chain.prev
 
-	if prev := obj.GetPreviousID(); prev != nil {
+	if prev := obj.PreviousID(); prev != nil {
 		c.chain.prev = &rangeChain{
 			next: c.chain,
 			id:   prev,

--- a/pkg/services/object_manager/gc/gc.go
+++ b/pkg/services/object_manager/gc/gc.go
@@ -116,8 +116,8 @@ func (gc *GC) Run(ctx context.Context) {
 						)
 					} else {
 						gc.log.Info("object removed",
-							zap.String("CID", stringifyCID(addr.GetContainerID())),
-							zap.String("ID", stringifyID(addr.GetObjectID())),
+							zap.String("CID", stringifyCID(addr.ContainerID())),
+							zap.String("ID", stringifyID(addr.ObjectID())),
 						)
 					}
 				}

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -181,7 +181,7 @@ func UseBuilder(b Builder) Option {
 // ForContainer is a traversal container setting option.
 func ForContainer(cnr *container.Container) Option {
 	return func(c *cfg) {
-		c.policy = netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy())
+		c.policy = cnr.PlacementPolicy()
 		c.addr.SetContainerID(container.CalculateID(cnr))
 	}
 }

--- a/pkg/services/object_manager/transformer/fmt.go
+++ b/pkg/services/object_manager/transformer/fmt.go
@@ -71,7 +71,7 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 
 	var parID *objectSDK.ID
 
-	if par := f.obj.GetParent(); par != nil {
+	if par := f.obj.Parent(); par != nil {
 		rawPar := objectSDK.NewRawFromV2(par.ToV2())
 
 		rawPar.SetSessionToken(f.prm.SessionToken)
@@ -81,7 +81,7 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 			return nil, errors.Wrap(err, "could not finalize parent object")
 		}
 
-		parID = rawPar.GetID()
+		parID = rawPar.ID()
 
 		f.obj.SetParent(rawPar.Object())
 	}
@@ -99,6 +99,6 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 	}
 
 	return new(AccessIdentifiers).
-		WithSelfID(f.obj.GetID()).
+		WithSelfID(f.obj.ID()).
 		WithParentID(parID), nil
 }

--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -90,10 +90,10 @@ func (s *payloadSizeLimiter) initialize() {
 
 func fromObject(obj *object.RawObject) *object.RawObject {
 	res := object.NewRaw()
-	res.SetContainerID(obj.GetContainerID())
-	res.SetOwnerID(obj.GetOwnerID())
-	res.SetAttributes(obj.GetAttributes()...)
-	res.SetType(obj.GetType())
+	res.SetContainerID(obj.ContainerID())
+	res.SetOwnerID(obj.OwnerID())
+	res.SetAttributes(obj.Attributes()...)
+	res.SetType(obj.Type())
 
 	return res
 }
@@ -207,7 +207,7 @@ func writeHashes(hashers []*payloadChecksumHasher) {
 }
 
 func (s *payloadSizeLimiter) initializeLinking() {
-	id := s.current.GetParentID()
+	id := s.current.ParentID()
 
 	s.current = fromObject(s.current)
 	s.current.SetParentID(id)

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
-	cnr, err := p.cnrSrc.Get(addr.GetContainerID())
+	cnr, err := p.cnrSrc.Get(addr.ContainerID())
 	if err != nil {
 		p.log.Error("could not get container",
 			zap.String("error", err.Error()),
@@ -22,7 +22,7 @@ func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
 		return
 	}
 
-	policy := netmap.NewPlacementPolicyFromV2(cnr.GetPlacementPolicy())
+	policy := cnr.PlacementPolicy()
 
 	nn, err := p.placementBuilder.BuildPlacement(addr, policy)
 	if err != nil {

--- a/pkg/services/session/storage/executor.go
+++ b/pkg/services/session/storage/executor.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/pkg/errors"
 )
 
 func (s *TokenStore) Create(ctx context.Context, body *session.CreateRequestBody) (*session.CreateResponseBody, error) {
-	ownerBytes, err := body.GetOwnerID().StableMarshal(nil)
+	ownerBytes, err := owner.NewIDFromV2(body.GetOwnerID()).Marshal()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/services/session/storage/storage.go
+++ b/pkg/services/session/storage/storage.go
@@ -35,7 +35,7 @@ func New() *TokenStore {
 //
 // Returns nil is there is no element in storage.
 func (s *TokenStore) Get(ownerID *owner.ID, tokenID []byte) *PrivateToken {
-	ownerBytes, err := ownerID.ToV2().StableMarshal(nil)
+	ownerBytes, err := ownerID.Marshal()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/attributes/parser.go
+++ b/pkg/util/attributes/parser.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 )
 
 const (
@@ -21,13 +21,13 @@ var (
 
 // ParseV2Attributes parses strings like "K1:V1/K2:V2/K3:V3" into netmap
 // attributes.
-func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.Attribute, error) {
+func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.NodeAttribute, error) {
 	restricted := make(map[string]struct{}, len(excl))
 	for i := range excl {
 		restricted[excl[i]] = struct{}{}
 	}
 
-	cache := make(map[string]*netmap.Attribute, len(attrs))
+	cache := make(map[string]*netmap.NodeAttribute, len(attrs))
 
 	for i := range attrs {
 		line := strings.Trim(attrs[i], pairSeparator)
@@ -47,7 +47,7 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.Attribute, erro
 			key := pair[0]
 			value := pair[1]
 
-			if at, ok := cache[key]; ok && at.GetValue() != value {
+			if at, ok := cache[key]; ok && at.Value() != value {
 				return nil, errNonUniqueBucket
 			}
 
@@ -55,12 +55,12 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.Attribute, erro
 				return nil, errUnexpectedKey
 			}
 
-			attribute := new(netmap.Attribute)
+			attribute := netmap.NewNodeAttribute()
 			attribute.SetKey(key)
 			attribute.SetValue(value)
 
 			if parentKey != "" {
-				attribute.SetParents([]string{parentKey})
+				attribute.SetParentKeys(parentKey)
 			}
 
 			parentKey = key
@@ -68,7 +68,7 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.Attribute, erro
 		}
 	}
 
-	result := make([]*netmap.Attribute, 0, len(cache))
+	result := make([]*netmap.NodeAttribute, 0, len(cache))
 	for _, v := range cache {
 		result = append(result, v)
 	}


### PR DESCRIPTION
- resolve conflicts

- use `Marshal(JSON)` / `Unmarshal(JSON)` methods

- decrease direct usage of `v2` structures