### PR TITLE
blobovnicza: Fix initializing dimensional buckets

### DIFF
--- a/pkg/local_object_storage/blobovnicza/iterate.go
+++ b/pkg/local_object_storage/blobovnicza/iterate.go
@@ -26,7 +26,9 @@ func (b *Blobovnicza) iterateBucketKeys(f func(uint64, uint64, []byte) (bool, er
 }
 
 func (b *Blobovnicza) iterateBounds(f func(uint64, uint64) (bool, error)) error {
-	for upper := firstBucketBound; upper <= max(b.objSizeLimit, firstBucketBound); upper *= 2 {
+	objLimitBound := upperPowerOfTwo(b.objSizeLimit)
+
+	for upper := firstBucketBound; upper <= max(objLimitBound, firstBucketBound); upper *= 2 {
 		var lower uint64
 
 		if upper == firstBucketBound {

--- a/pkg/local_object_storage/blobovnicza/sizes.go
+++ b/pkg/local_object_storage/blobovnicza/sizes.go
@@ -31,12 +31,14 @@ func bucketKeyFromBounds(upperBound uint64) []byte {
 }
 
 func bucketForSize(sz uint64) []byte {
-	var upperBound uint64
+	return bucketKeyFromBounds(upperPowerOfTwo(sz))
+}
 
-	for upperBound = firstBucketBound; upperBound < sz; upperBound *= 2 {
+func upperPowerOfTwo(v uint64) (upperBound uint64) {
+	for upperBound = firstBucketBound; upperBound < v; upperBound *= 2 {
 	}
 
-	return bucketKeyFromBounds(upperBound)
+	return
 }
 
 func (b *Blobovnicza) incSize(sz uint64) {


### PR DESCRIPTION
In previous implementation Blobovnicza could incorrectly initialize
dimensional buckets: if SmallSizeLimit = 2 ^ X + Y && Y < 2 ^ X, then
largest dimensional bucket was [2 ^ (X - 1) : 2 ^ X]. This was caused by an
incorrect condition for stopping the iterator along the dimensional
boundaries.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>