### PR TITLE
Implement PoR audit check

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -93,4 +93,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 
 	cfg.SetDefault("audit.task.exec_pool_size", 10)
 	cfg.SetDefault("audit.task.queue_capacity", 100)
+	cfg.SetDefault("audit.timeout.get", "5s")
+	cfg.SetDefault("audit.timeout.head", "5s")
+	cfg.SetDefault("audit.timeout.rangehash", "5s")
 }

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -216,7 +216,13 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 		return nil, err
 	}
 
-	clientCache := newClientCache(server.key)
+	clientCache := newClientCache(&clientCacheParams{
+		Log:          log,
+		Key:          server.key,
+		SGTimeout:    cfg.GetDuration("audit.timeout.get"),
+		HeadTimeout:  cfg.GetDuration("audit.timeout.head"),
+		RangeTimeout: cfg.GetDuration("audit.timeout.rangehash"),
+	})
 
 	auditTaskManager := audittask.New(
 		audittask.WithQueueCapacity(cfg.GetUint32("audit.task.queue_capacity")),

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -90,7 +90,8 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 			WithContainerID(containers[i]).
 			WithStorageGroupList(storageGroups).
 			WithContainerStructure(cnr).
-			WithContainerNodes(nodes)
+			WithContainerNodes(nodes).
+			WithNetworkMap(nm)
 
 		if err := ap.taskManager.PushTask(auditTask); err != nil {
 			ap.log.Error("could not push audit task",

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -113,9 +113,11 @@ func (ap *Processor) findStorageGroups(cid *container.ID, shuffled netmap.Nodes)
 			zap.Int("total_tries", ln),
 		)
 
-		addr, err := ipAddr(shuffled[i].Address())
+		addr, err := network.IPAddrFromMultiaddr(shuffled[i].Address())
 		if err != nil {
 			log.Warn("can't parse remote address", zap.String("error", err.Error()))
+
+			continue
 		}
 
 		cli, err := ap.clientCache.Get(addr)
@@ -145,13 +147,4 @@ func (ap *Processor) findStorageGroups(cid *container.ID, shuffled netmap.Nodes)
 	}
 
 	return sg
-}
-
-func ipAddr(multiaddr string) (string, error) {
-	address, err := network.AddressFromString(multiaddr)
-	if err != nil {
-		return "", err
-	}
-
-	return address.IPAddrString()
 }

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -90,6 +90,7 @@ func (c *ClientCache) GetSG(task *audit.Task, id *object.ID) (*storagegroup.Stor
 
 		cctx, cancel := context.WithTimeout(task.AuditContext(), c.sgTimeout)
 		obj, err := cli.GetObject(cctx, getParams)
+
 		cancel()
 
 		if err != nil {
@@ -135,6 +136,7 @@ func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.
 
 	cctx, cancel := context.WithTimeout(task.AuditContext(), c.headTimeout)
 	head, err := cli.GetObjectHeader(cctx, headParams, client.WithTTL(1))
+
 	cancel()
 
 	if err != nil {

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -1,25 +1,48 @@
 package innerring
 
 import (
+	"context"
 	"crypto/ecdsa"
+	"fmt"
+	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/storagegroup"
+	coreObject "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/audit"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
+	"go.uber.org/zap"
 )
 
-type ClientCache struct {
-	cache *cache.ClientCache
-	key   *ecdsa.PrivateKey
-}
+type (
+	ClientCache struct {
+		log   *zap.Logger
+		cache *cache.ClientCache
+		key   *ecdsa.PrivateKey
 
-func newClientCache(key *ecdsa.PrivateKey) *ClientCache {
+		sgTimeout, headTimeout, rangeTimeout time.Duration
+	}
+
+	clientCacheParams struct {
+		Log *zap.Logger
+		Key *ecdsa.PrivateKey
+
+		SGTimeout, HeadTimeout, RangeTimeout time.Duration
+	}
+)
+
+func newClientCache(p *clientCacheParams) *ClientCache {
 	return &ClientCache{
-		cache: cache.NewSDKClientCache(),
-		key:   key,
+		log:          p.Log,
+		cache:        cache.NewSDKClientCache(),
+		key:          p.Key,
+		sgTimeout:    p.SGTimeout,
+		headTimeout:  p.HeadTimeout,
+		rangeTimeout: p.RangeTimeout,
 	}
 }
 
@@ -30,12 +53,95 @@ func (c *ClientCache) Get(address string, opts ...client.Option) (*client.Client
 // GetSG polls the container from audit task to get the object by id.
 // Returns storage groups structure from received object.
 func (c *ClientCache) GetSG(task *audit.Task, id *object.ID) (*storagegroup.StorageGroup, error) {
-	panic("implement me")
+	nodes, err := placement.BuildObjectPlacement( // shuffle nodes
+		task.NetworkMap(),
+		task.ContainerNodes(),
+		id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("can't build object placement: %w", err)
+	}
+
+	sgAddress := new(object.Address)
+	sgAddress.SetContainerID(task.ContainerID())
+	sgAddress.SetObjectID(id)
+
+	getParams := new(client.GetObjectParams)
+	getParams.WithAddress(sgAddress)
+
+	for _, node := range placement.FlattenNodes(nodes) {
+		addr, err := network.IPAddrFromMultiaddr(node.Address())
+		if err != nil {
+			c.log.Warn("can't parse remote address",
+				zap.String("address", node.Address()),
+				zap.String("error", err.Error()))
+
+			continue
+		}
+
+		cli, err := c.Get(addr)
+		if err != nil {
+			c.log.Warn("can't setup remote connection",
+				zap.String("address", addr),
+				zap.String("error", err.Error()))
+
+			continue
+		}
+
+		cctx, cancel := context.WithTimeout(task.AuditContext(), c.sgTimeout)
+		obj, err := cli.GetObject(cctx, getParams)
+		cancel()
+
+		if err != nil {
+			c.log.Warn("can't get storage group object",
+				zap.String("error", err.Error()))
+
+			continue
+		}
+
+		sg := storagegroup.New()
+
+		err = sg.Unmarshal(obj.Payload())
+		if err != nil {
+			return nil, fmt.Errorf("can't parse storage group payload: %w", err)
+		}
+
+		return sg, nil
+	}
+
+	return nil, coreObject.ErrNotFound
 }
 
 // GetHeader requests node from the container under audit to return object header by id.
 func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.ID) (*object.Object, error) {
-	panic("implement me")
+	objAddress := new(object.Address)
+	objAddress.SetContainerID(task.ContainerID())
+	objAddress.SetObjectID(id)
+
+	headParams := new(client.ObjectHeaderParams)
+	headParams.WithRawFlag(true)
+	headParams.WithMainFields()
+	headParams.WithAddress(objAddress)
+
+	addr, err := network.IPAddrFromMultiaddr(node.Address())
+	if err != nil {
+		return nil, fmt.Errorf("can't parse remote address %s: %w", node.Address(), err)
+	}
+
+	cli, err := c.Get(addr)
+	if err != nil {
+		return nil, fmt.Errorf("can't setup remote connection with %s: %w", addr, err)
+	}
+
+	cctx, cancel := context.WithTimeout(task.AuditContext(), c.headTimeout)
+	head, err := cli.GetObjectHeader(cctx, headParams, client.WithTTL(1))
+	cancel()
+
+	if err != nil {
+		return nil, fmt.Errorf("object head error: %w", err)
+	}
+
+	return head, nil
 }
 
 // GetRangeHash requests node from the container under audit to return Tillich-Zemor hash of the

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -95,3 +95,13 @@ func multiaddrStringFromHostAddr(host string) (string, error) {
 func IsLocalAddress(src LocalAddressSource, addr *Address) bool {
 	return src.LocalAddress().ma.Equal(addr.ma)
 }
+
+// IPAddrFromMultiaddr converts "/dns4/localhost/tcp/8080" to "192.168.0.1:8080".
+func IPAddrFromMultiaddr(multiaddr string) (string, error) {
+	address, err := AddressFromString(multiaddr)
+	if err != nil {
+		return "", err
+	}
+
+	return address.IPAddrString()
+}

--- a/pkg/services/audit/auditor/context.go
+++ b/pkg/services/audit/auditor/context.go
@@ -17,6 +17,12 @@ type Context struct {
 	task *audit.Task
 
 	report *audit.Report
+
+	// consider adding mutex to access caches
+
+	sgMembersCache map[int][]*object.ID
+
+	placementCache map[string][]netmap.Nodes
 }
 
 // ContextPrm groups components required to conduct data audit checks.
@@ -76,6 +82,10 @@ func (c *Context) containerID() *container.ID {
 
 func (c *Context) init() {
 	c.report = audit.NewReport(c.containerID())
+
+	c.sgMembersCache = make(map[int][]*object.ID)
+
+	c.placementCache = make(map[string][]netmap.Nodes)
 
 	c.log = c.log.With(
 		zap.Stringer("container ID", c.task.ContainerID()),

--- a/pkg/services/audit/auditor/exec.go
+++ b/pkg/services/audit/auditor/exec.go
@@ -34,10 +34,6 @@ func (c *Context) Execute() {
 	c.writeReport()
 }
 
-func (c *Context) executePoR() {
-	// TODO: implement me
-}
-
 func (c *Context) executePoP() {
 	// TODO: implement me
 }

--- a/pkg/services/audit/auditor/por.go
+++ b/pkg/services/audit/auditor/por.go
@@ -1,0 +1,103 @@
+package auditor
+
+import (
+	"bytes"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
+	"github.com/nspcc-dev/tzhash/tz"
+	"go.uber.org/zap"
+)
+
+func (c *Context) executePoR() {
+	for i, sg := range c.task.StorageGroupList() {
+		c.checkStorageGroupPoR(i, sg) // consider parallel it
+	}
+}
+
+func (c *Context) checkStorageGroupPoR(ind int, sg *object.ID) {
+	storageGroup, err := c.cnrCom.GetSG(c.task, sg) // get storage group
+	if err != nil {
+		c.log.Warn("can't get storage group",
+			zap.Stringer("sgid", sg),
+			zap.String("error", err.Error()))
+
+		return
+	}
+
+	members := storageGroup.Members()
+	c.sgMembersCache[ind] = members
+
+	var (
+		tzHash    []byte
+		totalSize uint64
+	)
+
+	for i := range members {
+		objectPlacement, err := placement.BuildObjectPlacement(
+			c.task.NetworkMap(),
+			c.task.ContainerNodes(),
+			members[i],
+		)
+		if err != nil {
+			c.log.Info("can't build placement for storage group member",
+				zap.Stringer("sg", sg),
+				zap.Stringer("member_id", members[i]),
+			)
+
+			continue
+		}
+
+		c.placementCache[members[i].String()] = objectPlacement
+
+		for _, node := range placement.FlattenNodes(objectPlacement) {
+			hdr, err := c.cnrCom.GetHeader(c.task, node, members[i])
+			if err != nil {
+				c.log.Debug("can't head object",
+					zap.String("remote_node", node.Address()),
+					zap.Stringer("oid", members[i]))
+
+				continue
+			}
+
+			if len(tzHash) == 0 {
+				tzHash = hdr.PayloadHomomorphicHash().Sum()
+			} else {
+				tzHash, err = tz.Concat([][]byte{
+					tzHash,
+					hdr.PayloadHomomorphicHash().Sum(),
+				})
+				if err != nil {
+					c.log.Debug("can't concatenate tz hash",
+						zap.Stringer("oid", members[i]),
+						zap.String("error", err.Error()))
+
+					break
+				}
+			}
+
+			totalSize += hdr.PayloadSize()
+
+			break
+		}
+	}
+
+	sizeCheck := storageGroup.ValidationDataSize() == totalSize
+	tzCheck := bytes.Equal(tzHash, storageGroup.ValidationDataHash().Sum())
+
+	if sizeCheck && tzCheck {
+		c.report.PassedPoR(sg) // write report
+	} else {
+		if !sizeCheck {
+			c.log.Debug("storage group size check failed",
+				zap.Uint64("expected", storageGroup.ValidationDataSize()),
+				zap.Uint64("got", totalSize))
+		}
+
+		if !tzCheck {
+			c.log.Debug("storage group tz hash check failed")
+		}
+
+		c.report.FailedPoR(sg) // write report
+	}
+}

--- a/pkg/services/audit/report.go
+++ b/pkg/services/audit/report.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/audit"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 )
 
 // Report tracks the progress of auditing container data.
@@ -35,4 +36,14 @@ func (r *Report) Result() *audit.Result {
 // Complete completes audit report.
 func (r *Report) Complete() {
 	r.res.SetComplete(true)
+}
+
+// PassedPoR updates list of passed storage groups.
+func (r *Report) PassedPoR(sg *object.ID) {
+	r.res.SetPassSG(append(r.res.PassSG(), sg))
+}
+
+// FailedPoR updates list of failed storage groups.
+func (r *Report) FailedPoR(sg *object.ID) {
+	r.res.SetFailSG(append(r.res.FailSG(), sg))
 }

--- a/pkg/services/audit/task.go
+++ b/pkg/services/audit/task.go
@@ -18,6 +18,8 @@ type Task struct {
 
 	cnr *container.Container
 
+	nm *netmap.Netmap
+
 	cnrNodes netmap.ContainerNodes
 
 	sgList []*object.ID
@@ -83,6 +85,20 @@ func (t *Task) ContainerStructure() *container.Container {
 func (t *Task) WithContainerNodes(cnrNodes netmap.ContainerNodes) *Task {
 	if t != nil {
 		t.cnrNodes = cnrNodes
+	}
+
+	return t
+}
+
+// NetworkMap returns network map of audit epoch.
+func (t *Task) NetworkMap() *netmap.Netmap {
+	return t.nm
+}
+
+// WithNetworkMap sets network map of audit epoch.
+func (t *Task) WithNetworkMap(nm *netmap.Netmap) *Task {
+	if t != nil {
+		t.nm = nm
 	}
 
 	return t

--- a/pkg/services/object/acl/basic_helper.go
+++ b/pkg/services/object/acl/basic_helper.go
@@ -125,7 +125,7 @@ func (a basicACLHelper) SystemAllowed(op eacl.Operation) bool {
 // InnerRing nodes, as part of System group.
 func (a basicACLHelper) InnerRingAllowed(op eacl.Operation) bool {
 	switch op {
-	case eacl.OperationSearch, eacl.OperationRangeHash, eacl.OperationHead:
+	case eacl.OperationSearch, eacl.OperationRangeHash, eacl.OperationHead, eacl.OperationGet:
 		return true
 	default:
 		if n, ok := order[op]; ok {

--- a/pkg/services/object/get/v2/util.go
+++ b/pkg/services/object/get/v2/util.go
@@ -197,6 +197,8 @@ func toShortObjectHeader(hdr *object.Object) objectV2.GetHeaderPart {
 	sh.SetPayloadLength(hdrV2.GetPayloadLength())
 	sh.SetVersion(hdrV2.GetVersion())
 	sh.SetObjectType(hdrV2.GetObjectType())
+	sh.SetHomomorphicHash(hdrV2.GetHomomorphicHash())
+	sh.SetPayloadHash(hdrV2.GetPayloadHash())
 
 	return sh
 }

--- a/pkg/services/object_manager/placement/netmap.go
+++ b/pkg/services/object_manager/placement/netmap.go
@@ -37,19 +37,21 @@ func (b *netMapBuilder) BuildPlacement(a *object.Address, p *netmapSDK.Placement
 		return nil, errors.Wrap(err, "could not get network map")
 	}
 
-	aV2 := a.ToV2()
-
-	cn, err := nm.GetContainerNodes(p, aV2.GetContainerID().GetValue())
+	cn, err := nm.GetContainerNodes(p, a.ContainerID().ToV2().GetValue())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get container nodes")
 	}
 
-	oid := aV2.GetObjectID()
-	if oid == nil {
-		return cn.Replicas(), nil
+	return BuildObjectPlacement(nm, cn, a.ObjectID())
+}
+
+func BuildObjectPlacement(nm *netmapSDK.Netmap, cnrNodes netmapSDK.ContainerNodes, id *object.ID) ([]netmapSDK.Nodes, error) {
+	objectID := id.ToV2()
+	if objectID == nil {
+		return cnrNodes.Replicas(), nil
 	}
 
-	on, err := nm.GetPlacementVectors(cn, oid.GetValue())
+	on, err := nm.GetPlacementVectors(cnrNodes, objectID.GetValue())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get placement vectors for object")
 	}

--- a/pkg/services/object_manager/placement/netmap.go
+++ b/pkg/services/object_manager/placement/netmap.go
@@ -58,3 +58,13 @@ func BuildObjectPlacement(nm *netmapSDK.Netmap, cnrNodes netmapSDK.ContainerNode
 
 	return on, nil
 }
+
+// FlattenNodes appends each row to the flat list.
+func FlattenNodes(ns []netmapSDK.Nodes) netmapSDK.Nodes {
+	result := make(netmapSDK.Nodes, 0, len(ns))
+	for i := range ns {
+		result = append(result, ns[i]...)
+	}
+
+	return result
+}


### PR DESCRIPTION
This PR implements PoR audit check (closes #256) in inner ring node and:
- fixes Basic ACL access for inner ring nodes to get objects,
- fixes bug when `object.Head` did not fill new fields of short header structure.