### PR TITLE
morph/client: Return complete eACL signature from contract

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -425,10 +425,10 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 			for i := 0; i < awaitTimeout; i++ {
 				time.Sleep(1 * time.Second)
 
-				eaclSig, err := cli.GetEACLWithSignature(ctx, id, globalCallOptions()...)
+				table, err := cli.GetEACL(ctx, id, globalCallOptions()...)
 				if err == nil {
 					// compare binary values because EACL could have been set already
-					got, err := eaclSig.EACL().Marshal()
+					got, err := table.Marshal()
 					if err != nil {
 						continue
 					}

--- a/pkg/services/container/morph/executor.go
+++ b/pkg/services/container/morph/executor.go
@@ -111,14 +111,7 @@ func (s *morphExecutor) GetExtendedACL(ctx context.Context, body *container.GetE
 
 	res := new(container.GetExtendedACLResponseBody)
 	res.SetEACL(table.ToV2())
-
-	// Public key should be obtained by request sender, so we set up only
-	// the signature. Technically, node can make invocation to find container
-	// owner public key, but request sender cannot trust this info.
-	sig := new(refs.Signature)
-	sig.SetSign(signature)
-
-	res.SetSignature(sig)
+	res.SetSignature(signature.ToV2())
 
 	return res, nil
 }


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neofs-contract/pull/35