### PR TITLE
metabase: Add prefix to Graveyard and ToMoveIt bucket names

### DIFF
--- a/pkg/local_object_storage/metabase/containers.go
+++ b/pkg/local_object_storage/metabase/containers.go
@@ -39,7 +39,7 @@ func (db *DB) containers(tx *bbolt.Tx) ([]*container.ID, error) {
 func parseContainerID(name []byte) (*container.ID, error) {
 	strName := string(name)
 
-	if strings.Contains(strName, "_") {
+	if strings.Contains(strName, invalidBase58String) {
 		return nil, nil
 	}
 

--- a/pkg/local_object_storage/metabase/containers_test.go
+++ b/pkg/local_object_storage/metabase/containers_test.go
@@ -3,6 +3,7 @@ package meta_test
 import (
 	"testing"
 
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,4 +34,36 @@ func TestDB_Containers(t *testing.T) {
 
 		cids[cid.String()] = 1
 	}
+
+	t.Run("Inhume", func(t *testing.T) {
+		obj := generateRawObject(t).Object()
+
+		require.NoError(t, putBig(db, obj))
+
+		cnrs, err := db.Containers()
+		require.NoError(t, err)
+		require.Contains(t, cnrs, obj.ContainerID())
+
+		require.NoError(t, meta.Inhume(db, obj.Address(), generateAddress()))
+
+		cnrs, err = db.Containers()
+		require.NoError(t, err)
+		require.Contains(t, cnrs, obj.ContainerID())
+	})
+
+	t.Run("ToMoveIt", func(t *testing.T) {
+		obj := generateRawObject(t).Object()
+
+		require.NoError(t, putBig(db, obj))
+
+		cnrs, err := db.Containers()
+		require.NoError(t, err)
+		require.Contains(t, cnrs, obj.ContainerID())
+
+		require.NoError(t, meta.ToMoveIt(db, obj.Address()))
+
+		cnrs, err = db.Containers()
+		require.NoError(t, err)
+		require.Contains(t, cnrs, obj.ContainerID())
+	})
 }

--- a/pkg/local_object_storage/metabase/util.go
+++ b/pkg/local_object_storage/metabase/util.go
@@ -14,22 +14,24 @@ slows execution. Instead we can try to marshal these structures directly into
 bytes. Check it later.
 */
 
+const invalidBase58String = "_"
+
 var (
-	graveyardBucketName = []byte("Graveyard")
-	toMoveItBucketName  = []byte("ToMoveIt")
+	graveyardBucketName = []byte(invalidBase58String + "Graveyard")
+	toMoveItBucketName  = []byte(invalidBase58String + "ToMoveIt")
 
 	zeroValue = []byte{0xFF}
 
-	smallPostfix        = "_small"
-	storageGroupPostfix = "_SG"
-	tombstonePostfix    = "_TS"
-	ownerPostfix        = "_ownerid"
-	payloadHashPostfix  = "_payloadhash"
-	rootPostfix         = "_root"
-	parentPostfix       = "_parent"
-	splitPostfix        = "_splitid"
+	smallPostfix        = invalidBase58String + "small"
+	storageGroupPostfix = invalidBase58String + "SG"
+	tombstonePostfix    = invalidBase58String + "TS"
+	ownerPostfix        = invalidBase58String + "ownerid"
+	payloadHashPostfix  = invalidBase58String + "payloadhash"
+	rootPostfix         = invalidBase58String + "root"
+	parentPostfix       = invalidBase58String + "parent"
+	splitPostfix        = invalidBase58String + "splitid"
 
-	userAttributePostfix = "_attr_"
+	userAttributePostfix = invalidBase58String + "attr_"
 
 	splitInfoError *object.SplitInfoError // for errors.As comparisons
 )


### PR DESCRIPTION
In previous implementation DB.Containers method could return an error about
invalid container ID string format. This could happen if some of top-level
buckets had name w/o "_" substring.

Relates #253.