### PR TITLE
service/policer: Don't shrink node list at unknown error

### DIFF
--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -85,6 +85,8 @@ func (p *Policer) processNodes(ctx context.Context, addr *object.Address, nodes 
 					log.Error("could not receive object header",
 						zap.String("error", err.Error()),
 					)
+
+					continue
 				}
 			} else {
 				shortage--


### PR DESCRIPTION
Every unknown error must not decrease shortage counter and must not exclude faulty node from the node list, because this list will be used later for replication.