### PR TITLE
Fix block timer behavior after reset

### DIFF
--- a/pkg/innerring/timers/block.go
+++ b/pkg/innerring/timers/block.go
@@ -136,10 +136,7 @@ func (t *BlockTimer) reset() {
 	}
 
 	t.tgt = delta
-
-	for i := range t.ps {
-		t.ps[i].reset()
-	}
+	t.cur = 0
 }
 
 // Tick ticks one block in the BlockTimer.

--- a/pkg/innerring/timers/block_test.go
+++ b/pkg/innerring/timers/block_test.go
@@ -82,3 +82,31 @@ func TestDeltaPulse(t *testing.T) {
 	require.Equal(t, intervalNum, uint32(baseCallCounter))
 	require.Equal(t, intervalNum*div, uint32(deltaCallCounter))
 }
+
+func TestDeltaReset(t *testing.T) {
+	blockDur := uint32(6)
+	baseCallCounter := 0
+
+	bt := timers.NewBlockTimer(timers.StaticBlockMeter(blockDur), func() {
+		baseCallCounter++
+	})
+
+	detlaCallCounter := 0
+
+	bt.OnDelta(1, 3, func() {
+		detlaCallCounter++
+	})
+
+	require.NoError(t, bt.Reset())
+
+	tickN(bt, 6)
+
+	require.Equal(t, 1, baseCallCounter)
+	require.Equal(t, 1, detlaCallCounter)
+
+	require.NoError(t, bt.Reset())
+
+	tickN(bt, 3)
+
+	require.Equal(t, 2, detlaCallCounter)
+}


### PR DESCRIPTION
In previous implementation handler was not called more the one time after
Reset. It was caused by tick counter not being reset inside Reset method.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>