### PR TITLE
Use Alpine for cli instead of scratch

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -11,7 +11,7 @@ COPY . /src
 RUN make bin/neofs-cli
 
 # Executable image
-FROM scratch AS neofs-cli
+FROM alpine AS neofs-cli
 
 WORKDIR /
 


### PR DESCRIPTION
This is necessary in order to run the container in "limbo" (as a service) for general use, for example as service for neofs-dev-env with settings and environment variables.

Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>