### PR TITLE
Fix status value in update peer state invocation

### DIFF
--- a/pkg/innerring/invoke/netmap.go
+++ b/pkg/innerring/invoke/netmap.go
@@ -76,7 +76,7 @@ func UpdatePeerState(cli *client.Client, con util.Uint160, args *UpdatePeerArgs)
 	}
 
 	return cli.Invoke(con, extraFee, updatePeerStateMethod,
-		int64(args.Status),
+		int64(args.Status.ToV2()),
 		args.Key.Bytes(),
 	)
 }


### PR DESCRIPTION
We can't use enum values from SDK library directly, they can be different from API specification. Therefore we need to convert them into protocol level format.