### PR TITLE
Refactored metabase

### DIFF
--- a/pkg/local_object_storage/metabase/v2/cleanup.go
+++ b/pkg/local_object_storage/metabase/v2/cleanup.go
@@ -1,0 +1,85 @@
+package meta
+
+import (
+	"strings"
+
+	"go.etcd.io/bbolt"
+)
+
+func (db *DB) CleanUp() error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+			switch {
+			case isFKBTBucket(name):
+				cleanUpFKBT(tx, name, b)
+			case isListBucket(name):
+				cleanUpListBucket(tx, name, b)
+			default:
+				cleanUpUniqueBucket(tx, name, b)
+			}
+
+			return nil
+		})
+	})
+}
+
+func isFKBTBucket(name []byte) bool {
+	bucketName := string(name)
+
+	switch {
+	case
+		strings.Contains(bucketName, userAttributePostfix),
+		strings.Contains(bucketName, ownerPostfix):
+		return true
+	default:
+		return false
+	}
+}
+
+func isListBucket(name []byte) bool {
+	bucketName := string(name)
+
+	switch {
+	case
+		strings.Contains(bucketName, payloadHashPostfix),
+		strings.Contains(bucketName, parentPostfix):
+		return true
+	default:
+		return false
+	}
+}
+
+func cleanUpUniqueBucket(tx *bbolt.Tx, name []byte, b *bbolt.Bucket) {
+	if b.Stats().KeyN == 0 {
+		_ = tx.DeleteBucket(name) // ignore error, best effort there
+	}
+}
+
+func cleanUpFKBT(tx *bbolt.Tx, name []byte, b *bbolt.Bucket) {
+	removedBuckets := 0
+	remainingBuckets := b.Stats().BucketN - 1
+
+	_ = b.ForEach(func(k, _ []byte) error {
+		fkbtRoot := b.Bucket(k)
+		if fkbtRoot == nil {
+			return nil
+		}
+
+		if fkbtRoot.Stats().KeyN == 0 {
+			err := b.DeleteBucket(k)
+			if err == nil {
+				removedBuckets++
+			}
+		}
+
+		return nil
+	})
+
+	if remainingBuckets == removedBuckets {
+		_ = tx.DeleteBucket(name) // ignore error, best effort there
+	}
+}
+
+func cleanUpListBucket(tx *bbolt.Tx, name []byte, b *bbolt.Bucket) {
+	cleanUpUniqueBucket(tx, name, b)
+}

--- a/pkg/local_object_storage/metabase/v2/control.go
+++ b/pkg/local_object_storage/metabase/v2/control.go
@@ -1,0 +1,42 @@
+package meta
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+// Open boltDB instance for metabase.
+func (db *DB) Open() error {
+	err := os.MkdirAll(path.Dir(db.info.Path), db.info.Permission)
+	if err != nil {
+		return fmt.Errorf("can't create dir %s for metabase: %w", db.info.Path, err)
+	}
+
+	db.log.Debug("created directory for Metabase", zap.String("path", db.info.Path))
+
+	db.boltDB, err = bbolt.Open(db.info.Path, db.info.Permission, db.boltOptions)
+	if err != nil {
+		return fmt.Errorf("can't open boltDB database: %w", err)
+	}
+
+	db.log.Debug("opened boltDB instance for Metabase")
+
+	return nil
+}
+
+// Init initializes metabase, however metabase doesn't need extra preparations,
+// so it implemented to satisfy interface of storage engine components.
+func (db *DB) Init() error {
+	db.log.Debug("Metabase has been initialized")
+
+	return nil
+}
+
+// Close closes boltDB instance.
+func (db *DB) Close() error {
+	return db.boltDB.Close()
+}

--- a/pkg/local_object_storage/metabase/v2/db.go
+++ b/pkg/local_object_storage/metabase/v2/db.go
@@ -1,0 +1,106 @@
+package meta
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+// DB represents local metabase of storage node.
+type DB struct {
+	info Info
+
+	*cfg
+
+	matchers map[object.SearchMatchType]func(string, []byte, string) bool
+}
+
+// Option is an option of DB constructor.
+type Option func(*cfg)
+
+type cfg struct {
+	boltDB *bbolt.DB
+
+	log *logger.Logger
+}
+
+func defaultCfg() *cfg {
+	return &cfg{
+		log: zap.L(),
+	}
+}
+
+// NewDB creates, initializes and returns DB instance.
+func NewDB(opts ...Option) *DB {
+	c := defaultCfg()
+
+	for i := range opts {
+		opts[i](c)
+	}
+
+	return &DB{
+		info: Info{
+			Path: c.boltDB.Path(),
+		},
+		cfg: c,
+		matchers: map[object.SearchMatchType]func(string, []byte, string) bool{
+			object.MatchUnknown:     unknownMatcher,
+			object.MatchStringEqual: stringEqualMatcher,
+		},
+	}
+}
+
+func (db *DB) Close() error {
+	return db.boltDB.Close()
+}
+
+func stringEqualMatcher(key string, objVal []byte, filterVal string) bool {
+	switch key {
+	default:
+		return string(objVal) == filterVal
+	case v2object.FilterHeaderPayloadHash, v2object.FilterHeaderHomomorphicHash:
+		return hex.EncodeToString(objVal) == filterVal
+	case v2object.FilterHeaderCreationEpoch, v2object.FilterHeaderPayloadLength:
+		return strconv.FormatUint(binary.LittleEndian.Uint64(objVal), 10) == filterVal
+	}
+}
+
+func unknownMatcher(_ string, _ []byte, _ string) bool {
+	return false
+}
+
+// bucketKeyHelper returns byte representation of val that is used as a key
+// in boltDB. Useful for getting filter values from unique and list indexes.
+func bucketKeyHelper(hdr string, val string) []byte {
+	switch hdr {
+	case v2object.FilterHeaderPayloadHash:
+		v, err := hex.DecodeString(val)
+		if err != nil {
+			return nil
+		}
+
+		return v
+	default:
+		return []byte(val)
+	}
+}
+
+// FromBoltDB returns option to construct DB from BoltDB instance.
+func FromBoltDB(db *bbolt.DB) Option {
+	return func(c *cfg) {
+		c.boltDB = db
+	}
+}
+
+// WithLogger returns option to set logger of DB.
+func WithLogger(l *logger.Logger) Option {
+	return func(c *cfg) {
+		c.log = l
+	}
+}

--- a/pkg/local_object_storage/metabase/v2/db.go
+++ b/pkg/local_object_storage/metabase/v2/db.go
@@ -86,6 +86,15 @@ func bucketKeyHelper(hdr string, val string) []byte {
 		}
 
 		return v
+	case v2object.FilterHeaderSplitID:
+		s := object.NewSplitID()
+
+		err := s.Parse(val)
+		if err != nil {
+			return nil
+		}
+
+		return s.ToV2()
 	default:
 		return []byte(val)
 	}

