### PR TITLE
Cache size and tzHash of head responses in PoR

### DIFF
--- a/pkg/services/audit/auditor/por.go
+++ b/pkg/services/audit/auditor/por.go
@@ -54,6 +54,9 @@ func (c *Context) checkStorageGroupPoR(ind int, sg *object.ID) {
 				continue
 			}
 
+			// update cache for PoR and PDP audit checks
+			c.updateHeadResponses(hdr)
+
 			if len(tzHash) == 0 {
 				tzHash = hdr.PayloadHomomorphicHash().Sum()
 			} else {


### PR DESCRIPTION
Size is reused in PoP to exclude very small objects from PDP coverage.
TZHash is reused in PDP to make final hash comparison.