### PR TITLE
Fix storage node re-bootstrap approval

### DIFF
--- a/pkg/innerring/processors/netmap/process_peers.go
+++ b/pkg/innerring/processors/netmap/process_peers.go
@@ -56,7 +56,7 @@ func (np *Processor) processUpdatePeer(ev netmapEvent.UpdatePeer) {
 
 	// flag node to remove from local view, so it can be re-bootstrapped
 	// again before new epoch will tick
-	np.netmapSnapshot.flag(ev.PublicKey().String())
+	np.netmapSnapshot.flag(hex.EncodeToString(ev.PublicKey().Bytes()))
 
 	err := invoke.UpdatePeerState(np.morphClient, np.netmapContract,
 		&invoke.UpdatePeerArgs{


### PR DESCRIPTION
Netmap snapshot table caches bootstrap `AddPeer` txs so inner ring node does not produce redundant approval txs for bootstrapped nodes. However if node updates states to `Offline`, then such node should be flagged in snapshot table, so re-bootstrap will actually produce approval tx.

`ev.PublicKey.String()` returns uncompressed representation of the node's public key, while snapshot contains compressed values.  Therefore the node was not flagged and re-bootstrap tx was not approved by inner ring nodes.