--- a/pkg/local_object_storage/metabase/v2/db_test.go
+++ b/pkg/local_object_storage/metabase/v2/db_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/test"
 	"github.com/nspcc-dev/tzhash/tz"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 func testSelect(t *testing.T, db *meta.DB, fs objectSDK.SearchFilters, exp ...*objectSDK.Address) {
@@ -51,10 +50,11 @@ func testOID() *objectSDK.ID {
 func newDB(t testing.TB) *meta.DB {
 	path := t.Name()
 
-	bdb, err := bbolt.Open(path, 0600, nil)
-	require.NoError(t, err)
+	bdb := meta.New(meta.WithPath(path), meta.WithPermissions(0600))
 
-	return meta.NewDB(meta.FromBoltDB(bdb))
+	require.NoError(t, bdb.Open())
+
+	return bdb
 }
 
 func releaseDB(db *meta.DB) {

--- a/pkg/local_object_storage/metabase/v2/db_test.go
+++ b/pkg/local_object_storage/metabase/v2/db_test.go
@@ -1,0 +1,113 @@
+package meta_test
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"os"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/v2"
+	"github.com/nspcc-dev/neofs-node/pkg/util/test"
+	"github.com/nspcc-dev/tzhash/tz"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func testSelect(t *testing.T, db *meta.DB, fs objectSDK.SearchFilters, exp ...*objectSDK.Address) {
+	res, err := db.Select(fs)
+	require.NoError(t, err)
+	require.Len(t, res, len(exp))
+
+	for i := range exp {
+		require.Contains(t, res, exp[i])
+	}
+}
+
+func testCID() *container.ID {
+	cs := [sha256.Size]byte{}
+	_, _ = rand.Read(cs[:])
+
+	id := container.NewID()
+	id.SetSHA256(cs)
+
+	return id
+}
+
+func testOID() *objectSDK.ID {
+	cs := [sha256.Size]byte{}
+	_, _ = rand.Read(cs[:])
+
+	id := objectSDK.NewID()
+	id.SetSHA256(cs)
+
+	return id
+}
+
+func newDB(t testing.TB) *meta.DB {
+	path := t.Name()
+
+	bdb, err := bbolt.Open(path, 0600, nil)
+	require.NoError(t, err)
+
+	return meta.NewDB(meta.FromBoltDB(bdb))
+}
+
+func releaseDB(db *meta.DB) {
+	db.Close()
+	os.Remove(db.DumpInfo().Path)
+}
+
+func generateRawObject(t *testing.T) *object.RawObject {
+	return generateRawObjectWithCID(t, testCID())
+}
+
+func generateRawObjectWithCID(t *testing.T, cid *container.ID) *object.RawObject {
+	version := pkg.NewVersion()
+	version.SetMajor(2)
+	version.SetMinor(1)
+
+	w, err := owner.NEO3WalletFromPublicKey(&test.DecodeKey(-1).PublicKey)
+	require.NoError(t, err)
+
+	ownerID := owner.NewID()
+	ownerID.SetNeo3Wallet(w)
+
+	csum := new(pkg.Checksum)
+	csum.SetSHA256(sha256.Sum256(w.Bytes()))
+
+	csumTZ := new(pkg.Checksum)
+	csumTZ.SetTillichZemor(tz.Sum(csum.Sum()))
+
+	obj := object.NewRaw()
+	obj.SetID(testOID())
+	obj.SetOwnerID(ownerID)
+	obj.SetContainerID(cid)
+	obj.SetVersion(version)
+	obj.SetPayloadChecksum(csum)
+	obj.SetPayloadHomomorphicHash(csumTZ)
+
+	return obj
+}
+
+func generateAddress() *objectSDK.Address {
+	addr := objectSDK.NewAddress()
+	addr.SetContainerID(testCID())
+	addr.SetObjectID(testOID())
+
+	return addr
+}
+
+func addAttribute(obj *object.RawObject, key, val string) {
+	attr := objectSDK.NewAttribute()
+	attr.SetKey(key)
+	attr.SetValue(val)
+
+	attrs := obj.Attributes()
+	attrs = append(attrs, attr)
+	obj.SetAttributes(attrs...)
+}

--- a/pkg/local_object_storage/metabase/v2/delete.go
+++ b/pkg/local_object_storage/metabase/v2/delete.go
@@ -1,0 +1,217 @@
+package meta
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"go.etcd.io/bbolt"
+)
+
+var ErrVirtualObject = errors.New("do not remove virtual object directly")
+
+// DeleteObjects marks list of objects as deleted.
+func (db *DB) Delete(lst ...*objectSDK.Address) error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		for i := range lst {
+			err := db.delete(tx, lst[i], false)
+			if err != nil {
+				return err // maybe log and continue?
+			}
+		}
+
+		return nil
+	})
+}
+
+func (db *DB) delete(tx *bbolt.Tx, addr *objectSDK.Address, isParent bool) error {
+	pl := parentLength(tx, addr) // parentLength of address, for virtual objects it is > 0
+
+	// do not remove virtual objects directly
+	if !isParent && pl > 0 {
+		return ErrVirtualObject
+	}
+
+	// unmarshal object
+	obj, err := db.get(tx, addr, false)
+	if err != nil {
+		return err
+	}
+
+	// if object is an only link to a parent, then remove parent
+	if parent := obj.GetParent(); parent != nil {
+		if parentLength(tx, parent.Address()) == 1 {
+			err = db.deleteObject(tx, obj.GetParent(), true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// remove object
+	return db.deleteObject(tx, obj, isParent)
+}
+
+func (db *DB) deleteObject(
+	tx *bbolt.Tx,
+	obj *object.Object,
+	isParent bool,
+) error {
+	uniqueIndexes, err := delUniqueIndexes(obj, isParent)
+	if err != nil {
+		return fmt.Errorf("can' build unique indexes: %w", err)
+	}
+
+	// delete unique indexes
+	for i := range uniqueIndexes {
+		delUniqueIndexItem(tx, uniqueIndexes[i])
+	}
+
+	// build list indexes
+	listIndexes, err := listIndexes(obj)
+	if err != nil {
+		return fmt.Errorf("can' build list indexes: %w", err)
+	}
+
+	// delete list indexes
+	for i := range listIndexes {
+		delListIndexItem(tx, listIndexes[i])
+	}
+
+	// build fake bucket tree indexes
+	fkbtIndexes, err := fkbtIndexes(obj)
+	if err != nil {
+		return fmt.Errorf("can' build fake bucket tree indexes: %w", err)
+	}
+
+	// delete fkbt indexes
+	for i := range fkbtIndexes {
+		delFKBTIndexItem(tx, fkbtIndexes[i])
+	}
+
+	return nil
+}
+
+// parentLength returns amount of available children from parentid index.
+func parentLength(tx *bbolt.Tx, addr *objectSDK.Address) int {
+	bkt := tx.Bucket(parentBucketName(addr.ContainerID()))
+	if bkt == nil {
+		return 0
+	}
+
+	lst, err := decodeList(bkt.Get(objectKey(addr.ObjectID())))
+	if err != nil {
+		return 0
+	}
+
+	return len(lst)
+}
+
+func delUniqueIndexItem(tx *bbolt.Tx, item namedBucketItem) {
+	bkt := tx.Bucket(item.name)
+	if bkt != nil {
+		_ = bkt.Delete(item.key) // ignore error, best effort there
+	}
+}
+
+func delFKBTIndexItem(tx *bbolt.Tx, item namedBucketItem) {
+	bkt := tx.Bucket(item.name)
+	if bkt == nil {
+		return
+	}
+
+	fkbtRoot := bkt.Bucket(item.key)
+	if fkbtRoot == nil {
+		return
+	}
+
+	_ = fkbtRoot.Delete(item.val) // ignore error, best effort there
+}
+
+func delListIndexItem(tx *bbolt.Tx, item namedBucketItem) {
+	bkt := tx.Bucket(item.name)
+	if bkt == nil {
+		return
+	}
+
+	lst, err := decodeList(bkt.Get(item.key))
+	if err != nil || len(lst) == 0 {
+		return
+	}
+
+	// remove element from the list
+	newLst := make([][]byte, 0, len(lst))
+
+	for i := range lst {
+		if !bytes.Equal(item.val, lst[i]) {
+			newLst = append(newLst, lst[i])
+		}
+	}
+
+	// if list empty, remove the key from <list> bucket
+	if len(newLst) == 0 {
+		_ = bkt.Delete(item.key) // ignore error, best effort there
+
+		return
+	}
+
+	// if list is not empty, then update it
+	encodedLst, err := encodeList(lst)
+	if err != nil {
+		return // ignore error, best effort there
+	}
+
+	_ = bkt.Put(item.key, encodedLst) // ignore error, best effort there
+}
+
+func delUniqueIndexes(obj *object.Object, isParent bool) ([]namedBucketItem, error) {
+	addr := obj.Address()
+	objKey := objectKey(addr.ObjectID())
+	addrKey := addressKey(addr)
+
+	result := make([]namedBucketItem, 0, 5)
+
+	// add value to primary unique bucket
+	if !isParent {
+		var bucketName []byte
+
+		switch obj.Type() {
+		case objectSDK.TypeRegular:
+			bucketName = primaryBucketName(addr.ContainerID())
+		case objectSDK.TypeTombstone:
+			bucketName = tombstoneBucketName(addr.ContainerID())
+		case objectSDK.TypeStorageGroup:
+			bucketName = storageGroupBucketName(addr.ContainerID())
+		default:
+			return nil, ErrUnknownObjectType
+		}
+
+		result = append(result, namedBucketItem{
+			name: bucketName,
+			key:  objKey,
+		})
+	}
+
+	result = append(result,
+		namedBucketItem{ // remove from small blobovnicza id index
+			name: smallBucketName(addr.ContainerID()),
+			key:  objKey,
+		},
+		namedBucketItem{ // remove from root index
+			name: rootBucketName(addr.ContainerID()),
+			key:  objKey,
+		},
+		namedBucketItem{ // remove from graveyard index
+			name: graveyardBucketName,
+			key:  addrKey,
+		},
+		namedBucketItem{ // remove from ToMoveIt index
+			name: toMoveItBucketName,
+			key:  addrKey,
+		},
+	)
+
+	return result, nil
+}

--- a/pkg/local_object_storage/metabase/v2/delete_test.go
+++ b/pkg/local_object_storage/metabase/v2/delete_test.go
@@ -1,0 +1,60 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Delete(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+	parent := generateRawObjectWithCID(t, cid)
+	addAttribute(parent, "foo", "bar")
+
+	child := generateRawObjectWithCID(t, cid)
+	child.SetParent(parent.Object().SDK())
+	child.SetParentID(parent.ID())
+
+	// put object with parent
+	err := db.Put(child.Object(), nil)
+	require.NoError(t, err)
+
+	// fill ToMoveIt index
+	err = db.ToMoveIt(child.Object().Address())
+	require.NoError(t, err)
+
+	// check if Movable list is not empty
+	l, err := db.Movable()
+	require.NoError(t, err)
+	require.Len(t, l, 1)
+
+	// inhume parent and child so they will be on graveyard
+	ts := generateRawObjectWithCID(t, cid)
+
+	err = db.Inhume(child.Object().Address(), ts.Object().Address())
+	require.NoError(t, err)
+
+	err = db.Inhume(child.Object().Address(), ts.Object().Address())
+	require.NoError(t, err)
+
+	// delete object
+	err = db.Delete(child.Object().Address())
+	require.NoError(t, err)
+
+	// check if there is no data in Movable index
+	l, err = db.Movable()
+	require.NoError(t, err)
+	require.Len(t, l, 0)
+
+	// check if they removed from graveyard
+	ok, err := db.Exists(child.Object().Address())
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	ok, err = db.Exists(parent.Object().Address())
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/pkg/local_object_storage/metabase/v2/errors.go
+++ b/pkg/local_object_storage/metabase/v2/errors.go
@@ -1,0 +1,14 @@
+package meta
+
+import (
+	"errors"
+)
+
+var (
+	// ErrNotFound returned when object header should exist in primary index but
+	// it is not present there.
+	ErrNotFound = errors.New("address not found")
+
+	// ErrAlreadyRemoved returned when object has tombstone in graveyard.
+	ErrAlreadyRemoved = errors.New("object already removed")
+)

--- a/pkg/local_object_storage/metabase/v2/exists.go
+++ b/pkg/local_object_storage/metabase/v2/exists.go
@@ -1,0 +1,43 @@
+package meta
+
+import (
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"go.etcd.io/bbolt"
+)
+
+// Exists returns ErrAlreadyRemoved if addr was marked as removed. Otherwise it
+// returns true if addr is in primary index or false if it is not.
+func (db *DB) Exists(addr *objectSDK.Address) (exists bool, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		// check graveyard first
+		if inGraveyard(tx, addr) {
+			return ErrAlreadyRemoved
+		}
+
+		// if graveyard is empty, then check if object exists in primary bucket
+		primaryBucket := tx.Bucket(primaryBucketName(addr.ContainerID()))
+		if primaryBucket == nil {
+			return nil
+		}
+
+		// using `get` as `exists`: https://github.com/boltdb/bolt/issues/321
+		val := primaryBucket.Get(objectKey(addr.ObjectID()))
+		exists = len(val) != 0
+
+		return nil
+	})
+
+	return exists, err
+}
+
+// inGraveyard returns true if object was marked as removed.
+func inGraveyard(tx *bbolt.Tx, addr *objectSDK.Address) bool {
+	graveyard := tx.Bucket(graveyardBucketName)
+	if graveyard == nil {
+		return false
+	}
+
+	tombstone := graveyard.Get(addressKey(addr))
+
+	return len(tombstone) != 0
+}

--- a/pkg/local_object_storage/metabase/v2/exists_test.go
+++ b/pkg/local_object_storage/metabase/v2/exists_test.go
@@ -1,0 +1,29 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Exists(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw := generateRawObject(t)
+	addAttribute(raw, "foo", "bar")
+
+	obj := object.NewFromV2(raw.ToV2())
+
+	exists, err := db.Exists(obj.Address())
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	err = db.Put(obj, nil)
+	require.NoError(t, err)
+
+	exists, err = db.Exists(obj.Address())
+	require.NoError(t, err)
+	require.True(t, exists)
+}

--- a/pkg/local_object_storage/metabase/v2/exists_test.go
+++ b/pkg/local_object_storage/metabase/v2/exists_test.go
@@ -58,7 +58,7 @@ func TestDB_Exists(t *testing.T) {
 
 		child := generateRawObjectWithCID(t, cid)
 		child.SetParent(parent.Object().SDK())
-		child.SetParentID(parent.Object().Address().ObjectID())
+		child.SetParentID(parent.ID())
 
 		err := db.Put(child.Object(), nil)
 		require.NoError(t, err)

--- a/pkg/local_object_storage/metabase/v2/get.go
+++ b/pkg/local_object_storage/metabase/v2/get.go
@@ -12,7 +12,7 @@ import (
 // Get returns object header for specified address.
 func (db *DB) Get(addr *objectSDK.Address) (obj *object.Object, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
-		obj, err = db.get(tx, addr)
+		obj, err = db.get(tx, addr, true)
 
 		return err
 	})
@@ -20,12 +20,12 @@ func (db *DB) Get(addr *objectSDK.Address) (obj *object.Object, err error) {
 	return obj, err
 }
 
-func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address) (*object.Object, error) {
+func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address, checkGraveyard bool) (*object.Object, error) {
 	obj := object.New()
 	key := objectKey(addr.ObjectID())
 	cid := addr.ContainerID()
 
-	if inGraveyard(tx, addr) {
+	if checkGraveyard && inGraveyard(tx, addr) {
 		return nil, ErrAlreadyRemoved
 	}
 

--- a/pkg/local_object_storage/metabase/v2/get.go
+++ b/pkg/local_object_storage/metabase/v2/get.go
@@ -1,6 +1,9 @@
 package meta
 
 import (
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"go.etcd.io/bbolt"
@@ -17,8 +20,8 @@ func (db *DB) Get(addr *objectSDK.Address) (obj *object.Object, err error) {
 	return obj, err
 }
 
-func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address) (obj *object.Object, err error) {
-	obj = object.New()
+func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address) (*object.Object, error) {
+	obj := object.New()
 	key := objectKey(addr.ObjectID())
 	cid := addr.ContainerID()
 
@@ -44,7 +47,8 @@ func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address) (obj *object.Object, er
 		return obj, obj.Unmarshal(data)
 	}
 
-	return nil, ErrNotFound
+	// if not found then check if object is a virtual
+	return getVirtualObject(tx, cid, key)
 }
 
 func getFromBucket(tx *bbolt.Tx, name, key []byte) []byte {
@@ -54,4 +58,39 @@ func getFromBucket(tx *bbolt.Tx, name, key []byte) []byte {
 	}
 
 	return bkt.Get(key)
+}
+
+func getVirtualObject(tx *bbolt.Tx, cid *container.ID, key []byte) (*object.Object, error) {
+	parentBucket := tx.Bucket(parentBucketName(cid))
+	if parentBucket == nil {
+		return nil, ErrNotFound
+	}
+
+	relativeLst, err := decodeList(parentBucket.Get(key))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(relativeLst) == 0 { // this should never happen though
+		return nil, ErrNotFound
+	}
+
+	// pick last item, for now there is not difference which address to pick
+	// but later list might be sorted so first or last value can be more
+	// prioritized to choose
+	virtualOID := relativeLst[len(relativeLst)-1]
+	data := getFromBucket(tx, primaryBucketName(cid), virtualOID)
+
+	child := object.New()
+
+	err = child.Unmarshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("can't unmarshal child with parent: %w", err)
+	}
+
+	if child.GetParent() == nil { // this should never happen though
+		return nil, ErrNotFound
+	}
+
+	return child.GetParent(), nil
 }

--- a/pkg/local_object_storage/metabase/v2/get.go
+++ b/pkg/local_object_storage/metabase/v2/get.go
@@ -1,0 +1,57 @@
+package meta
+
+import (
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"go.etcd.io/bbolt"
+)
+
+// Get returns object header for specified address.
+func (db *DB) Get(addr *objectSDK.Address) (obj *object.Object, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		obj, err = db.get(tx, addr)
+
+		return err
+	})
+
+	return obj, err
+}
+
+func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address) (obj *object.Object, err error) {
+	obj = object.New()
+	key := objectKey(addr.ObjectID())
+	cid := addr.ContainerID()
+
+	if inGraveyard(tx, addr) {
+		return nil, ErrAlreadyRemoved
+	}
+
+	// check in primary index
+	data := getFromBucket(tx, primaryBucketName(cid), key)
+	if len(data) != 0 {
+		return obj, obj.Unmarshal(data)
+	}
+
+	// if not found then check in tombstone index
+	data = getFromBucket(tx, tombstoneBucketName(cid), key)
+	if len(data) != 0 {
+		return obj, obj.Unmarshal(data)
+	}
+
+	// if not found then check in storage group index
+	data = getFromBucket(tx, storageGroupBucketName(cid), key)
+	if len(data) != 0 {
+		return obj, obj.Unmarshal(data)
+	}
+
+	return nil, ErrNotFound
+}
+
+func getFromBucket(tx *bbolt.Tx, name, key []byte) []byte {
+	bkt := tx.Bucket(name)
+	if bkt == nil {
+		return nil
+	}
+
+	return bkt.Get(key)
+}

