### PR TITLE
object/acl: Make best effort to classify request

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -287,6 +287,7 @@ func initObjectService(c *cfg) {
 			acl.New(
 				acl.WithSenderClassifier(
 					acl.NewSenderClassifier(
+						c.log,
 						c.cfgNetmap.wrapper,
 						c.cfgNetmap.wrapper,
 					),


### PR DESCRIPTION
Classifier looks at list of inner ring nodes and container nodes from current and previous epoch to classify request. Sometimes these checks might return error.

Consider there is a request from unknown key and container's placement policy valid for current epoch and invalid for past epoch. Classifier tries to find if key belongs to container node from current epoch -- it is not. Then it tries to find if key belongs to container node from past epoch and it throws error, because placement policy is invalid for past epoch.

This is a legit case and classifier should ignore such errors to provide best effort in matching. The only error classifier should return is an error when request does not contain public key to classify it.