### PR TITLE
Don't update local node info for bootstrap

### DIFF
--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -127,7 +127,7 @@ func initState(c *cfg) {
 	ni, err := c.netmapLocalNodeState(epoch)
 	fatalOnErr(errors.Wrap(err, "could not init network state"))
 
-	c.handleLocalNodeInfo(ni)
+	c.handleNodeInfoStatus(ni)
 
 	c.log.Info("initial network state",
 		zap.Uint64("epoch", epoch),


### PR DESCRIPTION
Closes #366

At startup, update only node info status. Leave all other attributes from node configuration, so user can update them.