--- a/pkg/local_object_storage/metabase/v2/get_test.go
+++ b/pkg/local_object_storage/metabase/v2/get_test.go
@@ -1,0 +1,63 @@
+package meta_test
+
+import (
+	"testing"
+
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Get(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw := generateRawObject(t)
+	addAttribute(raw, "foo", "bar")
+
+	t.Run("object not found", func(t *testing.T) {
+		obj := object.NewFromV2(raw.ToV2())
+
+		_, err := db.Get(obj.Address())
+		require.Error(t, err)
+	})
+
+	t.Run("put regular object", func(t *testing.T) {
+		obj := object.NewFromV2(raw.ToV2())
+
+		err := db.Put(obj, nil)
+		require.NoError(t, err)
+
+		newObj, err := db.Get(obj.Address())
+		require.NoError(t, err)
+		require.Equal(t, obj, newObj)
+	})
+
+	t.Run("put tombstone object", func(t *testing.T) {
+		raw.SetType(objectSDK.TypeTombstone)
+		raw.SetID(testOID())
+
+		obj := object.NewFromV2(raw.ToV2())
+
+		err := db.Put(obj, nil)
+		require.NoError(t, err)
+
+		newObj, err := db.Get(obj.Address())
+		require.NoError(t, err)
+		require.Equal(t, obj, newObj)
+	})
+
+	t.Run("put storage group object", func(t *testing.T) {
+		raw.SetType(objectSDK.TypeStorageGroup)
+		raw.SetID(testOID())
+
+		obj := object.NewFromV2(raw.ToV2())
+
+		err := db.Put(obj, nil)
+		require.NoError(t, err)
+
+		newObj, err := db.Get(obj.Address())
+		require.NoError(t, err)
+		require.Equal(t, obj, newObj)
+	})
+}

--- a/pkg/local_object_storage/metabase/v2/get_test.go
+++ b/pkg/local_object_storage/metabase/v2/get_test.go
@@ -64,7 +64,7 @@ func TestDB_Get(t *testing.T) {
 
 		child := generateRawObjectWithCID(t, cid)
 		child.SetParent(parent.Object().SDK())
-		child.SetParentID(parent.Object().Address().ObjectID())
+		child.SetParentID(parent.ID())
 
 		err := db.Put(child.Object(), nil)
 		require.NoError(t, err)

--- a/pkg/local_object_storage/metabase/v2/get_test.go
+++ b/pkg/local_object_storage/metabase/v2/get_test.go
@@ -1,6 +1,7 @@
 package meta_test
 
 import (
+	"bytes"
 	"testing"
 
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
@@ -13,51 +14,83 @@ func TestDB_Get(t *testing.T) {
 	defer releaseDB(db)
 
 	raw := generateRawObject(t)
+
+	// equal fails on diff of <nil> attributes and <{}> attributes,
+	/* so we make non empty attribute slice in parent*/
 	addAttribute(raw, "foo", "bar")
 
 	t.Run("object not found", func(t *testing.T) {
-		obj := object.NewFromV2(raw.ToV2())
-
-		_, err := db.Get(obj.Address())
+		_, err := db.Get(raw.Object().Address())
 		require.Error(t, err)
 	})
 
 	t.Run("put regular object", func(t *testing.T) {
-		obj := object.NewFromV2(raw.ToV2())
-
-		err := db.Put(obj, nil)
+		err := db.Put(raw.Object(), nil)
 		require.NoError(t, err)
 
-		newObj, err := db.Get(obj.Address())
+		newObj, err := db.Get(raw.Object().Address())
 		require.NoError(t, err)
-		require.Equal(t, obj, newObj)
+		require.Equal(t, raw.Object(), newObj)
 	})
 
 	t.Run("put tombstone object", func(t *testing.T) {
 		raw.SetType(objectSDK.TypeTombstone)
 		raw.SetID(testOID())
 
-		obj := object.NewFromV2(raw.ToV2())
-
-		err := db.Put(obj, nil)
+		err := db.Put(raw.Object(), nil)
 		require.NoError(t, err)
 
-		newObj, err := db.Get(obj.Address())
+		newObj, err := db.Get(raw.Object().Address())
 		require.NoError(t, err)
-		require.Equal(t, obj, newObj)
+		require.Equal(t, raw.Object(), newObj)
 	})
 
 	t.Run("put storage group object", func(t *testing.T) {
 		raw.SetType(objectSDK.TypeStorageGroup)
 		raw.SetID(testOID())
 
-		obj := object.NewFromV2(raw.ToV2())
-
-		err := db.Put(obj, nil)
+		err := db.Put(raw.Object(), nil)
 		require.NoError(t, err)
 
-		newObj, err := db.Get(obj.Address())
+		newObj, err := db.Get(raw.Object().Address())
 		require.NoError(t, err)
-		require.Equal(t, obj, newObj)
+		require.Equal(t, raw.Object(), newObj)
 	})
+
+	t.Run("put virtual object", func(t *testing.T) {
+		cid := testCID()
+		parent := generateRawObjectWithCID(t, cid)
+		addAttribute(parent, "foo", "bar")
+
+		child := generateRawObjectWithCID(t, cid)
+		child.SetParent(parent.Object().SDK())
+		child.SetParentID(parent.Object().Address().ObjectID())
+
+		err := db.Put(child.Object(), nil)
+		require.NoError(t, err)
+
+		newParent, err := db.Get(parent.Object().Address())
+		require.NoError(t, err)
+		require.True(t, binaryEqual(parent.Object(), newParent))
+
+		newChild, err := db.Get(child.Object().Address())
+		require.NoError(t, err)
+		require.True(t, binaryEqual(child.Object(), newChild))
+	})
+}
+
+// binary equal is used when object contains empty lists in the structure and
+// requre.Equal fails on comparing <nil> and []{} lists.
+func binaryEqual(a, b *object.Object) bool {
+	binaryA, err := a.Marshal()
+	if err != nil {
+		return false
+	}
+
+	binaryB, err := b.Marshal()
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(binaryA, binaryB)
 }

--- a/pkg/local_object_storage/metabase/v2/info.go
+++ b/pkg/local_object_storage/metabase/v2/info.go
@@ -1,9 +1,16 @@
 package meta
 
+import (
+	"os"
+)
+
 // Info groups the information about DB.
 type Info struct {
 	// Full path to the metabase.
 	Path string
+
+	// Permission of database file.
+	Permission os.FileMode
 }
 
 // DumpInfo returns information about the DB.

--- a/pkg/local_object_storage/metabase/v2/info.go
+++ b/pkg/local_object_storage/metabase/v2/info.go
@@ -1,0 +1,12 @@
+package meta
+
+// Info groups the information about DB.
+type Info struct {
+	// Full path to the metabase.
+	Path string
+}
+
+// DumpInfo returns information about the DB.
+func (db *DB) DumpInfo() Info {
+	return db.info
+}

--- a/pkg/local_object_storage/metabase/v2/inhume.go
+++ b/pkg/local_object_storage/metabase/v2/inhume.go
@@ -1,0 +1,19 @@
+package meta
+
+import (
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"go.etcd.io/bbolt"
+)
+
+// Inhume marks objects as removed but not removes it from metabase.
+func (db *DB) Inhume(target, tombstone *objectSDK.Address) error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		graveyard, err := tx.CreateBucketIfNotExists(graveyardBucketName)
+		if err != nil {
+			return err
+		}
+
+		// consider checking if target is already in graveyard?
+		return graveyard.Put(addressKey(target), addressKey(tombstone))
+	})
+}

