### PR TITLE
Fix missing error when getting a nonexistent eACL table

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -345,12 +345,6 @@ var getExtendedACLCmd = &cobra.Command{
 			return fmt.Errorf("rpc error: %w", err)
 		}
 
-		v := eaclTable.Version()
-		if v.Major() == 0 && v.Major() == 0 {
-			fmt.Println("extended ACL table is not set for this container")
-			return nil
-		}
-
 		if containerPathTo == "" {
 			prettyPrintEACL(eaclTable)
 			return nil


### PR DESCRIPTION
- return error from `EACL` method of morph client wrapper if eACL is not set for container;

- do not check eACL version in container CLI.