### PR TITLE
Do not return payload formatting error on regular objects

### DIFF
--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -158,7 +158,7 @@ func (v *FormatValidator) ValidateContent(o *Object) error {
 			}
 		}
 	default:
-		return errors.Errorf("(%T) unsupported object type %s", v, o.Type())
+		// ignore all other object types, they do not need payload formatting
 	}
 
 	return nil


### PR DESCRIPTION
Regular objects by definition have valid payload, so there should be no errors.

Related to #302