### PR TITLE
Fixes around Dockerfiles

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -12,7 +12,7 @@ RUN make bin/neofs-cli
 
 # Executable image
 FROM alpine AS neofs-cli
-RUN apk add --update bash
+RUN apk add --no-cache bash
 
 WORKDIR /
 

--- a/Dockerfile.ir
+++ b/Dockerfile.ir
@@ -12,7 +12,7 @@ RUN make bin/neofs-ir
 
 # Executable image
 FROM alpine AS neofs-ir
-RUN apk add --update bash
+RUN apk add --no-cache bash
 
 WORKDIR /
 

--- a/Dockerfile.storage
+++ b/Dockerfile.storage
@@ -12,7 +12,7 @@ RUN make bin/neofs-node
 
 # Executable image
 FROM alpine AS neofs-node
-RUN apk add --update bash
+RUN apk add --no-cache bash
 
 WORKDIR /
 

--- a/Dockerfile.storage-testnet
+++ b/Dockerfile.storage-testnet
@@ -12,7 +12,7 @@ RUN make bin/neofs-node
 
 # Executable image
 FROM alpine AS neofs-node
-RUN apk add --update bash
+RUN apk add --no-cache bash
 
 WORKDIR /
 


### PR DESCRIPTION
When we build executable image, we should not store cache or build cache. That's why we should use `apk add --no-cache` instead of `apk add --update` otherwise `apk` stores it cache inside docker image ([see comment](https://github.com/nspcc-dev/neofs-node/pull/341#issuecomment-765651269))

For example

- using `--update`
```
/ # apk add --update bassh
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/4) Installing ncurses-terminfo-base (6.2_p20210109-r0)
(2/4) Installing ncurses-libs (6.2_p20210109-r0)
(3/4) Installing readline (8.1.0-r0)
(4/4) Installing bash (5.1.0-r0)
Executing bash-5.1.0-r0.post-install
Executing busybox-1.32.1-r0.trigger
OK: 8 MiB in 18 packages

/ # ls /var/cache/apk
APKINDEX.32aecc44.tar.gz  APKINDEX.c77b2f80.tar.gz
```
- using `--no-cache`
```
/ # apk add --no-cache bash
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/4) Installing ncurses-terminfo-base (6.2_p20210109-r0)
(2/4) Installing ncurses-libs (6.2_p20210109-r0)
(3/4) Installing readline (8.1.0-r0)
(4/4) Installing bash (5.1.0-r0)
Executing bash-5.1.0-r0.post-install
Executing busybox-1.32.1-r0.trigger
OK: 8 MiB in 18 package
# ls /var/cache/apk
```

Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>