### PR TITLE
engine: Make tests more predictable

### DIFF
--- a/pkg/local_object_storage/blobovnicza/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobovnicza/blobovnicza_test.go
@@ -1,8 +1,8 @@
 package blobovnicza
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -70,6 +70,8 @@ func testGet(t *testing.T, blz *Blobovnicza, addr *objectSDK.Address, expObj []b
 }
 
 func TestBlobovnicza(t *testing.T) {
+	rand.Seed(1024)
+
 	p := "./test_blz"
 
 	sizeLim := uint64(256 * 1 << 10) // 256KB

--- a/pkg/local_object_storage/blobstor/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza_test.go
@@ -1,9 +1,9 @@
 package blobstor
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"errors"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -55,6 +55,8 @@ func testObject(sz uint64) *object.Object {
 }
 
 func TestBlobovniczas(t *testing.T) {
+	rand.Seed(1024)
+
 	l := test.NewLogger(false)
 	p := "./test_blz"
 

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -1,8 +1,8 @@
 package meta_test
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
+	"math/rand"
 	"os"
 	"testing"
 

--- a/pkg/local_object_storage/shard/shard_test.go
+++ b/pkg/local_object_storage/shard/shard_test.go
@@ -1,8 +1,8 @@
 package shard_test
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
+	"math/rand"
 	"os"
 	"path"
 	"testing"


### PR DESCRIPTION
There is a codecov issue because objects are not placed in the engine the same way every unit test. Therefore sometimes there are more coverage, sometimes there are less. Seeded RNG should solve this issue for engine tests.