### PR TITLE
innerring/audit: Use pivot in container placement

### DIFF
--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -58,8 +58,10 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 			continue
 		}
 
+		pivot := containers[i].ToV2().GetValue()
+
 		// find all container nodes for current epoch
-		nodes, err := nm.GetContainerNodes(cnr.PlacementPolicy(), nil)
+		nodes, err := nm.GetContainerNodes(cnr.PlacementPolicy(), pivot)
 		if err != nil {
 			log.Info("can't build placement for container, ignore",
 				zap.Stringer("cid", containers[i]),


### PR DESCRIPTION
Pivot used to shuffle nodes in the CRUSH tree. This is required argument. We use container ID value to select container nodes, so `nil` value produces incorrect placements