### PR TITLE
Set SplitID in children

### DIFF
--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -653,6 +653,11 @@ func printHeader(cmd *cobra.Command, obj *object.Object, filename string) error 
 		}
 		cmd.Printf("  %s=%s\n", attr.Key(), attr.Value())
 	}
+
+	if obj.SplitID() != nil {
+		cmd.Printf("SplitID: %s\n", obj.SplitID().String())
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b
-	github.com/nspcc-dev/neofs-api-go v1.20.3
+	github.com/nspcc-dev/neofs-api-go v1.20.3-0.20201126102634-2a94fdc5e709
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5hTjFRUDcc=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b h1:gk5bZgpWOehaDVKI5vBDkcjXTpRkKqcvIb1h/vHnBH4=
 github.com/nspcc-dev/neo-go v0.91.1-pre.0.20201030072836-71216865717b/go.mod h1:9s7LNp2lMgf0caH2t0sam4+WT2SIauXozwP0AdBqnEo=
-github.com/nspcc-dev/neofs-api-go v1.20.3 h1:V8iqyAaX1WJFiAO79enjETveZfwForBoti6MwdY/Bf8=
-github.com/nspcc-dev/neofs-api-go v1.20.3/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.20.3-0.20201126102634-2a94fdc5e709 h1:t5kNkoT/SR6483xA72L3yeOxcxXNmqDE9cZtpqEFTOM=
+github.com/nspcc-dev/neofs-api-go v1.20.3-0.20201126102634-2a94fdc5e709/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/pkg/local_object_storage/metabase/db.go
+++ b/pkg/local_object_storage/metabase/db.go
@@ -63,8 +63,6 @@ func stringEqualMatcher(key, objVal, filterVal string) bool {
 	switch key {
 	default:
 		return objVal == filterVal
-	case v2object.FilterPropertyChildfree:
-		return (filterVal == v2object.BooleanPropertyValueTrue) == (objVal == v2object.BooleanPropertyValueTrue)
 	case v2object.FilterPropertyPhy, v2object.FilterPropertyRoot:
 		return true
 	}

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
-	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/util/test"
 	"github.com/pkg/errors"
@@ -174,24 +173,7 @@ func TestDB_SelectProperties(t *testing.T) {
 	lnk.SetID(testOID())
 	lnk.SetChildren(testOID())
 
-	lnkAddr := lnk.Object().Address()
-
 	require.NoError(t, db.Put(lnk.Object()))
-
-	// childfree filter
-	fs = fs[:0]
-	fs.AddChildfreeFilter()
-	testSelect(t, db, fs, childAddr, parAddr)
-
-	// non-childfree filter
-	fs = fs[:0]
-	fs.AddNonChildfreeFilter()
-	testSelect(t, db, fs, lnkAddr)
-
-	// childfree filter (with random false value)
-	fs = fs[:0]
-	fs.AddFilter(v2object.FilterPropertyChildfree, "some false value", objectSDK.MatchStringEqual)
-	testSelect(t, db, fs, lnkAddr)
 }
 
 func TestDB_Path(t *testing.T) {

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -96,12 +96,7 @@ func addressKey(addr *objectSDK.Address) []byte {
 func objectIndices(obj *object.Object, parent bool) []bucketItem {
 	as := obj.Attributes()
 
-	res := make([]bucketItem, 0, 7+len(as)) // 7 predefined buckets and object attributes
-
-	childfreeVal := v2object.BooleanPropertyValueTrue
-	if len(obj.Children()) > 0 {
-		childfreeVal = ""
-	}
+	res := make([]bucketItem, 0, 6+len(as)) // 6 predefined buckets and object attributes
 
 	res = append(res,
 		bucketItem{
@@ -115,10 +110,6 @@ func objectIndices(obj *object.Object, parent bool) []bucketItem {
 		bucketItem{
 			key: v2object.FilterHeaderOwnerID,
 			val: obj.OwnerID().String(),
-		},
-		bucketItem{
-			key: v2object.FilterPropertyChildfree,
-			val: childfreeVal,
 		},
 		bucketItem{
 			key: v2object.FilterHeaderParent,

--- a/pkg/services/object/search/query/v1/keys.go
+++ b/pkg/services/object/search/query/v1/keys.go
@@ -8,24 +8,24 @@ import (
 
 // FIXME: this is a temporary solution for object fields filters
 
+// fixme: remove it, it is broken now
 func NewRightChildQuery(par *object.ID) query.Query {
 	q := &Query{
 		filters: make(object.SearchFilters, 0, 2),
 	}
 
 	q.filters.AddFilter(v2object.FilterHeaderParent, idValue(par), object.MatchStringEqual)
-	q.filters.AddFilter(v2object.FilterPropertyChildfree, v2object.BooleanPropertyValueTrue, object.MatchStringEqual)
 
 	return q
 }
 
+// fixme: remove it, it is broken now
 func NewLinkingQuery(par *object.ID) query.Query {
 	q := &Query{
 		filters: make(object.SearchFilters, 0, 2),
 	}
 
 	q.filters.AddFilter(v2object.FilterHeaderParent, idValue(par), object.MatchStringEqual)
-	q.filters.AddFilter(v2object.FilterPropertyChildfree, v2object.BooleanPropertyValueFalse, object.MatchStringEqual)
 
 	return q
 }


### PR DESCRIPTION
This PR breaks object related operations for split objects in master branch. For `v0.12.x`  I created a branch, where we can make urgent fixes: https://github.com/nspcc-dev/neofs-node/tree/support/v0.12 