### PR TITLE
object/eacl: Fix processing of non-address header in HASH/DELETE

### DIFF
--- a/pkg/services/object/acl/eacl/v2/headers.go
+++ b/pkg/services/object/acl/eacl/v2/headers.go
@@ -95,16 +95,13 @@ func (h *headerSource) objectHeaders() ([]eacl.Header, bool) {
 		switch req := m.req.(type) {
 		case *objectV2.GetRequest:
 			return h.localObjectHeaders(h.addr)
-		case *objectV2.DeleteRequest:
-			hs, _ := h.localObjectHeaders(h.addr)
-			return hs, true
 		case *objectV2.HeadRequest:
 			return h.localObjectHeaders(h.addr)
-		case *objectV2.GetRangeRequest:
+		case
+			*objectV2.GetRangeRequest,
+			*objectV2.GetRangeHashRequest,
+			*objectV2.DeleteRequest:
 			return addressHeaders(objectSDK.NewAddressFromV2(h.addr)), true
-		case *objectV2.GetRangeHashRequest:
-			hs, _ := h.localObjectHeaders(h.addr)
-			return hs, true
 		case *objectV2.PutRequest:
 			if v, ok := req.GetBody().GetObjectPart().(*objectV2.PutObjectPartInit); ok {
 				oV2 := new(objectV2.Object)

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -78,6 +78,7 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		),
 		client.WithTTL(1), // FIXME: use constant
 		client.WithBearer(t.bearer),
+		client.WithSession(t.token),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "(%T) could not put object to %s", t, addr)

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -46,9 +46,7 @@ func (p *Streamer) initTarget(prm *PutInitPrm) error {
 		return errors.Wrapf(err, "(%T) could not prepare put parameters", p)
 	}
 
-	sToken := prm.common.SessionToken()
-
-	if sToken == nil {
+	if prm.hdr.Signature() != nil {
 		// prepare untrusted-Put object target
 		p.target = &validatingTarget{
 			nextTarget: p.newCommonTarget(prm),
@@ -57,6 +55,8 @@ func (p *Streamer) initTarget(prm *PutInitPrm) error {
 
 		return nil
 	}
+
+	sToken := prm.common.SessionToken()
 
 	// prepare trusted-Put object target
 


### PR DESCRIPTION
Session token loss during PUT is also fixed.

Closes #253.