### PR TITLE
[#202] object/eacl: Verify signature of eACL table

### DIFF
--- a/pkg/services/object/acl/eacl/opts.go
+++ b/pkg/services/object/acl/eacl/opts.go
@@ -35,6 +35,7 @@ func (s *morphStorage) GetEACL(cid *container.ID) (*eacl.Table, error) {
 		func() ([]byte, []byte) {
 			return sig.Key(), sig.Sign()
 		},
+		signature.SignWithRFC6979(),
 	); err != nil {
 		return nil, errors.Wrap(err, "incorrect signature")
 	}

--- a/pkg/services/object/acl/eacl/opts.go
+++ b/pkg/services/object/acl/eacl/opts.go
@@ -3,18 +3,43 @@ package eacl
 import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/acl/eacl"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"github.com/pkg/errors"
 )
 
 type morphStorage struct {
 	w *wrapper.Wrapper
 }
 
-func (s *morphStorage) GetEACL(cid *container.ID) (*eacl.Table, error) {
-	table, _, err := s.w.GetEACL(cid)
+type signedEACLTable eacl.Table
 
-	return table, err
+func (s *signedEACLTable) ReadSignedData(buf []byte) ([]byte, error) {
+	return (*eacl.Table)(s).Marshal(buf)
+}
+
+func (s *signedEACLTable) SignedDataSize() int {
+	// TODO: add eacl.Table.Size method
+	return (*eacl.Table)(s).ToV2().StableSize()
+}
+
+func (s *morphStorage) GetEACL(cid *container.ID) (*eacl.Table, error) {
+	table, sig, err := s.w.GetEACL(cid)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := signature.VerifyDataWithSource(
+		(*signedEACLTable)(table),
+		func() ([]byte, []byte) {
+			return sig.Key(), sig.Sign()
+		},
+	); err != nil {
+		return nil, errors.Wrap(err, "incorrect signature")
+	}
+
+	return table, nil
 }
 
 func WithLogger(v *logger.Logger) Option {


### PR DESCRIPTION
Since the contract started returning the table signature, it became
necessary to check its correctness.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

Closes #202.