--- a/pkg/local_object_storage/metabase/v2/inhume_test.go
+++ b/pkg/local_object_storage/metabase/v2/inhume_test.go
@@ -1,0 +1,32 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Inhume(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw := generateRawObject(t)
+	addAttribute(raw, "foo", "bar")
+
+	obj := object.NewFromV2(raw.ToV2())
+	tombstoneID := generateAddress()
+
+	err := db.Put(obj, nil)
+	require.NoError(t, err)
+
+	err = db.Inhume(obj.Address(), tombstoneID)
+	require.NoError(t, err)
+
+	_, err = db.Exists(obj.Address())
+	require.EqualError(t, err, meta.ErrAlreadyRemoved.Error())
+
+	_, err = db.Get(obj.Address())
+	require.EqualError(t, err, meta.ErrAlreadyRemoved.Error())
+}

--- a/pkg/local_object_storage/metabase/v2/inhume_test.go
+++ b/pkg/local_object_storage/metabase/v2/inhume_test.go
@@ -3,7 +3,6 @@ package meta_test
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -15,18 +14,17 @@ func TestDB_Inhume(t *testing.T) {
 	raw := generateRawObject(t)
 	addAttribute(raw, "foo", "bar")
 
-	obj := object.NewFromV2(raw.ToV2())
 	tombstoneID := generateAddress()
 
-	err := db.Put(obj, nil)
+	err := db.Put(raw.Object(), nil)
 	require.NoError(t, err)
 
-	err = db.Inhume(obj.Address(), tombstoneID)
+	err = db.Inhume(raw.Object().Address(), tombstoneID)
 	require.NoError(t, err)
 
-	_, err = db.Exists(obj.Address())
+	_, err = db.Exists(raw.Object().Address())
 	require.EqualError(t, err, meta.ErrAlreadyRemoved.Error())
 
-	_, err = db.Get(obj.Address())
+	_, err = db.Get(raw.Object().Address())
 	require.EqualError(t, err, meta.ErrAlreadyRemoved.Error())
 }

