### PR TITLE
Add some changes to split-transformation

### DIFF
--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -215,10 +215,8 @@ func writeHashes(hashers []*payloadChecksumHasher) {
 }
 
 func (s *payloadSizeLimiter) initializeLinking() {
-	id := s.current.ParentID()
-
 	s.current = fromObject(s.current)
-	s.current.SetParentID(id)
+	s.current.SetParent(s.parent.Object().SDK())
 	s.current.SetChildren(s.previous...)
 	s.current.SetSplitID(s.splitID)
 }


### PR DESCRIPTION
From now:
- attributes are not inherited in generated objects during split-transformation

- linking object carries full parent header