### PR TITLE
Use list of NEO endpoitns in neofs-node config

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -361,15 +361,16 @@ func initViper(path string) *viper.Viper {
 }
 
 func defaultConfiguration(v *viper.Viper) {
-	// fixme: all hardcoded private keys must be removed
-	v.SetDefault(cfgNodeKey, "Kwk6k2eC3L3QuPvD8aiaNyoSXgQ2YL1bwS5CP1oKoA9waeAze97s")
-	v.SetDefault(cfgBootstrapAddress, "") // address to bootstrap with
+	v.SetDefault(cfgNodeKey, "")          // node key
+	v.SetDefault(cfgBootstrapAddress, "") // announced address of the node
 
 	v.SetDefault(cfgMorphRPCAddress, []string{})
 	v.SetDefault(cfgMorphNotifyRPCAddress, []string{})
 	v.SetDefault(cfgMorphNotifyDialTimeout, 5*time.Second)
+
 	v.SetDefault(cfgListenAddress, "127.0.0.1:50501") // listen address
 	v.SetDefault(cfgMaxMsgSize, 4<<20)                // transport msg limit 4 MiB
+	v.SetDefault(cfgReflectService, false)
 
 	v.SetDefault(cfgAccountingContract, "1aeefe1d0dfade49740fff779c02cd4a0538ffb1")
 	v.SetDefault(cfgAccountingFee, "1")
@@ -397,8 +398,10 @@ func defaultConfiguration(v *viper.Viper) {
 	v.SetDefault(cfgPolicerWorkScope, 100)
 	v.SetDefault(cfgPolicerExpRate, 10) // in %
 	v.SetDefault(cfgPolicerHeadTimeout, 5*time.Second)
+	v.SetDefault(cfgPolicerDialTimeout, 5*time.Second)
 
 	v.SetDefault(cfgReplicatorPutTimeout, 5*time.Second)
+	v.SetDefault(cfgReplicatorDialTimeout, 5*time.Second)
 
 	v.SetDefault(cfgReBootstrapEnabled, false) // in epochs
 	v.SetDefault(cfgReBootstrapInterval, 2)    // in epochs

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -63,10 +63,10 @@ const (
 	cfgReflectService = "grpc.enable_reflect_service"
 
 	// config keys for cfgMorph
-	cfgMorphRPCAddress = "morph.endpoint"
+	cfgMorphRPCAddress = "morph.rpc_endpoint"
 
-	cfgMorphNotifyRPCAddress  = "morph.notification.endpoint"
-	cfgMorphNotifyDialTimeout = "morph.notification.dial_timeout"
+	cfgMorphNotifyRPCAddress  = "morph.notification_endpoint"
+	cfgMorphNotifyDialTimeout = "morph.dial_timeout"
 
 	// config keys for cfgAccounting
 	cfgAccountingContract = "accounting.scripthash"

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -142,6 +142,10 @@ const (
 type cfg struct {
 	ctx context.Context
 
+	ctxCancel func()
+
+	internalErr chan error // channel for internal application errors at runtime
+
 	viper *viper.Viper
 
 	log *zap.Logger
@@ -290,12 +294,13 @@ func initCfg(path string) *cfg {
 	state := newNetworkState()
 
 	c := &cfg{
-		ctx:        context.Background(),
-		viper:      viperCfg,
-		log:        log,
-		wg:         new(sync.WaitGroup),
-		key:        key,
-		apiVersion: pkg.SDKVersion(),
+		ctx:         context.Background(),
+		internalErr: make(chan error),
+		viper:       viperCfg,
+		log:         log,
+		wg:          new(sync.WaitGroup),
+		key:         key,
+		apiVersion:  pkg.SDKVersion(),
 		cfgAccounting: cfgAccounting{
 			scriptHash: u160Accounting,
 			fee:        fixedn.Fixed8(viperCfg.GetInt(cfgAccountingFee)),

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -365,8 +365,8 @@ func defaultConfiguration(v *viper.Viper) {
 	v.SetDefault(cfgNodeKey, "Kwk6k2eC3L3QuPvD8aiaNyoSXgQ2YL1bwS5CP1oKoA9waeAze97s")
 	v.SetDefault(cfgBootstrapAddress, "") // address to bootstrap with
 
-	v.SetDefault(cfgMorphRPCAddress, "http://morph_chain.localtest.nspcc.ru:30333/")
-	v.SetDefault(cfgMorphNotifyRPCAddress, "ws://morph_chain:30333/ws")
+	v.SetDefault(cfgMorphRPCAddress, []string{})
+	v.SetDefault(cfgMorphNotifyRPCAddress, []string{})
 	v.SetDefault(cfgMorphNotifyDialTimeout, 5*time.Second)
 	v.SetDefault(cfgListenAddress, "127.0.0.1:50501") // listen address
 	v.SetDefault(cfgMaxMsgSize, 4<<20)                // transport msg limit 4 MiB

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -11,14 +12,44 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/subscriber"
+	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
+	"go.uber.org/zap"
 )
 
 const newEpochNotification = "NewEpoch"
 
+var (
+	errNoRPCEndpoints = errors.New("NEO RPC endpoints are not specified in config")
+	errNoWSEndpoints  = errors.New("websocket NEO listener endpoints are not specified in config")
+)
+
 func initMorphComponents(c *cfg) {
 	var err error
 
-	c.cfgMorph.client, err = client.New(c.key, c.viper.GetString(cfgMorphRPCAddress))
+	addresses := c.viper.GetStringSlice(cfgMorphRPCAddress)
+	if len(addresses) == 0 {
+		fatalOnErr(errNoRPCEndpoints)
+	}
+
+	crand := rand.New() // math/rand with cryptographic source
+	crand.Shuffle(len(addresses), func(i, j int) {
+		addresses[i], addresses[j] = addresses[j], addresses[i]
+	})
+
+	for i := range addresses {
+		c.cfgMorph.client, err = client.New(c.key, addresses[i])
+		if err == nil {
+			c.log.Info("neo RPC connection established",
+				zap.String("endpoint", addresses[i]))
+
+			break
+		}
+
+		c.log.Info("failed to establish neo RPC connection, trying another",
+			zap.String("endpoint", addresses[i]),
+			zap.String("error", err.Error()))
+	}
+
 	fatalOnErr(err)
 
 	staticClient, err := client.NewStatic(
@@ -39,11 +70,41 @@ func initMorphComponents(c *cfg) {
 }
 
 func listenMorphNotifications(c *cfg) {
-	subs, err := subscriber.New(c.ctx, &subscriber.Params{
-		Log:         c.log,
-		Endpoint:    c.viper.GetString(cfgMorphNotifyRPCAddress),
-		DialTimeout: c.viper.GetDuration(cfgMorphNotifyDialTimeout),
+	var (
+		err  error
+		subs subscriber.Subscriber
+	)
+
+	endpoints := c.viper.GetStringSlice(cfgMorphNotifyRPCAddress)
+	if len(endpoints) == 0 {
+		fatalOnErr(errNoWSEndpoints)
+	}
+
+	timeout := c.viper.GetDuration(cfgMorphNotifyDialTimeout)
+
+	crand := rand.New() // math/rand with cryptographic source
+	crand.Shuffle(len(endpoints), func(i, j int) {
+		endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
 	})
+
+	for i := range endpoints {
+		subs, err = subscriber.New(c.ctx, &subscriber.Params{
+			Log:         c.log,
+			Endpoint:    endpoints[i],
+			DialTimeout: timeout,
+		})
+		if err == nil {
+			c.log.Info("websocket neo event listener established",
+				zap.String("endpoint", endpoints[i]))
+
+			break
+		}
+
+		c.log.Info("failed to establish websocket neo event listener, trying another",
+			zap.String("endpoint", endpoints[i]),
+			zap.String("error", err.Error()))
+	}
+
 	fatalOnErr(err)
 
 	lis, err := event.NewListener(event.ListenerParams{

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -51,7 +52,9 @@ func listenMorphNotifications(c *cfg) {
 	})
 	fatalOnErr(err)
 
-	c.workers = append(c.workers, newWorkerFromFunc(lis.Listen))
+	c.workers = append(c.workers, newWorkerFromFunc(func(ctx context.Context) {
+		lis.ListenWithError(ctx, c.internalErr)
+	}))
 
 	setNetmapNotificationParser(c, newEpochNotification, netmapEvent.ParseNewEpoch)
 	registerNotificationHandlers(c.cfgNetmap.scriptHash, lis, c.cfgNetmap.parsers, c.cfgNetmap.subscribers)

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -205,7 +205,7 @@ func (s listener) parseAndHandle(notifyEvent *state.NotificationEvent) {
 	s.mtx.RUnlock()
 
 	if !ok {
-		log.Warn("event parser not set")
+		log.Debug("event parser not set")
 
 		return
 	}


### PR DESCRIPTION
Closes #157 

Configuration will look like this:

```yaml
morph:
  endpoint:
    - http://seed1.neo.org:20333
    - http://seed2.neo.org:20333
    - http://seed3.neo.org:20333
  notification:
    endpoint:
      - ws://seed1.neo.org:20333/ws
      - ws://seed-go.nspcc.ru:30333/ws
```

Storage node at startup randomly picks notification and client RPC endpoints. If endpoint is not available, then application picks another one. If all endpoints are down then application won't start.

If endpoint fails at runtime, then storage node shuts down. Later we can reinitialize app without downtime. 

Edit 1: new config looks like this now

```yaml
morph:
  rpc_endpoint:
    - http://seed1.neo.org:20333
    - http://seed2.neo.org:20333
    - http://seed3.neo.org:20333
  notification_endpoint:
    - ws://seed1.neo.org:20333/ws
    - ws://seed-go.nspcc.ru:30333/ws
  dial_timeout: 10s
```