--- a/pkg/local_object_storage/metabase/v2/movable.go
+++ b/pkg/local_object_storage/metabase/v2/movable.go
@@ -1,0 +1,73 @@
+package meta
+
+import (
+	"fmt"
+
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"go.etcd.io/bbolt"
+)
+
+// ToMoveIt marks objects to move it into another shard. This useful for
+// faster HRW fetching.
+func (db *DB) ToMoveIt(addr *objectSDK.Address) error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		toMoveIt, err := tx.CreateBucketIfNotExists(toMoveItBucketName)
+		if err != nil {
+			return err
+		}
+
+		return toMoveIt.Put(addressKey(addr), zeroValue)
+	})
+}
+
+// DoNotMove removes `MoveIt` mark from the object.
+func (db *DB) DoNotMove(addr *objectSDK.Address) error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		toMoveIt := tx.Bucket(toMoveItBucketName)
+		if toMoveIt == nil {
+			return nil
+		}
+
+		return toMoveIt.Delete(addressKey(addr))
+	})
+}
+
+// Movable returns list of marked objects to move into other shard.
+func (db *DB) Movable() ([]*objectSDK.Address, error) {
+	var strAddrs []string
+
+	err := db.boltDB.View(func(tx *bbolt.Tx) error {
+		toMoveIt := tx.Bucket(toMoveItBucketName)
+		if toMoveIt == nil {
+			return nil
+		}
+
+		return toMoveIt.ForEach(func(k, v []byte) error {
+			strAddrs = append(strAddrs, string(k))
+
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// we can parse strings to structures in-place, but probably it seems
+	// more efficient to keep bolt db TX code smaller because it might be
+	// bottleneck.
+	addrs := make([]*objectSDK.Address, 0, len(strAddrs))
+
+	for i := range strAddrs {
+		addr := objectSDK.NewAddress()
+
+		err = addr.Parse(strAddrs[i])
+		if err != nil {
+			return nil, fmt.Errorf("can't parse object address %v: %w",
+				strAddrs[i], err)
+		}
+
+		addrs = append(addrs, addr)
+	}
+
+	return addrs, nil
+}

--- a/pkg/local_object_storage/metabase/v2/movable_test.go
+++ b/pkg/local_object_storage/metabase/v2/movable_test.go
@@ -1,0 +1,59 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_Movable(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw1 := generateRawObject(t)
+	raw2 := generateRawObject(t)
+
+	obj1 := object.NewFromV2(raw1.ToV2())
+	obj2 := object.NewFromV2(raw2.ToV2())
+
+	// put two objects in metabase
+	err := db.Put(obj1, nil)
+	require.NoError(t, err)
+
+	err = db.Put(obj2, nil)
+	require.NoError(t, err)
+
+	// check if toMoveIt index empty
+	toMoveList, err := db.Movable()
+	require.NoError(t, err)
+	require.Len(t, toMoveList, 0)
+
+	// mark to move object2
+	err = db.ToMoveIt(obj2.Address())
+	require.NoError(t, err)
+
+	// check if toMoveIt index contains address of object 2
+	toMoveList, err = db.Movable()
+	require.NoError(t, err)
+	require.Len(t, toMoveList, 1)
+	require.Contains(t, toMoveList, obj2.Address())
+
+	// remove from toMoveIt index non existing address
+	err = db.DoNotMove(obj1.Address())
+	require.NoError(t, err)
+
+	// check if toMoveIt index hasn't changed
+	toMoveList, err = db.Movable()
+	require.NoError(t, err)
+	require.Len(t, toMoveList, 1)
+
+	// remove from toMoveIt index existing address
+	err = db.DoNotMove(obj2.Address())
+	require.NoError(t, err)
+
+	// check if toMoveIt index is empty now
+	toMoveList, err = db.Movable()
+	require.NoError(t, err)
+	require.Len(t, toMoveList, 0)
+}

--- a/pkg/local_object_storage/metabase/v2/movable_test.go
+++ b/pkg/local_object_storage/metabase/v2/movable_test.go
@@ -3,7 +3,6 @@ package meta_test
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,14 +13,11 @@ func TestDB_Movable(t *testing.T) {
 	raw1 := generateRawObject(t)
 	raw2 := generateRawObject(t)
 
-	obj1 := object.NewFromV2(raw1.ToV2())
-	obj2 := object.NewFromV2(raw2.ToV2())
-
 	// put two objects in metabase
-	err := db.Put(obj1, nil)
+	err := db.Put(raw1.Object(), nil)
 	require.NoError(t, err)
 
-	err = db.Put(obj2, nil)
+	err = db.Put(raw2.Object(), nil)
 	require.NoError(t, err)
 
 	// check if toMoveIt index empty
@@ -30,17 +26,17 @@ func TestDB_Movable(t *testing.T) {
 	require.Len(t, toMoveList, 0)
 
 	// mark to move object2
-	err = db.ToMoveIt(obj2.Address())
+	err = db.ToMoveIt(raw2.Object().Address())
 	require.NoError(t, err)
 
 	// check if toMoveIt index contains address of object 2
 	toMoveList, err = db.Movable()
 	require.NoError(t, err)
 	require.Len(t, toMoveList, 1)
-	require.Contains(t, toMoveList, obj2.Address())
+	require.Contains(t, toMoveList, raw2.Object().Address())
 
 	// remove from toMoveIt index non existing address
-	err = db.DoNotMove(obj1.Address())
+	err = db.DoNotMove(raw1.Object().Address())
 	require.NoError(t, err)
 
 	// check if toMoveIt index hasn't changed
@@ -49,7 +45,7 @@ func TestDB_Movable(t *testing.T) {
 	require.Len(t, toMoveList, 1)
 
 	// remove from toMoveIt index existing address
-	err = db.DoNotMove(obj2.Address())
+	err = db.DoNotMove(raw2.Object().Address())
 	require.NoError(t, err)
 
 	// check if toMoveIt index is empty now

--- a/pkg/local_object_storage/metabase/v2/put.go
+++ b/pkg/local_object_storage/metabase/v2/put.go
@@ -105,7 +105,7 @@ func (db *DB) put(tx *bbolt.Tx, obj *object.Object, id *blobovnicza.ID, isParent
 func uniqueIndexes(obj *object.Object, isParent bool, id *blobovnicza.ID) ([]namedBucketItem, error) {
 	addr := obj.Address()
 	objKey := objectKey(addr.ObjectID())
-	result := make([]namedBucketItem, 0, 2)
+	result := make([]namedBucketItem, 0, 3)
 
 	// add value to primary unique bucket
 	if !isParent {
@@ -157,7 +157,7 @@ func uniqueIndexes(obj *object.Object, isParent bool, id *blobovnicza.ID) ([]nam
 
 // builds list of <list> indexes from the object.
 func listIndexes(obj *object.Object) ([]namedBucketItem, error) {
-	result := make([]namedBucketItem, 0, 1)
+	result := make([]namedBucketItem, 0, 3)
 	addr := obj.Address()
 	objKey := objectKey(addr.ObjectID())
 
@@ -168,6 +168,7 @@ func listIndexes(obj *object.Object) ([]namedBucketItem, error) {
 		val:  objKey,
 	})
 
+	// index parent ids
 	if obj.ParentID() != nil {
 		result = append(result, namedBucketItem{
 			name: parentBucketName(addr.ContainerID()),
@@ -176,7 +177,14 @@ func listIndexes(obj *object.Object) ([]namedBucketItem, error) {
 		})
 	}
 
-	// todo: index splitID
+	// index split ids
+	if obj.SplitID() != nil {
+		result = append(result, namedBucketItem{
+			name: splitBucketName(addr.ContainerID()),
+			key:  obj.SplitID().ToV2(),
+			val:  objKey,
+		})
+	}
 
 	return result, nil
 }

--- a/pkg/local_object_storage/metabase/v2/put.go
+++ b/pkg/local_object_storage/metabase/v2/put.go
@@ -1,0 +1,268 @@
+package meta
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"go.etcd.io/bbolt"
+)
+
+type (
+	namedBucketItem struct {
+		name, key, val []byte
+	}
+)
+
+var ErrUnknownObjectType = errors.New("unknown object type")
+
+// Put saves object header in metabase. Object payload expected to be cut.
+// Big objects have nil blobovniczaID.
+func (db *DB) Put(obj *object.Object, id *blobovnicza.ID) error {
+	var isParent bool // true when object header obtained from `split.Parent`
+
+	for ; obj != nil; obj, isParent = obj.GetParent(), true {
+		exists, err := db.Exists(obj.Address())
+		if err != nil {
+			return err
+		}
+
+		// most right child and split header overlap parent so we have to
+		// check if object exists to not overwrite it twice
+		if exists {
+			continue
+		}
+
+		uniqueIndexes, err := uniqueIndexes(obj, isParent, id)
+		if err != nil {
+			return fmt.Errorf("can' build unique indexes: %w", err)
+		}
+
+		// build list indexes
+		listIndexes, err := listIndexes(obj)
+		if err != nil {
+			return fmt.Errorf("can' build list indexes: %w", err)
+		}
+
+		fkbtIndexes, err := fkbtIndexes(obj)
+		if err != nil {
+			return fmt.Errorf("can' build fake bucket tree indexes: %w", err)
+		}
+
+		// consider making one TX for both target object and parent
+		err = db.boltDB.Update(func(tx *bbolt.Tx) error {
+			// put unique indexes
+			for i := range uniqueIndexes {
+				err := putUniqueIndexItem(tx, uniqueIndexes[i])
+				if err != nil {
+					return err
+				}
+			}
+
+			// put list indexes
+			for i := range listIndexes {
+				err := putListIndexItem(tx, listIndexes[i])
+				if err != nil {
+					return err
+				}
+			}
+
+			// put fake bucket tree indexes
+			for i := range fkbtIndexes {
+				err := putFKBTIndexItem(tx, fkbtIndexes[i])
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil { // if tx failed then return error
+			return err
+		}
+	}
+
+	return nil
+}
+
+// builds list of <unique> indexes from the object.
+func uniqueIndexes(obj *object.Object, isParent bool, id *blobovnicza.ID) ([]namedBucketItem, error) {
+	addr := obj.Address()
+	objKey := objectKey(addr.ObjectID())
+	result := make([]namedBucketItem, 0, 2)
+
+	// add value to primary unique bucket
+	if !isParent {
+		var bucketName []byte
+
+		switch obj.Type() {
+		case objectSDK.TypeRegular:
+			bucketName = primaryBucketName(addr.ContainerID())
+		case objectSDK.TypeTombstone:
+			bucketName = tombstoneBucketName(addr.ContainerID())
+		case objectSDK.TypeStorageGroup:
+			bucketName = storageGroupBucketName(addr.ContainerID())
+		default:
+			return nil, ErrUnknownObjectType
+		}
+
+		rawObject, err := obj.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("can't marshal object header: %w", err)
+		}
+
+		result = append(result, namedBucketItem{
+			name: bucketName,
+			key:  objKey,
+			val:  rawObject,
+		})
+
+		// index blobovniczaID if it is present
+		if id != nil {
+			result = append(result, namedBucketItem{
+				name: smallBucketName(addr.ContainerID()),
+				key:  objKey,
+				val:  *id,
+			})
+		}
+	}
+
+	// index root object
+	if obj.Type() == objectSDK.TypeRegular && !obj.HasParent() {
+		result = append(result, namedBucketItem{
+			name: rootBucketName(addr.ContainerID()),
+			key:  objKey,
+			val:  zeroValue, // todo: store split.Info when it will be ready
+		})
+	}
+
+	return result, nil
+}
+
+// builds list of <list> indexes from the object.
+func listIndexes(obj *object.Object) ([]namedBucketItem, error) {
+	result := make([]namedBucketItem, 0, 1)
+	addr := obj.Address()
+	objKey := objectKey(addr.ObjectID())
+
+	// index payload hashes
+	result = append(result, namedBucketItem{
+		name: payloadHashBucketName(addr.ContainerID()),
+		key:  obj.PayloadChecksum().Sum(),
+		val:  objKey,
+	})
+
+	if obj.ParentID() != nil {
+		result = append(result, namedBucketItem{
+			name: parentBucketName(addr.ContainerID()),
+			key:  objectKey(obj.ParentID()),
+			val:  objKey,
+		})
+	}
+
+	// todo: index splitID
+
+	return result, nil
+}
+
+// builds list of <fake bucket tree> indexes from the object.
+func fkbtIndexes(obj *object.Object) ([]namedBucketItem, error) {
+	addr := obj.Address()
+	objKey := []byte(addr.ObjectID().String())
+
+	attrs := obj.Attributes()
+	result := make([]namedBucketItem, 0, 1+len(attrs))
+
+	// owner
+	result = append(result, namedBucketItem{
+		name: ownerBucketName(addr.ContainerID()),
+		key:  []byte(obj.OwnerID().String()),
+		val:  objKey,
+	})
+
+	// user specified attributes
+	for i := range attrs {
+		result = append(result, namedBucketItem{
+			name: attributeBucketName(addr.ContainerID(), attrs[i].Key()),
+			key:  []byte(attrs[i].Value()),
+			val:  objKey,
+		})
+	}
+
+	return result, nil
+}
+
+func putUniqueIndexItem(tx *bbolt.Tx, item namedBucketItem) error {
+	bkt, err := tx.CreateBucketIfNotExists(item.name)
+	if err != nil {
+		return fmt.Errorf("can't create index %v: %w", item.name, err)
+	}
+
+	return bkt.Put(item.key, item.val)
+}
+
+func putFKBTIndexItem(tx *bbolt.Tx, item namedBucketItem) error {
+	bkt, err := tx.CreateBucketIfNotExists(item.name)
+	if err != nil {
+		return fmt.Errorf("can't create index %v: %w", item.name, err)
+	}
+
+	fkbtRoot, err := bkt.CreateBucketIfNotExists(item.key)
+	if err != nil {
+		return fmt.Errorf("can't create fake bucket tree index %v: %w", item.key, err)
+	}
+
+	return fkbtRoot.Put(item.val, zeroValue)
+}
+
+func putListIndexItem(tx *bbolt.Tx, item namedBucketItem) error {
+	bkt, err := tx.CreateBucketIfNotExists(item.name)
+	if err != nil {
+		return fmt.Errorf("can't create index %v: %w", item.name, err)
+	}
+
+	lst, err := decodeList(bkt.Get(item.key))
+	if err != nil {
+		return fmt.Errorf("can't decode leaf list %v: %w", item.key, err)
+	}
+
+	lst = append(lst, item.val)
+
+	encodedLst, err := encodeList(lst)
+	if err != nil {
+		return fmt.Errorf("can't encode leaf list %v: %w", item.key, err)
+	}
+
+	return bkt.Put(item.key, encodedLst)
+}
+
+// encodeList decodes list of bytes into a single blog for list bucket indexes.
+func encodeList(lst [][]byte) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	encoder := gob.NewEncoder(buf)
+
+	// consider using protobuf encoding instead of glob
+	if err := encoder.Encode(lst); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeList decodes blob into the list of bytes from list bucket index.
+func decodeList(data []byte) (lst [][]byte, err error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	decoder := gob.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&lst); err != nil {
+		return nil, err
+	}
+
+	return lst, nil
+}

--- a/pkg/local_object_storage/metabase/v2/put_test.go
+++ b/pkg/local_object_storage/metabase/v2/put_test.go
@@ -1,0 +1,48 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_PutBlobovnicaUpdate(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw1 := generateRawObject(t)
+	blobovniczaID := blobovnicza.ID{1, 2, 3, 4}
+
+	// put one object with blobovniczaID
+	err := db.Put(raw1.Object(), &blobovniczaID)
+	require.NoError(t, err)
+
+	fetchedBlobovniczaID, err := db.IsSmall(raw1.Object().Address())
+	require.NoError(t, err)
+	require.Equal(t, &blobovniczaID, fetchedBlobovniczaID)
+
+	t.Run("update blobovniczaID", func(t *testing.T) {
+		newID := blobovnicza.ID{5, 6, 7, 8}
+
+		err := db.Put(raw1.Object(), &newID)
+		require.NoError(t, err)
+
+		fetchedBlobovniczaID, err := db.IsSmall(raw1.Object().Address())
+		require.NoError(t, err)
+		require.Equal(t, &newID, fetchedBlobovniczaID)
+	})
+
+	t.Run("update blobovniczaID on bad object", func(t *testing.T) {
+		raw2 := generateRawObject(t)
+		err := db.Put(raw2.Object(), nil)
+		require.NoError(t, err)
+
+		fetchedBlobovniczaID, err := db.IsSmall(raw2.Object().Address())
+		require.NoError(t, err)
+		require.Nil(t, fetchedBlobovniczaID)
+
+		err = db.Put(raw2.Object(), &blobovniczaID)
+		require.Error(t, err)
+	})
+}

--- a/pkg/local_object_storage/metabase/v2/select.go
+++ b/pkg/local_object_storage/metabase/v2/select.go
@@ -293,7 +293,7 @@ func (db *DB) matchSlowFilters(tx *bbolt.Tx, addr *object.Address, f object.Sear
 		return true
 	}
 
-	obj, err := db.get(tx, addr)
+	obj, err := db.get(tx, addr, true)
 	if err != nil {
 		return false
 	}

--- a/pkg/local_object_storage/metabase/v2/select.go
+++ b/pkg/local_object_storage/metabase/v2/select.go
@@ -1,0 +1,331 @@
+package meta
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/pkg/errors"
+	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
+)
+
+type (
+	// filterGroup is a structure that have search filters grouped by access
+	// method. We have fast filters that looks for indexes and do not unmarshal
+	// objects, and slow filters, that applied after fast filters created
+	// smaller set of objects to check.
+	filterGroup struct {
+		cid         *container.ID
+		fastFilters object.SearchFilters
+		slowFilters object.SearchFilters
+	}
+)
+
+var ErrContainerNotInQuery = errors.New("search query does not contain container id filter")
+
+// Select returns list of addresses of objects that match search filters.
+func (db *DB) Select(fs object.SearchFilters) (res []*object.Address, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		res, err = db.selectObjects(tx, fs)
+
+		return err
+	})
+
+	return res, err
+}
+
+func (db *DB) selectObjects(tx *bbolt.Tx, fs object.SearchFilters) ([]*object.Address, error) {
+	group, err := groupFilters(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	if group.cid == nil {
+		return nil, ErrContainerNotInQuery
+	}
+
+	// keep matched addresses in this cache
+	// value equal to number (index+1) of latest matched filter
+	mAddr := make(map[string]int)
+
+	expLen := len(group.fastFilters) // expected value of matched filters in mAddr
+
+	if len(group.fastFilters) == 0 {
+		expLen = 1
+
+		db.selectAll(tx, group.cid, mAddr)
+	} else {
+		for i := range group.fastFilters {
+			db.selectFastFilter(tx, group.cid, group.fastFilters[i], mAddr, i)
+		}
+	}
+
+	res := make([]*object.Address, 0, len(mAddr))
+
+	for a, ind := range mAddr {
+		if ind != expLen {
+			continue // ignore objects with unmatched fast filters
+		}
+
+		addr := object.NewAddress()
+		if err := addr.Parse(a); err != nil {
+			// TODO: storage was broken, so we need to handle it
+			return nil, err
+		}
+
+		if inGraveyard(tx, addr) {
+			continue // ignore removed objects
+		}
+
+		if !db.matchSlowFilters(tx, addr, group.slowFilters) {
+			continue // ignore objects with unmatched slow filters
+		}
+
+		res = append(res, addr)
+	}
+
+	return res, nil
+}
+
+// selectAll adds to resulting cache all available objects in metabase.
+func (db *DB) selectAll(tx *bbolt.Tx, cid *container.ID, to map[string]int) {
+	prefix := cid.String() + "/"
+
+	selectAllFromBucket(tx, primaryBucketName(cid), prefix, to, 0)
+	selectAllFromBucket(tx, tombstoneBucketName(cid), prefix, to, 0)
+	selectAllFromBucket(tx, storageGroupBucketName(cid), prefix, to, 0)
+	selectAllFromBucket(tx, parentBucketName(cid), prefix, to, 0)
+}
+
+// selectAllFromBucket goes through all keys in bucket and adds them in a
+// resulting cache. Keys should be stringed object ids.
+func selectAllFromBucket(tx *bbolt.Tx, name []byte, prefix string, to map[string]int, fNum int) {
+	bkt := tx.Bucket(name)
+	if bkt == nil {
+		return
+	}
+
+	_ = bkt.ForEach(func(k, v []byte) error {
+		key := prefix + string(k) // consider using string builders from sync.Pool
+		markAddressInCache(to, fNum, key)
+
+		return nil
+	})
+}
+
+// selectFastFilter makes fast optimized checks for well known buckets or
+// looking through user attribute buckets otherwise.
+func (db *DB) selectFastFilter(
+	tx *bbolt.Tx,
+	cid *container.ID, // container we search on
+	f object.SearchFilter, // fast filter
+	to map[string]int, // resulting cache
+	fNum int, // index of filter
+) {
+	prefix := cid.String() + "/"
+
+	// todo: add splitID
+
+	switch f.Header() {
+	case v2object.FilterHeaderObjectID:
+		// todo: implement me
+	case v2object.FilterHeaderOwnerID:
+		bucketName := ownerBucketName(cid)
+		db.selectFromFKBT(tx, bucketName, f, prefix, to, fNum)
+	case v2object.FilterHeaderPayloadHash:
+		bucketName := payloadHashBucketName(cid)
+		db.selectFromList(tx, bucketName, f, prefix, to, fNum)
+	case v2object.FilterHeaderObjectType:
+		var bucketName []byte
+
+		switch f.Value() { // do it better after https://github.com/nspcc-dev/neofs-api/issues/84
+		case "Regular":
+			bucketName = primaryBucketName(cid)
+
+			selectAllFromBucket(tx, bucketName, prefix, to, fNum)
+
+			bucketName = parentBucketName(cid)
+		case "Tombstone":
+			bucketName = tombstoneBucketName(cid)
+		case "StorageGroup":
+			bucketName = storageGroupBucketName(cid)
+		default:
+			db.log.Debug("unknown object type", zap.String("type", f.Value()))
+		}
+
+		selectAllFromBucket(tx, bucketName, prefix, to, fNum)
+	case v2object.FilterHeaderParent:
+		bucketName := parentBucketName(cid)
+		db.selectFromList(tx, bucketName, f, prefix, to, fNum)
+	case v2object.FilterPropertyRoot:
+		selectAllFromBucket(tx, rootBucketName(cid), prefix, to, fNum)
+	case v2object.FilterPropertyPhy:
+		selectAllFromBucket(tx, primaryBucketName(cid), prefix, to, fNum)
+		selectAllFromBucket(tx, tombstoneBucketName(cid), prefix, to, fNum)
+		selectAllFromBucket(tx, storageGroupBucketName(cid), prefix, to, fNum)
+	default: // user attribute
+		bucketName := attributeBucketName(cid, f.Header())
+		db.selectFromFKBT(tx, bucketName, f, prefix, to, fNum)
+	}
+}
+
+// selectFromList looks into <fkbt> index to find list of addresses to add in
+// resulting cache.
+func (db *DB) selectFromFKBT(
+	tx *bbolt.Tx,
+	name []byte, // fkbt root bucket name
+	f object.SearchFilter, // filter for operation and value
+	prefix string, // prefix to create addr from oid in index
+	to map[string]int, // resulting cache
+	fNum int, // index of filter
+) { //
+	matchFunc, ok := db.matchers[f.Operation()]
+	if !ok {
+		db.log.Debug("missing matcher", zap.Uint32("operation", uint32(f.Operation())))
+
+		return
+	}
+
+	fkbtRoot := tx.Bucket(name)
+	if fkbtRoot == nil {
+		return
+	}
+
+	err := fkbtRoot.ForEach(func(k, _ []byte) error {
+		if matchFunc(f.Header(), k, f.Value()) {
+			fkbtLeaf := fkbtRoot.Bucket(k)
+			if fkbtLeaf == nil {
+				return nil
+			}
+
+			return fkbtLeaf.ForEach(func(k, _ []byte) error {
+				addr := prefix + string(k)
+				markAddressInCache(to, fNum, addr)
+
+				return nil
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		db.log.Debug("error in FKBT selection", zap.String("error", err.Error()))
+	}
+}
+
+// selectFromList looks into <list> index to find list of addresses to add in
+// resulting cache.
+func (db *DB) selectFromList(
+	tx *bbolt.Tx,
+	name []byte, // list root bucket name
+	f object.SearchFilter, // filter for operation and value
+	prefix string, // prefix to create addr from oid in index
+	to map[string]int, // resulting cache
+	fNum int, // index of filter
+) { //
+	bkt := tx.Bucket(name)
+	if bkt == nil {
+		return
+	}
+
+	switch f.Operation() {
+	case object.MatchStringEqual:
+	default:
+		db.log.Debug("unknown operation", zap.Uint32("operation", uint32(f.Operation())))
+	}
+
+	// warning: it works only for MatchStringEQ, for NotEQ you should iterate over
+	// bkt and apply matchFunc, don't forget to implement this when it will be
+	// needed. Right now it is not efficient to iterate over bucket
+	// when there is only MatchStringEQ.
+	lst, err := decodeList(bkt.Get(bucketKeyHelper(f.Header(), f.Value())))
+	if err != nil {
+		db.log.Debug("can't decode list bucket leaf", zap.String("error", err.Error()))
+	}
+
+	for i := range lst {
+		addr := prefix + string(lst[i])
+		markAddressInCache(to, fNum, addr)
+	}
+}
+
+// matchSlowFilters return true if object header is matched by all slow filters.
+func (db *DB) matchSlowFilters(tx *bbolt.Tx, addr *object.Address, f object.SearchFilters) bool {
+	if len(f) == 0 {
+		return true
+	}
+
+	obj, err := db.get(tx, addr)
+	if err != nil {
+		return false
+	}
+
+	for i := range f {
+		matchFunc, ok := db.matchers[f[i].Operation()]
+		if !ok {
+			return false
+		}
+
+		var data []byte
+
+		switch f[i].Header() {
+		case v2object.FilterHeaderVersion:
+			data = []byte(obj.Version().String())
+		case v2object.FilterHeaderHomomorphicHash:
+			data = obj.PayloadHomomorphicHash().Sum()
+		case v2object.FilterHeaderCreationEpoch:
+			data = make([]byte, 8)
+			binary.LittleEndian.PutUint64(data, obj.CreationEpoch())
+		case v2object.FilterHeaderPayloadLength:
+			data = make([]byte, 8)
+			binary.LittleEndian.PutUint64(data, obj.PayloadSize())
+		}
+
+		if !matchFunc(f[i].Header(), data, f[i].Value()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// groupFilters divides filters in two groups: fast and slow. Fast filters
+// processed by indexes and slow filters processed after by unmarshaling
+// object headers.
+func groupFilters(filters object.SearchFilters) (*filterGroup, error) {
+	res := &filterGroup{
+		fastFilters: make(object.SearchFilters, 0, len(filters)),
+		slowFilters: make(object.SearchFilters, 0, len(filters)),
+	}
+
+	for i := range filters {
+		switch filters[i].Header() {
+		case v2object.FilterHeaderContainerID:
+			res.cid = container.NewID()
+
+			err := res.cid.Parse(filters[i].Value())
+			if err != nil {
+				return nil, fmt.Errorf("can't parse container id: %w", err)
+			}
+		case // slow filters
+			v2object.FilterHeaderVersion,
+			v2object.FilterHeaderCreationEpoch,
+			v2object.FilterHeaderPayloadLength,
+			v2object.FilterHeaderHomomorphicHash:
+			res.slowFilters = append(res.slowFilters, filters[i])
+		default: // fast filters or user attributes if unknown
+			res.fastFilters = append(res.fastFilters, filters[i])
+		}
+	}
+
+	return res, nil
+}
+
+func markAddressInCache(cache map[string]int, fNum int, addr string) {
+	if num := cache[addr]; num == fNum {
+		cache[addr] = num + 1
+	}
+}

--- a/pkg/local_object_storage/metabase/v2/select.go
+++ b/pkg/local_object_storage/metabase/v2/select.go
@@ -160,6 +160,9 @@ func (db *DB) selectFastFilter(
 	case v2object.FilterHeaderParent:
 		bucketName := parentBucketName(cid)
 		db.selectFromList(tx, bucketName, f, prefix, to, fNum)
+	case v2object.FilterHeaderSplitID:
+		bucketName := splitBucketName(cid)
+		db.selectFromList(tx, bucketName, f, prefix, to, fNum)
 	case v2object.FilterPropertyRoot:
 		selectAllFromBucket(tx, rootBucketName(cid), prefix, to, fNum)
 	case v2object.FilterPropertyPhy:

--- a/pkg/local_object_storage/metabase/v2/select_test.go
+++ b/pkg/local_object_storage/metabase/v2/select_test.go
@@ -95,14 +95,14 @@ func TestDB_SelectRootPhyParent(t *testing.T) {
 
 	rightChild := generateRawObjectWithCID(t, cid)
 	rightChild.SetParent(parent.Object().SDK())
-	rightChild.SetParentID(parent.Object().Address().ObjectID())
+	rightChild.SetParentID(parent.ID())
 	err = db.Put(rightChild.Object(), nil)
 	require.NoError(t, err)
 
 	link := generateRawObjectWithCID(t, cid)
 	link.SetParent(parent.Object().SDK())
-	link.SetParentID(parent.Object().Address().ObjectID())
-	link.SetChildren(leftChild.Object().Address().ObjectID(), rightChild.Object().Address().ObjectID())
+	link.SetParentID(parent.ID())
+	link.SetChildren(leftChild.ID(), rightChild.ID())
 
 	err = db.Put(link.Object(), nil)
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestDB_SelectRootPhyParent(t *testing.T) {
 	t.Run("objects with parent", func(t *testing.T) {
 		fs := generateSearchFilter(cid)
 		fs.AddFilter(v2object.FilterHeaderParent,
-			parent.Object().Address().ObjectID().String(),
+			parent.ID().String(),
 			objectSDK.MatchStringEqual)
 
 		testSelect(t, db, fs,

--- a/pkg/local_object_storage/metabase/v2/select_test.go
+++ b/pkg/local_object_storage/metabase/v2/select_test.go
@@ -1,0 +1,302 @@
+package meta_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_SelectUserAttributes(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+
+	raw1 := generateRawObjectWithCID(t, cid)
+	addAttribute(raw1, "foo", "bar")
+	addAttribute(raw1, "x", "y")
+
+	err := db.Put(raw1.Object(), nil)
+	require.NoError(t, err)
+
+	raw2 := generateRawObjectWithCID(t, cid)
+	addAttribute(raw2, "foo", "bar")
+	addAttribute(raw2, "x", "z")
+
+	err = db.Put(raw2.Object(), nil)
+	require.NoError(t, err)
+
+	raw3 := generateRawObjectWithCID(t, cid)
+	addAttribute(raw3, "a", "b")
+
+	err = db.Put(raw3.Object(), nil)
+	require.NoError(t, err)
+
+	fs := generateSearchFilter(cid)
+	fs.AddFilter("foo", "bar", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs,
+		raw1.Object().Address(),
+		raw2.Object().Address(),
+	)
+
+	fs = generateSearchFilter(cid)
+	fs.AddFilter("x", "y", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs, raw1.Object().Address())
+
+	fs = generateSearchFilter(cid)
+	fs.AddFilter("a", "b", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs, raw3.Object().Address())
+
+	fs = generateSearchFilter(cid)
+	fs.AddFilter("c", "d", objectSDK.MatchStringEqual)
+	testSelect(t, db, fs)
+
+	fs = generateSearchFilter(cid)
+	testSelect(t, db, fs,
+		raw1.Object().Address(),
+		raw2.Object().Address(),
+		raw3.Object().Address(),
+	)
+}
+
+func TestDB_SelectRootPhyParent(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+
+	// prepare
+
+	small := generateRawObjectWithCID(t, cid)
+	err := db.Put(small.Object(), nil)
+	require.NoError(t, err)
+
+	ts := generateRawObjectWithCID(t, cid)
+	ts.SetType(objectSDK.TypeTombstone)
+	err = db.Put(ts.Object(), nil)
+	require.NoError(t, err)
+
+	sg := generateRawObjectWithCID(t, cid)
+	sg.SetType(objectSDK.TypeStorageGroup)
+	err = db.Put(sg.Object(), nil)
+	require.NoError(t, err)
+
+	leftChild := generateRawObjectWithCID(t, cid)
+	leftChild.InitRelations()
+	err = db.Put(leftChild.Object(), nil)
+	require.NoError(t, err)
+
+	parent := generateRawObjectWithCID(t, cid)
+
+	rightChild := generateRawObjectWithCID(t, cid)
+	rightChild.SetParent(parent.Object().SDK())
+	rightChild.SetParentID(parent.Object().Address().ObjectID())
+	err = db.Put(rightChild.Object(), nil)
+	require.NoError(t, err)
+
+	link := generateRawObjectWithCID(t, cid)
+	link.SetParent(parent.Object().SDK())
+	link.SetParentID(parent.Object().Address().ObjectID())
+	link.SetChildren(leftChild.Object().Address().ObjectID(), rightChild.Object().Address().ObjectID())
+
+	err = db.Put(link.Object(), nil)
+	require.NoError(t, err)
+
+	// printDB(meta.ExtractDB(db))
+	// return
+
+	t.Run("root objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddRootFilter()
+		testSelect(t, db, fs,
+			small.Object().Address(),
+			parent.Object().Address(),
+		)
+	})
+
+	t.Run("phy objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddPhyFilter()
+		testSelect(t, db, fs,
+			small.Object().Address(),
+			ts.Object().Address(),
+			sg.Object().Address(),
+			leftChild.Object().Address(),
+			rightChild.Object().Address(),
+			link.Object().Address(),
+		)
+	})
+
+	t.Run("regular objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderObjectType, "Regular", objectSDK.MatchStringEqual)
+		testSelect(t, db, fs,
+			small.Object().Address(),
+			leftChild.Object().Address(),
+			rightChild.Object().Address(),
+			link.Object().Address(),
+			parent.Object().Address(),
+		)
+	})
+
+	t.Run("tombstone objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderObjectType, "Tombstone", objectSDK.MatchStringEqual)
+		testSelect(t, db, fs, ts.Object().Address())
+	})
+
+	t.Run("storage group objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderObjectType, "StorageGroup", objectSDK.MatchStringEqual)
+		testSelect(t, db, fs, sg.Object().Address())
+	})
+
+	t.Run("objects with parent", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderParent,
+			parent.Object().Address().ObjectID().String(),
+			objectSDK.MatchStringEqual)
+
+		testSelect(t, db, fs,
+			rightChild.Object().Address(),
+			link.Object().Address(),
+		)
+	})
+
+	t.Run("all objects", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		testSelect(t, db, fs,
+			small.Object().Address(),
+			ts.Object().Address(),
+			sg.Object().Address(),
+			leftChild.Object().Address(),
+			rightChild.Object().Address(),
+			link.Object().Address(),
+			parent.Object().Address(),
+		)
+	})
+}
+
+func TestDB_SelectInhume(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+
+	raw1 := generateRawObjectWithCID(t, cid)
+	err := db.Put(raw1.Object(), nil)
+	require.NoError(t, err)
+
+	raw2 := generateRawObjectWithCID(t, cid)
+	err = db.Put(raw2.Object(), nil)
+	require.NoError(t, err)
+
+	fs := generateSearchFilter(cid)
+	testSelect(t, db, fs,
+		raw1.Object().Address(),
+		raw2.Object().Address(),
+	)
+
+	tombstone := objectSDK.NewAddress()
+	tombstone.SetContainerID(cid)
+	tombstone.SetObjectID(testOID())
+
+	err = db.Inhume(raw2.Object().Address(), tombstone)
+	require.NoError(t, err)
+
+	fs = generateSearchFilter(cid)
+	testSelect(t, db, fs,
+		raw1.Object().Address(),
+	)
+}
+
+func TestDB_SelectPayloadHash(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+
+	raw1 := generateRawObjectWithCID(t, cid)
+	err := db.Put(raw1.Object(), nil)
+	require.NoError(t, err)
+
+	raw2 := generateRawObjectWithCID(t, cid)
+	err = db.Put(raw2.Object(), nil)
+	require.NoError(t, err)
+
+	fs := generateSearchFilter(cid)
+	fs.AddFilter(v2object.FilterHeaderPayloadHash,
+		hex.EncodeToString(raw1.PayloadChecksum().Sum()),
+		objectSDK.MatchStringEqual)
+
+	testSelect(t, db, fs, raw1.Object().Address())
+}
+
+func TestDB_SelectWithSlowFilters(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	cid := testCID()
+
+	v20 := new(pkg.Version)
+	v20.SetMajor(2)
+
+	v21 := new(pkg.Version)
+	v21.SetMajor(2)
+	v21.SetMinor(1)
+
+	raw1 := generateRawObjectWithCID(t, cid)
+	raw1.SetPayloadSize(10)
+	raw1.SetCreationEpoch(11)
+	raw1.SetVersion(v20)
+	err := db.Put(raw1.Object(), nil)
+	require.NoError(t, err)
+
+	raw2 := generateRawObjectWithCID(t, cid)
+	raw2.SetPayloadSize(20)
+	raw2.SetCreationEpoch(21)
+	raw2.SetVersion(v21)
+	err = db.Put(raw2.Object(), nil)
+	require.NoError(t, err)
+
+	t.Run("object with TZHash", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderHomomorphicHash,
+			hex.EncodeToString(raw1.PayloadHomomorphicHash().Sum()),
+			objectSDK.MatchStringEqual)
+
+		testSelect(t, db, fs, raw1.Object().Address())
+	})
+
+	t.Run("object with payload length", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderPayloadLength, "20", objectSDK.MatchStringEqual)
+
+		testSelect(t, db, fs, raw2.Object().Address())
+	})
+
+	t.Run("object with creation epoch", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddFilter(v2object.FilterHeaderCreationEpoch, "11", objectSDK.MatchStringEqual)
+
+		testSelect(t, db, fs, raw1.Object().Address())
+	})
+
+	t.Run("object with version", func(t *testing.T) {
+		fs := generateSearchFilter(cid)
+		fs.AddObjectVersionFilter(objectSDK.MatchStringEqual, v21)
+		testSelect(t, db, fs, raw2.Object().Address())
+	})
+}
+
+func generateSearchFilter(cid *container.ID) objectSDK.SearchFilters {
+	fs := objectSDK.SearchFilters{}
+	fs.AddObjectContainerIDFilter(objectSDK.MatchStringEqual, cid)
+
+	return fs
+}

--- a/pkg/local_object_storage/metabase/v2/small.go
+++ b/pkg/local_object_storage/metabase/v2/small.go
@@ -1,0 +1,28 @@
+package meta
+
+import (
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"go.etcd.io/bbolt"
+)
+
+// IsSmall returns blobovniczaID for small objects and nil for big objects.
+// Small objects stored in blobovnicza instances. Big objects stored in FS by
+// shallow path which is calculated from address and therefore it is not
+// indexed in metabase.
+func (db *DB) IsSmall(addr *objectSDK.Address) (id *blobovnicza.ID, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		// if graveyard is empty, then check if object exists in primary bucket
+		smallBucket := tx.Bucket(smallBucketName(addr.ContainerID()))
+		if smallBucket == nil {
+			return nil
+		}
+
+		blobovniczaID := smallBucket.Get(objectKey(addr.ObjectID()))
+		id = blobovnicza.NewIDFromBytes(blobovniczaID)
+
+		return err
+	})
+
+	return id, err
+}

--- a/pkg/local_object_storage/metabase/v2/small.go
+++ b/pkg/local_object_storage/metabase/v2/small.go
@@ -12,17 +12,22 @@ import (
 // indexed in metabase.
 func (db *DB) IsSmall(addr *objectSDK.Address) (id *blobovnicza.ID, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
-		// if graveyard is empty, then check if object exists in primary bucket
-		smallBucket := tx.Bucket(smallBucketName(addr.ContainerID()))
-		if smallBucket == nil {
-			return nil
-		}
-
-		blobovniczaID := smallBucket.Get(objectKey(addr.ObjectID()))
-		id = blobovnicza.NewIDFromBytes(blobovniczaID)
+		id, err = db.isSmall(tx, addr)
 
 		return err
 	})
 
 	return id, err
+}
+
+func (db *DB) isSmall(tx *bbolt.Tx, addr *objectSDK.Address) (*blobovnicza.ID, error) {
+	smallBucket := tx.Bucket(smallBucketName(addr.ContainerID()))
+	if smallBucket == nil {
+		return nil, nil
+	}
+
+	blobovniczaID := smallBucket.Get(objectKey(addr.ObjectID()))
+	id := blobovnicza.NewIDFromBytes(blobovniczaID)
+
+	return id, nil
 }

--- a/pkg/local_object_storage/metabase/v2/small_test.go
+++ b/pkg/local_object_storage/metabase/v2/small_test.go
@@ -1,0 +1,45 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDB_IsSmall(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	raw1 := generateRawObject(t)
+	raw2 := generateRawObject(t)
+
+	blobovniczaID := blobovnicza.ID{1, 2, 3, 4}
+
+	obj1 := object.NewFromV2(raw1.ToV2())
+	obj2 := object.NewFromV2(raw2.ToV2())
+
+	// check IsSmall from empty database
+	fetchedBlobovniczaID, err := db.IsSmall(obj1.Address())
+	require.NoError(t, err)
+	require.Nil(t, fetchedBlobovniczaID)
+
+	// put one object with blobovniczaID
+	err = db.Put(obj1, &blobovniczaID)
+	require.NoError(t, err)
+
+	// put one object without blobovniczaID
+	err = db.Put(obj2, nil)
+	require.NoError(t, err)
+
+	// check IsSmall for object without blobovniczaID
+	fetchedBlobovniczaID, err = db.IsSmall(obj2.Address())
+	require.NoError(t, err)
+	require.Nil(t, fetchedBlobovniczaID)
+
+	// check IsSmall for object with blobovniczaID
+	fetchedBlobovniczaID, err = db.IsSmall(obj1.Address())
+	require.NoError(t, err)
+	require.Equal(t, blobovniczaID, *fetchedBlobovniczaID)
+}

--- a/pkg/local_object_storage/metabase/v2/small_test.go
+++ b/pkg/local_object_storage/metabase/v2/small_test.go
@@ -3,7 +3,6 @@ package meta_test
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/stretchr/testify/require"
 )
@@ -17,29 +16,26 @@ func TestDB_IsSmall(t *testing.T) {
 
 	blobovniczaID := blobovnicza.ID{1, 2, 3, 4}
 
-	obj1 := object.NewFromV2(raw1.ToV2())
-	obj2 := object.NewFromV2(raw2.ToV2())
-
 	// check IsSmall from empty database
-	fetchedBlobovniczaID, err := db.IsSmall(obj1.Address())
+	fetchedBlobovniczaID, err := db.IsSmall(raw1.Object().Address())
 	require.NoError(t, err)
 	require.Nil(t, fetchedBlobovniczaID)
 
 	// put one object with blobovniczaID
-	err = db.Put(obj1, &blobovniczaID)
+	err = db.Put(raw1.Object(), &blobovniczaID)
 	require.NoError(t, err)
 
 	// put one object without blobovniczaID
-	err = db.Put(obj2, nil)
+	err = db.Put(raw2.Object(), nil)
 	require.NoError(t, err)
 
 	// check IsSmall for object without blobovniczaID
-	fetchedBlobovniczaID, err = db.IsSmall(obj2.Address())
+	fetchedBlobovniczaID, err = db.IsSmall(raw2.Object().Address())
 	require.NoError(t, err)
 	require.Nil(t, fetchedBlobovniczaID)
 
 	// check IsSmall for object with blobovniczaID
-	fetchedBlobovniczaID, err = db.IsSmall(obj1.Address())
+	fetchedBlobovniczaID, err = db.IsSmall(raw1.Object().Address())
 	require.NoError(t, err)
-	require.Equal(t, blobovniczaID, *fetchedBlobovniczaID)
+	require.Equal(t, &blobovniczaID, fetchedBlobovniczaID)
 }

--- a/pkg/local_object_storage/metabase/v2/util.go
+++ b/pkg/local_object_storage/metabase/v2/util.go
@@ -27,6 +27,7 @@ var (
 	payloadHashPostfix  = "_payloadhash"
 	rootPostfix         = "_root"
 	parentPostfix       = "_parent"
+	splitPostfix        = "_splitid"
 
 	userAttributePostfix = "_attr_"
 )
@@ -76,9 +77,14 @@ func ownerBucketName(cid *container.ID) []byte {
 	return []byte(cid.String() + ownerPostfix)
 }
 
-// parentBucketNAme returns <CID>_parent.
+// parentBucketName returns <CID>_parent.
 func parentBucketName(cid *container.ID) []byte {
 	return []byte(cid.String() + parentPostfix)
+}
+
+// splitBucketName returns <CID>_splitid.
+func splitBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + splitPostfix)
 }
 
 // addressKey returns key for K-V tables when key is a whole address.

--- a/pkg/local_object_storage/metabase/v2/util.go
+++ b/pkg/local_object_storage/metabase/v2/util.go
@@ -1,0 +1,92 @@
+package meta
+
+import (
+	"strings"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+)
+
+/*
+We might increase performance by not using string representation of
+identities and addresses. String representation require base58 encoding that
+slows execution. Instead we can try to marshal these structures directly into
+bytes. Check it later.
+*/
+
+var (
+	graveyardBucketName = []byte("Graveyard")
+	toMoveItBucketName  = []byte("ToMoveIt")
+
+	zeroValue = []byte{0xFF}
+
+	smallPostfix        = "_small"
+	storageGroupPostfix = "_SG"
+	tombstonePostfix    = "_TS"
+	ownerPostfix        = "_ownerid"
+	payloadHashPostfix  = "_payloadhash"
+	rootPostfix         = "_root"
+	parentPostfix       = "_parent"
+
+	userAttributePostfix = "_attr_"
+)
+
+// primaryBucketName returns <CID>.
+func primaryBucketName(cid *container.ID) []byte {
+	return []byte(cid.String())
+}
+
+// tombstoneBucketName returns <CID>_TS.
+func tombstoneBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + tombstonePostfix)
+}
+
+// storageGroupBucketName returns <CID>_SG.
+func storageGroupBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + storageGroupPostfix)
+}
+
+// smallBucketName returns <CID>_small.
+func smallBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + smallPostfix) // consider caching output values
+}
+
+// attributeBucketName returns <CID>_attr_<attributeKey>.
+func attributeBucketName(cid *container.ID, attributeKey string) []byte {
+	sb := strings.Builder{} // consider getting string builders from sync.Pool
+	sb.WriteString(cid.String())
+	sb.WriteString(userAttributePostfix)
+	sb.WriteString(attributeKey)
+
+	return []byte(sb.String())
+}
+
+// payloadHashBucketName returns <CID>_payloadhash.
+func payloadHashBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + payloadHashPostfix)
+}
+
+// rootBucketName returns <CID>_root.
+func rootBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + rootPostfix)
+}
+
+// ownerBucketName returns <CID>_ownerid.
+func ownerBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + ownerPostfix)
+}
+
+// parentBucketNAme returns <CID>_parent.
+func parentBucketName(cid *container.ID) []byte {
+	return []byte(cid.String() + parentPostfix)
+}
+
+// addressKey returns key for K-V tables when key is a whole address.
+func addressKey(addr *object.Address) []byte {
+	return []byte(addr.String())
+}
+
+// objectKey returns key for K-V tables when key is an object id.
+func objectKey(oid *object.ID) []byte {
+	return []byte(oid.String())
+}


### PR DESCRIPTION
- [x] Inhume
- [x] Put
- [x] Get
- [x] Exists
- [x] Select
- [x] ToMoveIt (plus Movable, plus DoNotMove)
- [x] IsSmall

Edit1: Couple more upcoming changes and it should be ready to merge:
- [x] Refactor exist check to run it from `meta.Select` method.
- [x] Make one `db.Update` in `meta.Put` instead of two (less wasted iops)
- [x] Fix getting headers of virtual objects
- [x] Support obejct ID search in `meta.Select`

There won't be `Delete` implementation since it was not implemented in original metabase and It takes a bit of time to implement index rebuilding routine accurately. 

There also won't be `splitID` support. It will be supported after #208 will be merged to master and then rebased in localstorage branch.