### PR TITLE
Fix sticky bit check on object service

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -508,7 +508,7 @@ func basicACLCheck(info requestInfo) bool {
 }
 
 func stickyBitCheck(info requestInfo, owner *owner.ID) bool {
-	if owner == nil || info.cnrOwner == nil {
+	if owner == nil || len(info.senderKey) == 0 {
 		return false
 	}
 
@@ -516,7 +516,9 @@ func stickyBitCheck(info requestInfo, owner *owner.ID) bool {
 		return true
 	}
 
-	return bytes.Equal(owner.ToV2().GetValue(), info.cnrOwner.ToV2().GetValue())
+	requestSenderKey := crypto.UnmarshalPublicKey(info.senderKey)
+
+	return isOwnerFromKey(owner, requestSenderKey)
 }
 
 func eACLCheck(msg interface{}, reqInfo requestInfo, cfg *eACLCfg) bool {

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -56,7 +56,7 @@ type (
 		requestRole acl.Role
 		isInnerRing bool
 		operation   acl.Operation // put, get, head, etc.
-		owner       *owner.ID     // container owner
+		cnrOwner    *owner.ID     // container owner
 
 		cid *container.ID
 
@@ -423,7 +423,7 @@ func (b Service) findRequestInfo(
 	info.requestRole = role
 	info.isInnerRing = isIR
 	info.operation = verb
-	info.owner = cnr.OwnerID()
+	info.cnrOwner = cnr.OwnerID()
 	info.cid = cid
 
 	// it is assumed that at the moment the key will be valid,
@@ -508,7 +508,7 @@ func basicACLCheck(info requestInfo) bool {
 }
 
 func stickyBitCheck(info requestInfo, owner *owner.ID) bool {
-	if owner == nil || info.owner == nil {
+	if owner == nil || info.cnrOwner == nil {
 		return false
 	}
 
@@ -516,7 +516,7 @@ func stickyBitCheck(info requestInfo, owner *owner.ID) bool {
 		return true
 	}
 
-	return bytes.Equal(owner.ToV2().GetValue(), info.owner.ToV2().GetValue())
+	return bytes.Equal(owner.ToV2().GetValue(), info.cnrOwner.ToV2().GetValue())
 }
 
 func eACLCheck(msg interface{}, reqInfo requestInfo, cfg *eACLCfg) bool {
@@ -640,7 +640,7 @@ func isValidBearer(reqInfo requestInfo, st netmap.State) bool {
 
 	// 3. Then check if container owner signed this token.
 	tokenIssuerKey := crypto.UnmarshalPublicKey(token.GetSignature().GetKey())
-	if !isOwnerFromKey(reqInfo.owner, tokenIssuerKey) {
+	if !isOwnerFromKey(reqInfo.cnrOwner, tokenIssuerKey) {
 		// todo: in this case we can issue all owner keys from neofs.id and check once again
 		return false
 	}

--- a/pkg/services/object/acl/classifier.go
+++ b/pkg/services/object/acl/classifier.go
@@ -201,15 +201,12 @@ func ownerFromToken(token *session.SessionToken) (*owner.ID, *ecdsa.PublicKey, e
 
 	// 2. Then check if session token owner issued the session token
 	tokenIssuerKey := crypto.UnmarshalPublicKey(token.GetSignature().GetKey())
-	tokenIssuerWallet, err := owner.NEO3WalletFromPublicKey(tokenIssuerKey)
-	if err != nil {
-		return nil, nil, errors.Wrap(ErrMalformedRequest, "invalid token issuer key")
-	}
+	tokenOwner := owner.NewIDFromV2(token.GetBody().GetOwnerID())
 
-	if !bytes.Equal(token.GetBody().GetOwnerID().GetValue(), tokenIssuerWallet.Bytes()) {
+	if !isOwnerFromKey(tokenOwner, tokenIssuerKey) {
 		// todo: in this case we can issue all owner keys from neofs.id and check once again
 		return nil, nil, errors.Wrap(ErrMalformedRequest, "invalid session token owner")
 	}
 
-	return owner.NewIDFromV2(token.GetBody().GetOwnerID()), tokenIssuerKey, nil
+	return tokenOwner, tokenIssuerKey, nil
 }


### PR DESCRIPTION
Fixes #181 

Sticky bit checked if object owner is a container owner, but it is wrong. Sticky bit should check if object owner is a request sender.