### PR TITLE
Update neofs-api-go version

### DIFF
--- a/cmd/neofs-cli/modules/control.go
+++ b/cmd/neofs-cli/modules/control.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -90,9 +91,8 @@ func healthCheck(cmd *cobra.Command, _ []string) error {
 
 	sign := resp.GetSignature()
 
-	if err := signature.VerifyDataWithSource(resp, func() ([]byte, []byte) {
-		return sign.GetKey(), sign.GetSign()
-	}); err != nil {
+	if err := signature.VerifyData(resp, sign.GetKey(), sign.GetSign(),
+		signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 		return err
 	}
 
@@ -142,9 +142,8 @@ func setNetmapStatus(cmd *cobra.Command, _ []string) error {
 
 	sign := resp.GetSignature()
 
-	if err := signature.VerifyDataWithSource(resp, func() ([]byte, []byte) {
-		return sign.GetKey(), sign.GetSign()
-	}); err != nil {
+	if err := signature.VerifyData(resp, sign.GetKey(), sign.GetSign(),
+		signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 		return err
 	}
 
@@ -208,9 +207,8 @@ var dropObjectsCmd = &cobra.Command{
 
 		sign := resp.GetSignature()
 
-		if err := signature.VerifyDataWithSource(resp, func() ([]byte, []byte) {
-			return sign.GetKey(), sign.GetSign()
-		}); err != nil {
+		if err := signature.VerifyData(resp, sign.GetKey(), sign.GetSign(),
+			signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 			return err
 		}
 

--- a/cmd/neofs-cli/modules/netmap.go
+++ b/cmd/neofs-cli/modules/netmap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/spf13/cobra"
 )
 
@@ -117,9 +118,8 @@ var snapshotCmd = &cobra.Command{
 
 		sign := resp.GetSignature()
 
-		if err := signature.VerifyDataWithSource(resp, func() ([]byte, []byte) {
-			return sign.GetKey(), sign.GetSign()
-		}); err != nil {
+		if err := signature.VerifyData(resp, sign.GetKey(), sign.GetSign(),
+			signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 			return err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/compress v1.11.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mr-tron/base58 v1.1.3
+	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.2.0
 	github.com/multiformats/go-multiaddr-net v0.1.2 // v0.1.1 => v0.1.2
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.94.0
 	github.com/nspcc-dev/neofs-api-go v1.25.0
-	github.com/nspcc-dev/neofs-crypto v0.3.0
+	github.com/nspcc-dev/neofs-crypto v0.3.1-0.20210323101142-225b24f7f42d
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0
 	github.com/paulmach/orb v0.2.1
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	go.etcd.io/bbolt v1.3.5
 	go.uber.org/atomic v1.5.1
 	go.uber.org/multierr v1.4.0 // indirect
@@ -41,3 +41,5 @@ require (
 
 // Used for debug reasons
 // replace github.com/nspcc-dev/neofs-api-go => ../neofs-api-go
+
+replace github.com/nspcc-dev/neofs-api-go => github.com/fyrchik/neofs-api-go 8c4a79cec202b632c768a7c32a1b967525540799

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,9 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
+github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
+github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/multiformats/go-multiaddr v0.2.0 h1:lR52sFwcTCuQb6bTfnXF6zA2XfyYvyd+5a9qECv/J90=
 github.com/multiformats/go-multiaddr v0.2.0/go.mod h1:0nO36NvPpyV4QzvTLi/lafl2y95ncPj0vFwVF6k6wJ4=
 github.com/multiformats/go-multiaddr-net v0.1.2 h1:P7zcBH9FRETdPkDrylcXVjQLQ2t1JQtNItZULWNWgeg=
@@ -283,8 +284,9 @@ github.com/nspcc-dev/neofs-api-go v1.25.0 h1:hw1TTi3/3wCBB3KN6cycuM8Sn/MFnapSQpt
 github.com/nspcc-dev/neofs-api-go v1.25.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
-github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
+github.com/nspcc-dev/neofs-crypto v0.3.1-0.20210323101142-225b24f7f42d h1:K8Zg59PIyS8tu382ezos+RgKNt+4cf6ukH2QYpWmr54=
+github.com/nspcc-dev/neofs-crypto v0.3.1-0.20210323101142-225b24f7f42d/go.mod h1:v3sF93XF5rmWHGuUyvvcJPL/jw52KQyYdBK9XC8CNW0=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
@@ -377,8 +379,9 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/goleveldb v0.0.0-20180307113352-169b1b37be73 h1:I2drr5K0tykBofr74ZEGliE/Hf6fNkEbcPyFvsy7wZk=

--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -7,9 +7,10 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/pkg/storagegroup"
+	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
-	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/pkg/errors"
 )
 
@@ -83,7 +84,8 @@ func (v *FormatValidator) Validate(obj *Object) error {
 			return errors.Wrapf(err, "object did not pass expiration check")
 		}
 
-		if err := object.CheckHeaderVerificationFields(obj.SDK()); err != nil {
+		if err := object.CheckHeaderVerificationFields(obj.SDK(),
+			signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 			return errors.Wrapf(err, "(%T) could not validate header fields", v)
 		}
 	}
@@ -105,7 +107,7 @@ func (v *FormatValidator) validateSignatureKey(obj *Object) error {
 }
 
 func (v *FormatValidator) checkOwnerKey(id *owner.ID, key []byte) error {
-	wallet, err := owner.NEO3WalletFromPublicKey(crypto.UnmarshalPublicKey(key))
+	wallet, err := owner.NEO3WalletFromPublicKey(keycache.UnmarshalPublicKey(key))
 	if err != nil {
 		// TODO: check via NeoFSID
 		return err

--- a/pkg/innerring/processors/neofs/processor.go
+++ b/pkg/innerring/processors/neofs/processor.go
@@ -41,7 +41,7 @@ type (
 		epochState          EpochState
 		activeState         ActiveState
 		converter           PrecisionConverter
-		mintEmitLock        *sync.Mutex
+		mintEmitLock        sync.Mutex
 		mintEmitCache       *lru.Cache
 		mintEmitThreshold   uint64
 		mintEmitValue       fixedn.Fixed8
@@ -111,7 +111,6 @@ func New(p *Params) (*Processor, error) {
 		epochState:          p.EpochState,
 		activeState:         p.ActiveState,
 		converter:           p.Converter,
-		mintEmitLock:        new(sync.Mutex),
 		mintEmitCache:       lruCache,
 		mintEmitThreshold:   p.MintEmitThreshold,
 		mintEmitValue:       p.MintEmitValue,

--- a/pkg/innerring/processors/netmap/cleanup_table.go
+++ b/pkg/innerring/processors/netmap/cleanup_table.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	cleanupTable struct {
-		*sync.RWMutex
+		sync.RWMutex
 		enabled    bool
 		threshold  uint64
 		lastAccess map[string]epochStamp
@@ -23,7 +23,6 @@ type (
 
 func newCleanupTable(enabled bool, threshold uint64) cleanupTable {
 	return cleanupTable{
-		RWMutex:    new(sync.RWMutex),
 		enabled:    enabled,
 		threshold:  threshold,
 		lastAccess: make(map[string]epochStamp),

--- a/pkg/innerring/timers/block.go
+++ b/pkg/innerring/timers/block.go
@@ -17,7 +17,7 @@ type BlockTickHandler func()
 type BlockTimer struct {
 	rolledBack bool
 
-	mtx *sync.Mutex
+	mtx sync.Mutex
 
 	dur BlockMeter
 
@@ -61,7 +61,6 @@ func StaticBlockMeter(d uint32) BlockMeter {
 // Reset should be called before timer ticking.
 func NewBlockTimer(dur BlockMeter, h BlockTickHandler) *BlockTimer {
 	return &BlockTimer{
-		mtx: new(sync.Mutex),
 		dur: dur,
 		mul: 1,
 		div: 1,

--- a/pkg/local_object_storage/engine/engine.go
+++ b/pkg/local_object_storage/engine/engine.go
@@ -12,7 +12,7 @@ import (
 type StorageEngine struct {
 	*cfg
 
-	mtx *sync.RWMutex
+	mtx sync.RWMutex
 
 	shards map[string]*shard.Shard
 }
@@ -42,7 +42,6 @@ func New(opts ...Option) *StorageEngine {
 
 	return &StorageEngine{
 		cfg:    c,
-		mtx:    new(sync.RWMutex),
 		shards: make(map[string]*shard.Shard),
 	}
 }

--- a/pkg/morph/subscriber/subscriber.go
+++ b/pkg/morph/subscriber/subscriber.go
@@ -24,7 +24,7 @@ type (
 	}
 
 	subscriber struct {
-		*sync.RWMutex
+		sync.RWMutex
 		log    *zap.Logger
 		client *client.WSClient
 
@@ -172,7 +172,6 @@ func New(ctx context.Context, p *Params) (Subscriber, error) {
 	}
 
 	sub := &subscriber{
-		RWMutex:   new(sync.RWMutex),
 		log:       p.Log,
 		client:    wsClient,
 		notify:    make(chan *state.NotificationEvent),

--- a/pkg/network/cache/client.go
+++ b/pkg/network/cache/client.go
@@ -10,7 +10,7 @@ type (
 	// ClientCache is a structure around neofs-api-go/pkg/client to reuse
 	// already created clients.
 	ClientCache struct {
-		mu      *sync.RWMutex
+		mu      sync.RWMutex
 		clients map[string]client.Client
 		opts    []client.Option
 	}
@@ -20,7 +20,6 @@ type (
 // `opts` are used for new client creation.
 func NewSDKClientCache(opts ...client.Option) *ClientCache {
 	return &ClientCache{
-		mu:      new(sync.RWMutex),
 		clients: make(map[string]client.Client),
 		opts:    opts,
 	}

--- a/pkg/services/control/server/sign.go
+++ b/pkg/services/control/server/sign.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 )
 
 // SignedMessage is an interface of Control service message.
@@ -37,9 +38,8 @@ func (s *Server) isValidRequest(req SignedMessage) error {
 	}
 
 	// verify signature
-	return signature.VerifyDataWithSource(req, func() ([]byte, []byte) {
-		return key, sign.GetSign()
-	})
+	return signature.VerifyData(req, key, sign.GetSign(),
+		signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey))
 }
 
 // SignMessage signs Control service message with private key.

--- a/pkg/services/control/service.go
+++ b/pkg/services/control/service.go
@@ -1,6 +1,8 @@
 package control
 
 import (
+	"io"
+
 	"github.com/nspcc-dev/neofs-api-go/util/proto"
 )
 
@@ -15,6 +17,10 @@ import (
 // Structures with the same field values have the same binary format.
 func (x *HealthCheckRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
+}
+
+func (x *HealthCheckRequest_Body) MarshalStream(s proto.Stream) (int, error) {
+	return 0, nil
 }
 
 // StableSize returns binary size of health check request body
@@ -39,7 +45,7 @@ func (x *HealthCheckRequest) SetSignature(body *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of health check request to buf.
+// WriteSignedDataTo reads signed data of health check request to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -47,8 +53,8 @@ func (x *HealthCheckRequest) SetSignature(body *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *HealthCheckRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *HealthCheckRequest) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -117,6 +123,27 @@ func (x *HealthCheckResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
 }
 
+func (x *HealthCheckResponse_Body) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	var (
+		offset, n int
+		err       error
+	)
+
+	n, err = s.EnumMarshal(healthRespBodyStatusFNum, int32(x.NetmapStatus))
+	if err != nil {
+		return offset + n, err
+	}
+
+	offset += n
+
+	n, err = s.EnumMarshal(healthRespBodyHealthStatusFNum, int32(x.HealthStatus))
+	return offset + n, err
+}
+
 // StableSize returns binary size of health check response body
 // in protobuf binary format.
 //
@@ -148,7 +175,7 @@ func (x *HealthCheckResponse) SetSignature(v *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of health check response to buf.
+// WriteSignedDataTo reads signed data of health check response to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -156,8 +183,8 @@ func (x *HealthCheckResponse) SetSignature(v *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *HealthCheckResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *HealthCheckResponse) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -179,6 +206,10 @@ func (x *HealthCheckResponse) SignedDataSize() int {
 // Structures with the same field values have the same binary format.
 func (x *NetmapSnapshotRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
+}
+
+func (x *NetmapSnapshotRequest_Body) MarshalStream(s proto.Stream) (int, error) {
+	return 0, nil
 }
 
 // StableSize returns binary size of netmap snapshot request body
@@ -203,7 +234,7 @@ func (x *NetmapSnapshotRequest) SetSignature(body *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of netmap snapshot request to buf.
+// WriteSignedDataTo reads signed data of netmap snapshot request to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -211,8 +242,8 @@ func (x *NetmapSnapshotRequest) SetSignature(body *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *NetmapSnapshotRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *NetmapSnapshotRequest) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -261,6 +292,14 @@ func (x *NetmapSnapshotResponse_Body) StableMarshal(buf []byte) ([]byte, error) 
 	return buf, nil
 }
 
+func (x *NetmapSnapshotResponse_Body) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	return s.NestedStructureMarshal(snapshotRespBodyNetmapFNum, x.Netmap)
+}
+
 // StableSize returns binary size of netmap snapshot response body
 // in protobuf binary format.
 //
@@ -291,7 +330,7 @@ func (x *NetmapSnapshotResponse) SetSignature(v *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of netmap snapshot response to buf.
+// WriteSignedDataTo reads signed data of netmap snapshot response to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -299,8 +338,8 @@ func (x *NetmapSnapshotResponse) SetSignature(v *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *NetmapSnapshotResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *NetmapSnapshotResponse) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -349,6 +388,14 @@ func (x *SetNetmapStatusRequest_Body) StableMarshal(buf []byte) ([]byte, error) 
 	return buf, nil
 }
 
+func (x *SetNetmapStatusRequest_Body) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	return s.EnumMarshal(setNetmapStatusReqBodyStatusFNum, int32(x.Status))
+}
+
 // StableSize returns binary size of health check response body
 // in protobuf binary format.
 //
@@ -379,7 +426,7 @@ func (x *SetNetmapStatusRequest) SetSignature(body *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of set netmap status request to buf.
+// WriteSignedDataTo reads signed data of set netmap status request to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -387,8 +434,8 @@ func (x *SetNetmapStatusRequest) SetSignature(body *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *SetNetmapStatusRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *SetNetmapStatusRequest) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -410,6 +457,10 @@ func (x *SetNetmapStatusRequest) SignedDataSize() int {
 // Structures with the same field values have the same binary format.
 func (x *SetNetmapStatusResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
+}
+
+func (x *SetNetmapStatusResponse_Body) MarshalStream(proto.Stream) (int, error) {
+	return 0, nil
 }
 
 // StableSize returns binary size of set netmap status response body
@@ -434,7 +485,7 @@ func (x *SetNetmapStatusResponse) SetSignature(v *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of set netmap status response to buf.
+// WriteSignedDataTo reads signed data of set netmap status response to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -442,8 +493,8 @@ func (x *SetNetmapStatusResponse) SetSignature(v *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *SetNetmapStatusResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *SetNetmapStatusResponse) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -492,6 +543,14 @@ func (x *DropObjectsRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
 }
 
+func (x *DropObjectsRequest_Body) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	return s.RepeatedBytesMarshal(addrListReqBodyStatusFNum, x.AddressList)
+}
+
 // StableSize returns binary size of "Drop objects" response body
 // in protobuf binary format.
 //
@@ -522,7 +581,7 @@ func (x *DropObjectsRequest) SetSignature(body *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of "Drop objects" request to buf.
+// WriteSignedDataTo reads signed data of "Drop objects" request to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -530,8 +589,8 @@ func (x *DropObjectsRequest) SetSignature(body *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *DropObjectsRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *DropObjectsRequest) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data of "Drop objects" request.
@@ -552,6 +611,10 @@ func (x *DropObjectsRequest) SignedDataSize() int {
 // Structures with the same field values have the same binary format.
 func (x *DropObjectsResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
+}
+
+func (x *DropObjectsResponse_Body) MarshalStream(proto.Stream) (int, error) {
+	return 0, nil
 }
 
 // StableSize returns binary size of "Drop objects" response body
@@ -576,7 +639,7 @@ func (x *DropObjectsResponse) SetSignature(v *Signature) {
 	}
 }
 
-// ReadSignedData reads signed data of "Drop objects" response to buf.
+// WriteSignedDataTo reads signed data of "Drop objects" response to buf.
 //
 // If buffer length is less than x.SignedDataSize(), new buffer is allocated.
 //
@@ -584,8 +647,8 @@ func (x *DropObjectsResponse) SetSignature(v *Signature) {
 // Otherwise, returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same signed data.
-func (x *DropObjectsResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+func (x *DropObjectsResponse) WriteSignedDataTo(w io.Writer) (int, error) {
+	return x.GetBody().MarshalStream(proto.NewStream(w))
 }
 
 // SignedDataSize returns binary size of the signed data of "Drop objects" response.

--- a/pkg/services/control/types.go
+++ b/pkg/services/control/types.go
@@ -95,6 +95,41 @@ func (x *NodeInfo_Attribute) StableMarshal(buf []byte) ([]byte, error) {
 
 	return buf, nil
 }
+func (x *NodeInfo_Attribute) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	var (
+		offset, n int
+		err       error
+	)
+
+	n, err = s.StringMarshal(nodeAttrKeyFNum, x.Key)
+	if err != nil {
+		return offset + n, err
+	}
+
+	offset += n
+
+	n, err = s.StringMarshal(nodeAttrValueFNum, x.Value)
+	if err != nil {
+		return offset + n, err
+	}
+
+	offset += n
+
+	for i := range x.Parents {
+		n, err = s.StringMarshal(nodeAttrParentsFNum, x.Parents[i])
+		if err != nil {
+			return offset + n, err
+		}
+
+		offset += n
+	}
+
+	return offset, nil
+}
 
 // StableSize returns binary size of node attribute
 // in protobuf binary format.
@@ -208,6 +243,43 @@ func (x *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
 	return buf, nil
 }
 
+func (x *NodeInfo) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	var (
+		offset, n int
+		err       error
+	)
+
+	n, err = s.BytesMarshal(nodePubKeyFNum, x.PublicKey)
+	if err != nil {
+		return offset + n, err
+	}
+
+	offset += n
+
+	n, err = s.StringMarshal(nodeAddrFNum, x.Address)
+	if err != nil {
+		return offset + n, err
+	}
+
+	offset += n
+
+	for i := range x.Attributes {
+		n, err = s.NestedStructureMarshal(nodeAttrsFNum, x.Attributes[i])
+		if err != nil {
+			return offset + n, err
+		}
+
+		offset += n
+	}
+
+	n, err = s.EnumMarshal(nodeStateFNum, int32(x.State))
+	return offset + n, err
+}
+
 // StableSize returns binary size of node information
 // in protobuf binary format.
 //
@@ -290,6 +362,35 @@ func (x *Netmap) StableMarshal(buf []byte) ([]byte, error) {
 	}
 
 	return buf, nil
+}
+
+func (x *Netmap) MarshalStream(s proto.Stream) (int, error) {
+	if x == nil {
+		return 0, nil
+	}
+
+	var (
+		offset, n int
+		err       error
+	)
+
+	n, err = s.UInt64Marshal(netmapEpochFNum, x.Epoch)
+	if err != nil {
+		return n, err
+	}
+
+	offset += n
+
+	for i := range x.Nodes {
+		n, err = s.NestedStructureMarshal(netmapNodesFNum, x.Nodes[i])
+		if err != nil {
+			return offset + n, err
+		}
+
+		offset += n
+	}
+
+	return offset, nil
 }
 
 // StableSize returns binary size of netmap  in protobuf binary format.

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -23,6 +23,7 @@ import (
 	objectSvc "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl"
 	eaclV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl/v2"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/pkg/errors"
 )
 
@@ -719,10 +720,10 @@ func isValidBearer(reqInfo requestInfo, st netmap.State) bool {
 
 	// 2. Then check if bearer token is signed correctly.
 	signWrapper := v2signature.StableMarshalerWrapper{SM: token.GetBody()}
-	if err := signature.VerifyDataWithSource(signWrapper, func() (key, sig []byte) {
-		tokenSignature := token.GetSignature()
-		return tokenSignature.GetKey(), tokenSignature.GetSign()
-	}); err != nil {
+	tokenSignature := token.GetSignature()
+
+	if err := signature.VerifyData(signWrapper, tokenSignature.GetKey(), tokenSignature.GetSign(),
+		signature.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 		return false // invalid signature
 	}
 

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -264,7 +264,7 @@ func (exec *execCtx) headChild(id *objectSDK.ID) (*object.Object, bool) {
 	}
 }
 
-func (exec execCtx) remoteClient(node *network.Address) (getClient, bool) {
+func (exec execCtx) remoteClient(node *network.Address) (client.Client, bool) {
 	ipAddr, err := node.IPAddrString()
 
 	log := exec.log.With(zap.Stringer("node", node))
@@ -276,7 +276,7 @@ func (exec execCtx) remoteClient(node *network.Address) (getClient, bool) {
 
 		log.Debug("could not calculate node IP address")
 	case err == nil:
-		c, err := exec.svc.clientCache.get(ipAddr)
+		c, err := exec.svc.clientCache.Get(ipAddr)
 
 		switch {
 		default:

--- a/pkg/services/object/get/remote.go
+++ b/pkg/services/object/get/remote.go
@@ -20,7 +20,7 @@ func (exec *execCtx) processNode(ctx context.Context, addr *network.Address) boo
 		return true
 	}
 
-	obj, err := client.getObject(exec)
+	obj, err := getObject(exec, client)
 
 	var errSplitInfo *objectSDK.SplitInfoError
 

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -20,10 +20,6 @@ type Service struct {
 // Option is a Service's constructor option.
 type Option func(*cfg)
 
-type getClient interface {
-	getObject(*execCtx) (*objectSDK.Object, error)
-}
-
 type cfg struct {
 	assembly bool
 
@@ -34,7 +30,7 @@ type cfg struct {
 	}
 
 	clientCache interface {
-		get(string) (getClient, error)
+		Get(string) (client.Client, error)
 	}
 
 	traverserGenerator interface {
@@ -51,7 +47,6 @@ func defaultCfg() *cfg {
 		assembly:     true,
 		log:          zap.L(),
 		localStorage: new(storageEngineWrapper),
-		clientCache:  new(clientCacheWrapper),
 	}
 }
 
@@ -98,7 +93,7 @@ type ClientConstructor interface {
 // WithClientConstructor returns option to set constructor of remote node clients.
 func WithClientConstructor(v ClientConstructor) Option {
 	return func(c *cfg) {
-		c.clientCache.(*clientCacheWrapper).cache = v
+		c.clientCache = v
 	}
 }
 

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/transformer"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/pkg/errors"
 )
 
@@ -72,6 +73,7 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 			t.commonPrm.RemoteCallOptions(),
 			client.WithTTL(1), // FIXME: use constant
 			client.WithKey(key),
+			client.WithUnmarshalPublic(keycache.UnmarshalPublicKey),
 		)...,
 	)
 	if err != nil {

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -27,7 +27,7 @@ type Option func(*cfg)
 // Traverser represents utility for controlling
 // traversal of object placement vectors.
 type Traverser struct {
-	mtx *sync.RWMutex
+	mtx sync.RWMutex
 
 	vectors []netmap.Nodes
 
@@ -98,7 +98,6 @@ func NewTraverser(opts ...Option) (*Traverser, error) {
 	}
 
 	return &Traverser{
-		mtx:     new(sync.RWMutex),
 		rem:     rem,
 		vectors: ns,
 	}, nil

--- a/pkg/services/session/storage/storage.go
+++ b/pkg/services/session/storage/storage.go
@@ -14,7 +14,7 @@ type key struct {
 }
 
 type TokenStore struct {
-	mtx *sync.RWMutex
+	mtx sync.RWMutex
 
 	tokens map[key]*PrivateToken
 }
@@ -26,7 +26,6 @@ var ErrNotFound = errors.New("private token not found")
 // The elements of the instance are stored in the map.
 func New() *TokenStore {
 	return &TokenStore{
-		mtx:    new(sync.RWMutex),
 		tokens: make(map[key]*PrivateToken),
 	}
 }

--- a/pkg/services/util/sign.go
+++ b/pkg/services/util/sign.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 
+	signer "github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	"github.com/nspcc-dev/neofs-api-go/v2/signature"
+	"github.com/nspcc-dev/neofs-node/pkg/util/keycache"
 	"github.com/pkg/errors"
 )
 
@@ -53,7 +55,8 @@ func NewUnarySignService(key *ecdsa.PrivateKey) *SignService {
 
 func (s *RequestMessageStreamer) Send(req interface{}) error {
 	// verify request signatures
-	if err := signature.VerifyServiceMessage(req); err != nil {
+	if err := signature.VerifyServiceMessage(req,
+		signer.WithUnmarshalPublicKey(keycache.UnmarshalPublicKey)); err != nil {
 		return errors.Wrap(err, "could not verify request")
 	}
 

--- a/pkg/util/keycache/cache.go
+++ b/pkg/util/keycache/cache.go
@@ -1,0 +1,47 @@
+package keycache
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+	crypto "github.com/nspcc-dev/neofs-crypto"
+)
+
+// KeyCache represents public key cache.
+type KeyCache interface {
+	UnmarshalPublic([]byte) *ecdsa.PublicKey
+}
+
+type keyCache struct {
+	simplelru.LRU
+}
+
+// New creates new key cache.
+func New(capacity int) KeyCache {
+	c, err := simplelru.NewLRU(capacity, nil)
+	if err != nil {
+		// panic occurs only with nil capacity, which is a programmer error.
+		panic(err)
+	}
+	return &keyCache{
+		LRU: *c,
+	}
+}
+
+// UnmarshalPublic implements KeyCache interface.
+func (k *keyCache) UnmarshalPublic(data []byte) *ecdsa.PublicKey {
+	s := string(data)
+	if pub, ok := k.Get(s); ok {
+		return pub.(*ecdsa.PublicKey)
+	}
+
+	pub := crypto.UnmarshalPublicKey(data)
+	k.Add(s, pub)
+	return pub
+}
+
+var global = New(100)
+
+func UnmarshalPublicKey(data []byte) *ecdsa.PublicKey {
+	return global.UnmarshalPublic(data)
+}


### PR DESCRIPTION
Add cache for public keys, provide it to verification routines.
Currently it is provided only to ones which appear in pprof.

Draft, because `neofs-api-go` needs to be merged first. Currently my branch is specified in `go.mod`.