### PR TITLE
Define shard modes

### DIFF
--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var errShardNotFound = errors.New("shard not found")
+
 // AddShard adds a new shard to the storage engine.
 //
 // Returns any error encountered that did not allow adding a shard.
@@ -71,4 +73,20 @@ func (e *StorageEngine) iterateOverSortedShards(addr *object.Address, handler fu
 			break
 		}
 	}
+}
+
+// SetShardMode sets mode of the shard with provided identifier.
+//
+// Returns an error if shard mode was not set, or shard was not found in storage engine.
+func (e *StorageEngine) SetShardMode(id *shard.ID, m shard.Mode) error {
+	e.mtx.RLock()
+	defer e.mtx.RUnlock()
+
+	for shID, sh := range e.shards {
+		if id.String() == shID {
+			return sh.SetMode(m)
+		}
+	}
+
+	return errShardNotFound
 }

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -1,0 +1,42 @@
+package shard
+
+// Mode represents enumeration of Shard work modes.
+type Mode uint32
+
+// TODO: more detailed description of shard modes.
+
+const (
+	_ Mode = iota
+
+	// ModeActive is a Mode value for active shard.
+	ModeActive
+
+	// ModeInactive is a Mode value for inactive shard.
+	ModeInactive
+
+	// ModeReadOnly is a Mode value for read-only shard.
+	ModeReadOnly
+
+	// ModeFault is a Mode value for faulty shard.
+	ModeFault
+
+	// ModeEvacuate is a Mode value for evacuating shard.
+	ModeEvacuate
+)
+
+func (m Mode) String() string {
+	switch m {
+	default:
+		return "UNDEFINED"
+	case ModeActive:
+		return "ACTIVE"
+	case ModeInactive:
+		return "INACTIVE"
+	case ModeReadOnly:
+		return "READ_ONLY"
+	case ModeFault:
+		return "FAULT"
+	case ModeEvacuate:
+		return "EVACUATE"
+	}
+}

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -40,3 +40,15 @@ func (m Mode) String() string {
 		return "EVACUATE"
 	}
 }
+
+// SetMode sets mode of the shard.
+//
+// Returns any error encountered that did not allow
+// to set shard mode.
+func (s *Shard) SetMode(m Mode) error {
+	s.mode.Store(uint32(m))
+}
+
+func (s *Shard) getMode() Mode {
+	return Mode(s.mode.Load())
+}

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -4,11 +4,14 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"go.uber.org/atomic"
 )
 
 // Shard represents single shard of NeoFS Local Storage Engine.
 type Shard struct {
 	*cfg
+
+	mode *atomic.Uint32
 
 	weight WeightValues
 
@@ -44,6 +47,7 @@ func New(opts ...Option) *Shard {
 
 	return &Shard{
 		cfg:      c,
+		mode:     atomic.NewUint32(0), // TODO: init with particular mode
 		blobStor: blobstor.New(c.blobOpts...),
 		metaBase: meta.NewDB(c.metaOpts...),
 	}


### PR DESCRIPTION
- define the enumeration of `Shard` modes;

- implement methods to set shard mode on `Shard` and `StorageEngine`.

Working with particular mode values will be implemented later.