### PR TITLE
Add support for quick and dirty Docker image build

### DIFF
--- a/Dockerfile.dirty-cli
+++ b/Dockerfile.dirty-cli
@@ -1,0 +1,8 @@
+FROM alpine
+RUN apk add --no-cache bash ca-certificates
+
+WORKDIR /
+
+COPY bin/neofs-cli /bin/neofs-cli
+
+CMD ["neofs-cli"]

--- a/Dockerfile.dirty-ir
+++ b/Dockerfile.dirty-ir
@@ -1,0 +1,8 @@
+FROM alpine
+RUN apk add --no-cache bash ca-certificates
+
+WORKDIR /
+
+COPY bin/neofs-ir /bin/neofs-ir
+
+CMD ["neofs-ir"]

--- a/Dockerfile.dirty-storage
+++ b/Dockerfile.dirty-storage
@@ -1,0 +1,8 @@
+FROM alpine
+RUN apk add --no-cache bash ca-certificates
+
+WORKDIR /
+
+COPY bin/neofs-node /bin/neofs-node
+
+CMD ["neofs-node"]

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,10 @@ image-%:
 # Build all Docker images
 images: image-storage image-ir image-cli
 
-# Run all code formaters
+# Build dirty local Docker images
+dirty-images: image-dirty-storage image-dirty-ir image-dirty-cli
+
+# Run all code formatters
 fmts: fmt imports
 
 # Reformat code


### PR DESCRIPTION
Docker containers are supposed to be used for clean image building without side effects from local execution environment, though it may be useful to save some time and have a dirty image built quick.

For those young and inpatient there is a way to do it now.