### PR TITLE
Add cache for SDK clients

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -200,7 +200,7 @@ func initObjectService(c *cfg) {
 		),
 		replicator.WithLocalStorage(ls),
 		replicator.WithRemoteSender(
-			putsvc.NewRemoteSender(keyStorage),
+			putsvc.NewRemoteSender(keyStorage, clientCache),
 		),
 	)
 
@@ -246,6 +246,7 @@ func initObjectService(c *cfg) {
 
 	sPut := putsvc.NewService(
 		putsvc.WithKeyStorage(keyStorage),
+		putsvc.WithClientCache(clientCache),
 		putsvc.WithMaxSizeSource(c),
 		putsvc.WithLocalStorage(ls),
 		putsvc.WithContainerSource(c.cfgObject.cnrStorage),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -265,6 +265,7 @@ func initObjectService(c *cfg) {
 
 	sSearch := searchsvc.NewService(
 		searchsvc.WithKeyStorage(keyStorage),
+		searchsvc.WithClientCache(clientCache),
 		searchsvc.WithLocalStorage(ls),
 		searchsvc.WithContainerSource(c.cfgObject.cnrStorage),
 		searchsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -294,6 +294,7 @@ func initObjectService(c *cfg) {
 
 	sRange := rangesvc.NewService(
 		rangesvc.WithKeyStorage(keyStorage),
+		rangesvc.WithClientCache(clientCache),
 		rangesvc.WithLocalStorage(ls),
 		rangesvc.WithContainerSource(c.cfgObject.cnrStorage),
 		rangesvc.WithNetworkMapSource(c.cfgObject.netMapStorage),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/bucket"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	objectTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/object/grpc"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl"
@@ -180,6 +181,8 @@ func initObjectService(c *cfg) {
 
 	nodeOwner.SetNeo3Wallet(neo3Wallet)
 
+	clientCache := cache.NewSDKClientCache()
+
 	objGC := gc.New(
 		gc.WithLogger(c.log),
 		gc.WithRemover(ls),
@@ -220,7 +223,7 @@ func initObjectService(c *cfg) {
 		),
 		policer.WithTrigger(ch),
 		policer.WithRemoteHeader(
-			headsvc.NewRemoteHeader(keyStorage),
+			headsvc.NewRemoteHeader(keyStorage, clientCache),
 		),
 		policer.WithLocalAddressSource(c),
 		policer.WithHeadTimeout(
@@ -274,6 +277,7 @@ func initObjectService(c *cfg) {
 
 	sHead := headsvc.NewService(
 		headsvc.WithKeyStorage(keyStorage),
+		headsvc.WithClientCache(clientCache),
 		headsvc.WithLocalStorage(ls),
 		headsvc.WithContainerSource(c.cfgObject.cnrStorage),
 		headsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -317,6 +317,7 @@ func initObjectService(c *cfg) {
 
 	sRangeHash := rangehashsvc.NewService(
 		rangehashsvc.WithKeyStorage(keyStorage),
+		rangehashsvc.WithClientCache(clientCache),
 		rangehashsvc.WithLocalStorage(ls),
 		rangehashsvc.WithContainerSource(c.cfgObject.cnrStorage),
 		rangehashsvc.WithNetworkMapSource(c.cfgObject.netMapStorage),

--- a/pkg/network/cache/client.go
+++ b/pkg/network/cache/client.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
+	crypto "github.com/nspcc-dev/neofs-crypto"
+)
+
+type (
+	// ClientCache is a structure around neofs-api-go/pkg/client to reuse
+	// already created clients.
+	ClientCache struct {
+		mu      *sync.RWMutex
+		clients map[string]*client.Client
+	}
+)
+
+// NewSDKClientCache creates instance of client cache.
+func NewSDKClientCache() *ClientCache {
+	return &ClientCache{
+		mu:      new(sync.RWMutex),
+		clients: make(map[string]*client.Client),
+	}
+}
+
+// Get function returns existing client or creates a new one. Consider passing
+// connection options to specify details for client, but don't forget that two
+// different set of options should provide two different clients.
+func (c *ClientCache) Get(key *ecdsa.PrivateKey, address string) (*client.Client, error) {
+	id := uniqueID(key, address)
+
+	c.mu.RLock()
+	if cli, ok := c.clients[id]; ok {
+		// todo: check underlying connection neofs-api-go#196
+		c.mu.RUnlock()
+
+		return cli, nil
+	}
+
+	c.mu.RUnlock()
+	// if client is not found in cache, then create a new one
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// check once again if client is missing in cache, concurrent routine could
+	// create client while this routine was locked on `c.mu.Lock()`.
+	if cli, ok := c.clients[id]; ok {
+		return cli, nil
+	}
+
+	cli, err := client.New(key, client.WithAddress(address))
+	if err != nil {
+		return nil, err
+	}
+
+	c.clients[id] = cli
+
+	return cli, nil
+}
+
+func uniqueID(key *ecdsa.PrivateKey, address string) string {
+	keyFingerprint := sha256.Sum256(crypto.MarshalPrivateKey(key))
+
+	return hex.EncodeToString(keyFingerprint[:]) + address
+}

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -7,6 +7,7 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
@@ -15,6 +16,8 @@ import (
 // the object header from a remote host.
 type RemoteHeader struct {
 	keyStorage *util.KeyStorage
+
+	clientCache *cache.ClientCache
 }
 
 // RemoteHeadPrm groups remote header operation parameters.
@@ -25,9 +28,10 @@ type RemoteHeadPrm struct {
 }
 
 // NewRemoteHeader creates, initializes and returns new RemoteHeader instance.
-func NewRemoteHeader(keyStorage *util.KeyStorage) *RemoteHeader {
+func NewRemoteHeader(keyStorage *util.KeyStorage, cache *cache.ClientCache) *RemoteHeader {
 	return &RemoteHeader{
-		keyStorage: keyStorage,
+		keyStorage:  keyStorage,
+		clientCache: cache,
 	}
 }
 
@@ -61,9 +65,7 @@ func (h *RemoteHeader) Head(ctx context.Context, prm *RemoteHeadPrm) (*object.Ob
 		return nil, err
 	}
 
-	c, err := client.New(key,
-		client.WithAddress(addr),
-	)
+	c, err := h.clientCache.Get(key, addr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not create SDK client %s", h, addr)
 	}

--- a/pkg/services/object/head/service.go
+++ b/pkg/services/object/head/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/pkg/errors"
@@ -132,5 +133,11 @@ func WithLocalAddressSource(v network.LocalAddressSource) Option {
 func WithRightChildSearcher(v RelationSearcher) Option {
 	return func(c *cfg) {
 		c.rightChildSearcher = v
+	}
+}
+
+func WithClientCache(v *cache.ClientCache) Option {
+	return func(c *cfg) {
+		c.remoteHeader.clientCache = v
 	}
 }

--- a/pkg/services/object/put/service.go
+++ b/pkg/services/object/put/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 )
@@ -46,6 +47,8 @@ type cfg struct {
 	fmtValidatorOpts []object.FormatValidatorOption
 
 	networkState netmap.State
+
+	clientCache *cache.ClientCache
 }
 
 func defaultCfg() *cfg {
@@ -126,5 +129,11 @@ func WithFormatValidatorOpts(v ...object.FormatValidatorOption) Option {
 func WithNetworkState(v netmap.State) Option {
 	return func(c *cfg) {
 		c.networkState = v
+	}
+}
+
+func WithClientCache(v *cache.ClientCache) Option {
+	return func(c *cfg) {
+		c.clientCache = v
 	}
 }

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -138,11 +138,12 @@ func (p *Streamer) newCommonTarget(prm *PutInitPrm) transformer.ObjectTarget {
 				}
 			} else {
 				return &remoteTarget{
-					ctx:        p.ctx,
-					keyStorage: p.keyStorage,
-					token:      prm.common.SessionToken(),
-					bearer:     prm.common.BearerToken(),
-					addr:       addr,
+					ctx:         p.ctx,
+					keyStorage:  p.keyStorage,
+					token:       prm.common.SessionToken(),
+					bearer:      prm.common.BearerToken(),
+					addr:        addr,
+					clientCache: p.clientCache,
 				}
 			}
 		},

--- a/pkg/services/object/range/remote.go
+++ b/pkg/services/object/range/remote.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/token"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
@@ -26,6 +27,8 @@ type remoteRangeWriter struct {
 	addr *object.Address
 
 	rng *object.Range
+
+	clientCache *cache.ClientCache
 }
 
 func (r *remoteRangeWriter) WriteTo(w io.Writer) (int64, error) {
@@ -39,9 +42,7 @@ func (r *remoteRangeWriter) WriteTo(w io.Writer) (int64, error) {
 		return 0, err
 	}
 
-	c, err := client.New(key,
-		client.WithAddress(addr),
-	)
+	c, err := r.clientCache.Get(key, addr)
 	if err != nil {
 		return 0, errors.Wrapf(err, "(%T) could not create SDK client %s", r, addr)
 	}

--- a/pkg/services/object/range/service.go
+++ b/pkg/services/object/range/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head"
 	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
@@ -35,6 +36,8 @@ type cfg struct {
 	localAddrSrc network.LocalAddressSource
 
 	headSvc *headsvc.Service
+
+	clientCache *cache.ClientCache
 }
 
 func defaultCfg() *cfg {
@@ -162,5 +165,11 @@ func WithLocalAddressSource(v network.LocalAddressSource) Option {
 func WithHeadService(v *headsvc.Service) Option {
 	return func(c *cfg) {
 		c.headSvc = v
+	}
+}
+
+func WithClientCache(v *cache.ClientCache) Option {
+	return func(c *cfg) {
+		c.clientCache = v
 	}
 }

--- a/pkg/services/object/range/streamer.go
+++ b/pkg/services/object/range/streamer.go
@@ -178,13 +178,14 @@ loop:
 						}
 					} else {
 						rngWriter = &remoteRangeWriter{
-							ctx:        p.ctx,
-							keyStorage: p.keyStorage,
-							node:       addr,
-							token:      p.prm.common.SessionToken(),
-							bearer:     p.prm.common.BearerToken(),
-							addr:       objAddr,
-							rng:        nextRange,
+							ctx:         p.ctx,
+							keyStorage:  p.keyStorage,
+							node:        addr,
+							token:       p.prm.common.SessionToken(),
+							bearer:      p.prm.common.BearerToken(),
+							addr:        objAddr,
+							rng:         nextRange,
+							clientCache: p.clientCache,
 						}
 					}
 

--- a/pkg/services/object/rangehash/distributed.go
+++ b/pkg/services/object/rangehash/distributed.go
@@ -112,8 +112,9 @@ loop:
 					}
 				} else {
 					hasher = &remoteHasher{
-						keyStorage: h.keyStorage,
-						node:       addr,
+						keyStorage:  h.keyStorage,
+						node:        addr,
+						clientCache: h.clientCache,
 					}
 				}
 

--- a/pkg/services/object/rangehash/remote.go
+++ b/pkg/services/object/rangehash/remote.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg"
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
@@ -15,6 +16,8 @@ type remoteHasher struct {
 	keyStorage *util.KeyStorage
 
 	node *network.Address
+
+	clientCache *cache.ClientCache
 }
 
 func (h *remoteHasher) hashRange(ctx context.Context, prm *Prm, handler func([][]byte)) error {
@@ -28,9 +31,7 @@ func (h *remoteHasher) hashRange(ctx context.Context, prm *Prm, handler func([][
 		return err
 	}
 
-	c, err := client.New(key,
-		client.WithAddress(addr),
-	)
+	c, err := h.clientCache.Get(key, addr)
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not create SDK client %s", h, addr)
 	}

--- a/pkg/services/object/rangehash/service.go
+++ b/pkg/services/object/rangehash/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head"
 	rangesvc "github.com/nspcc-dev/neofs-node/pkg/services/object/range"
 	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
@@ -41,6 +42,8 @@ type cfg struct {
 	headSvc *headsvc.Service
 
 	rangeSvc *rangesvc.Service
+
+	clientCache *cache.ClientCache
 }
 
 func defaultCfg() *cfg {
@@ -262,5 +265,11 @@ func WithHeadService(v *headsvc.Service) Option {
 func WithRangeService(v *rangesvc.Service) Option {
 	return func(c *cfg) {
 		c.rangeSvc = v
+	}
+}
+
+func WithClientCache(v *cache.ClientCache) Option {
+	return func(c *cfg) {
+		c.clientCache = v
 	}
 }

--- a/pkg/services/object/search/remote.go
+++ b/pkg/services/object/search/remote.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/pkg/errors"
 )
@@ -16,6 +17,8 @@ type remoteStream struct {
 	keyStorage *util.KeyStorage
 
 	addr *network.Address
+
+	clientCache *cache.ClientCache
 }
 
 func (s *remoteStream) stream(ctx context.Context, ch chan<- []*object.ID) error {
@@ -29,9 +32,7 @@ func (s *remoteStream) stream(ctx context.Context, ch chan<- []*object.ID) error
 		return err
 	}
 
-	c, err := client.New(key,
-		client.WithAddress(addr),
-	)
+	c, err := s.clientCache.Get(key, addr)
 	if err != nil {
 		return errors.Wrapf(err, "(%T) could not create SDK client %s", s, addr)
 	}

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/localstore"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	objutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 )
@@ -31,6 +32,8 @@ type cfg struct {
 	workerPool util.WorkerPool
 
 	localAddrSrc network.LocalAddressSource
+
+	clientCache *cache.ClientCache
 }
 
 func defaultCfg() *cfg {
@@ -94,5 +97,11 @@ func WithWorkerPool(v util.WorkerPool) Option {
 func WithLocalAddressSource(v network.LocalAddressSource) Option {
 	return func(c *cfg) {
 		c.localAddrSrc = v
+	}
+}
+
+func WithClientCache(v *cache.ClientCache) Option {
+	return func(c *cfg) {
+		c.clientCache = v
 	}
 }

--- a/pkg/services/object/search/streamer.go
+++ b/pkg/services/object/search/streamer.go
@@ -161,9 +161,10 @@ loop:
 					}
 				} else {
 					streamer = &remoteStream{
-						prm:        prm,
-						keyStorage: p.keyStorage,
-						addr:       addr,
+						prm:         prm,
+						keyStorage:  p.keyStorage,
+						addr:        addr,
+						clientCache: p.clientCache,
 					}
 				}
 


### PR DESCRIPTION
Right now there are go routine leak in storage nodes when they store data. Replication mechanism runs object related requests and creates new SDK client for each request. Object service uses address as a endpoint identifier, so SDK clients creates new connection every time. This generates huge amount of routines because they can't be dropped or closed (https://github.com/nspcc-dev/neofs-api-go/issues/196). 

Instead we can store clients in cache. Later neofs-api-go will provide mechanism to check underlying client connection (it can be gRPC or any other transport connection) and this cache will be able to remove old clients. 