### PR TITLE
Support updated reputation contract

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -67,6 +67,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("contracts.container", "")
 	cfg.SetDefault("contracts.audit", "")
 	cfg.SetDefault("contracts.proxy", "")
+	cfg.SetDefault("contracts.reputation", "")
 	// alphabet contracts
 	cfg.SetDefault("contracts.alphabet.amount", 7)
 
@@ -87,6 +88,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("workers.neofs", "10")
 	cfg.SetDefault("workers.container", "10")
 	cfg.SetDefault("workers.alphabet", "10")
+	cfg.SetDefault("workers.reputation", "10")
 
 	cfg.SetDefault("netmap_cleaner.enabled", false)
 	cfg.SetDefault("netmap_cleaner.threshold", 3)

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -180,13 +180,21 @@ func (s *loggingReputationServer) SendLocalTrust(_ context.Context, req *v2reput
 
 	for _, t := range body.GetTrusts() {
 		log.Info("local trust received",
-			zap.String("peer", hex.EncodeToString(t.GetPeer())),
+			zap.String("peer", hex.EncodeToString(t.GetPeer().GetValue())),
 			zap.Float64("value", t.GetValue()),
 		)
 	}
 
 	resp := new(v2reputation.SendLocalTrustResponse)
 	resp.SetBody(new(v2reputation.SendLocalTrustResponseBody))
+
+	return resp, nil
+}
+
+func (s *loggingReputationServer) SendIntermediateResult(_ context.Context, req *v2reputation.SendIntermediateResultRequest) (*v2reputation.SendIntermediateResultResponse, error) {
+	resp := new(v2reputation.SendIntermediateResultResponse)
+
+	// todo: implement me
 
 	return resp, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.94.0
-	github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210325082034-b792e4e4647a
+	github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210402125759-771f395d9d4e
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5
 github.com/nspcc-dev/neo-go v0.94.0 h1:2eafoyEnueqEMGDZF06HZJQN0MHgYxFzlcre5YUOP1M=
 github.com/nspcc-dev/neo-go v0.94.0/go.mod h1:IrBT/UG3/Slhqgjge8r6zni5tNRsWmwwG9OnVdASheI=
 github.com/nspcc-dev/neofs-api-go v1.24.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
-github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210325082034-b792e4e4647a h1:wCf07NTkQeIn0ev8AOGckuz7HmmmV/sEREyGX0Ae7xw=
-github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210325082034-b792e4e4647a/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
+github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210402125759-771f395d9d4e h1:yAsO+uJDClvttFwhStZgnV2xdYP+TWGyk0ib5ceTaIo=
+github.com/nspcc-dev/neofs-api-go v1.25.1-0.20210402125759-771f395d9d4e/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/pkg/innerring/invoke/enhanced.go
+++ b/pkg/innerring/invoke/enhanced.go
@@ -13,6 +13,8 @@ import (
 	wrapContainer "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	morphNetmap "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	wrapNetmap "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation"
+	reputationWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
 	"github.com/pkg/errors"
 )
 
@@ -69,4 +71,19 @@ func NewBalanceClient(cli *client.Client, contract util.Uint160) (*balanceWrappe
 	}
 
 	return balanceWrapper.New(enhancedBalanceClient)
+}
+
+// NewReputationClient creates wrapper to work with reputation contract.
+func NewReputationClient(cli *client.Client, contract util.Uint160) (*reputationWrapper.ClientWrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create static client of reputation contract")
+	}
+
+	enhancedRepurationClient, err := reputation.New(staticClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create reputation contract client")
+	}
+
+	return reputationWrapper.WrapClient(enhancedRepurationClient), nil
 }

--- a/pkg/innerring/processors/reputation/handlers.go
+++ b/pkg/innerring/processors/reputation/handlers.go
@@ -1,0 +1,31 @@
+package reputation
+
+import (
+	"encoding/hex"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	reputationEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/reputation"
+	"go.uber.org/zap"
+)
+
+func (rp *Processor) handlePutReputation(ev event.Event) {
+	put := ev.(reputationEvent.Put)
+	rp.log.Info("notification",
+		zap.String("type", "reputation put"),
+		zap.String("peer_id", hex.EncodeToString(put.PeerID().Bytes())))
+
+	// send event to the worker pool
+
+	err := rp.pool.Submit(func() {
+		rp.processPut(
+			put.Epoch(),
+			put.PeerID(),
+			put.Value(),
+		)
+	})
+	if err != nil {
+		// there system can be moved into controlled degradation stage
+		rp.log.Warn("reputation worker pool drained",
+			zap.Int("capacity", rp.pool.Cap()))
+	}
+}

--- a/pkg/innerring/processors/reputation/handlers.go
+++ b/pkg/innerring/processors/reputation/handlers.go
@@ -10,16 +10,18 @@ import (
 
 func (rp *Processor) handlePutReputation(ev event.Event) {
 	put := ev.(reputationEvent.Put)
+	peerID := put.PeerID()
+
 	rp.log.Info("notification",
 		zap.String("type", "reputation put"),
-		zap.String("peer_id", hex.EncodeToString(put.PeerID().Bytes())))
+		zap.String("peer_id", hex.EncodeToString(peerID.ToV2().GetValue())))
 
 	// send event to the worker pool
 
 	err := rp.pool.Submit(func() {
 		rp.processPut(
 			put.Epoch(),
-			put.PeerID(),
+			peerID,
 			put.Value(),
 		)
 	})

--- a/pkg/innerring/processors/reputation/process_put.go
+++ b/pkg/innerring/processors/reputation/process_put.go
@@ -3,18 +3,38 @@ package reputation
 import (
 	"encoding/hex"
 
+	"github.com/nspcc-dev/neofs-api-go/pkg/reputation"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
-	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	"go.uber.org/zap"
 )
 
-func (rp *Processor) processPut(epoch uint64, id reputation.PeerID, value []byte) {
+func (rp *Processor) processPut(epoch uint64, id reputation.PeerID, value reputation.GlobalTrust) {
 	if !rp.alphabetState.IsAlphabet() {
 		rp.log.Info("non alphabet mode, ignore reputation put notification")
 		return
 	}
 
-	// todo: do sanity checks of value and epoch
+	// check if epoch is valid
+	currentEpoch := rp.epochState.EpochCounter()
+	if epoch >= currentEpoch {
+		rp.log.Info("ignore reputation value",
+			zap.String("reason", "invalid epoch number"),
+			zap.Uint64("trust_epoch", epoch),
+			zap.Uint64("local_epoch", currentEpoch))
+
+		return
+	}
+
+	// check signature
+	if err := value.VerifySignature(); err != nil {
+		rp.log.Info("ignore reputation value",
+			zap.String("reason", "invalid signature"),
+			zap.String("error", err.Error()))
+
+		return
+	}
+
+	// todo: do sanity checks of value
 
 	args := wrapper.PutArgs{}
 	args.SetEpoch(epoch)
@@ -24,7 +44,7 @@ func (rp *Processor) processPut(epoch uint64, id reputation.PeerID, value []byte
 	err := rp.reputationWrp.PutViaNotary(args)
 	if err != nil {
 		rp.log.Warn("can't send approval tx for reputation value",
-			zap.String("peer_id", hex.EncodeToString(id.Bytes())),
+			zap.String("peer_id", hex.EncodeToString(id.ToV2().GetValue())),
 			zap.String("error", err.Error()))
 	}
 }

--- a/pkg/innerring/processors/reputation/process_put.go
+++ b/pkg/innerring/processors/reputation/process_put.go
@@ -1,0 +1,30 @@
+package reputation
+
+import (
+	"encoding/hex"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	"go.uber.org/zap"
+)
+
+func (rp *Processor) processPut(epoch uint64, id reputation.PeerID, value []byte) {
+	if !rp.alphabetState.IsAlphabet() {
+		rp.log.Info("non alphabet mode, ignore reputation put notification")
+		return
+	}
+
+	// todo: do sanity checks of value and epoch
+
+	args := wrapper.PutArgs{}
+	args.SetEpoch(epoch)
+	args.SetPeerID(id)
+	args.SetValue(value)
+
+	err := rp.reputationWrp.PutViaNotary(args)
+	if err != nil {
+		rp.log.Warn("can't send approval tx for reputation value",
+			zap.String("peer_id", hex.EncodeToString(id.Bytes())),
+			zap.String("error", err.Error()))
+	}
+}

--- a/pkg/innerring/processors/reputation/processor.go
+++ b/pkg/innerring/processors/reputation/processor.go
@@ -1,0 +1,113 @@
+package reputation
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	reputationWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	reputationEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/reputation"
+	"github.com/panjf2000/ants/v2"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type (
+	// EpochState is a callback interface for inner ring global state.
+	EpochState interface {
+		EpochCounter() uint64
+	}
+
+	// AlphabetState is a callback interface for inner ring global state.
+	AlphabetState interface {
+		IsAlphabet() bool
+	}
+
+	// Processor of events produced by reputation contract.
+	Processor struct {
+		log  *zap.Logger
+		pool *ants.Pool
+
+		reputationContract util.Uint160
+
+		epochState    EpochState
+		alphabetState AlphabetState
+
+		reputationWrp *reputationWrapper.ClientWrapper
+	}
+
+	// Params of the processor constructor.
+	Params struct {
+		Log                *zap.Logger
+		PoolSize           int
+		ReputationContract util.Uint160
+		EpochState         EpochState
+		AlphabetState      AlphabetState
+		ReputationWrapper  *reputationWrapper.ClientWrapper
+	}
+)
+
+const (
+	putReputationNotification = "reputationPut"
+)
+
+// New creates reputation contract processor instance.
+func New(p *Params) (*Processor, error) {
+	switch {
+	case p.Log == nil:
+		return nil, errors.New("ir/reputation: logger is not set")
+	case p.EpochState == nil:
+		return nil, errors.New("ir/reputation: global state is not set")
+	case p.AlphabetState == nil:
+		return nil, errors.New("ir/reputation: global state is not set")
+	case p.ReputationWrapper == nil:
+		return nil, errors.New("ir/reputation: reputation contract wrapper is not set")
+	}
+
+	p.Log.Debug("reputation worker pool", zap.Int("size", p.PoolSize))
+
+	pool, err := ants.NewPool(p.PoolSize, ants.WithNonblocking(true))
+	if err != nil {
+		return nil, errors.Wrap(err, "ir/reputation: can't create worker pool")
+	}
+
+	return &Processor{
+		log:                p.Log,
+		pool:               pool,
+		reputationContract: p.ReputationContract,
+		epochState:         p.EpochState,
+		alphabetState:      p.AlphabetState,
+		reputationWrp:      p.ReputationWrapper,
+	}, nil
+}
+
+// ListenerParsers for the 'event.Listener' event producer.
+func (rp *Processor) ListenerParsers() []event.ParserInfo {
+	var parsers []event.ParserInfo
+
+	// put reputation event
+	put := event.ParserInfo{}
+	put.SetType(putReputationNotification)
+	put.SetScriptHash(rp.reputationContract)
+	put.SetParser(reputationEvent.ParsePut)
+	parsers = append(parsers, put)
+
+	return parsers
+}
+
+// ListenerHandlers for the 'event.Listener' event producer.
+func (rp *Processor) ListenerHandlers() []event.HandlerInfo {
+	var handlers []event.HandlerInfo
+
+	// put reputation handler
+	put := event.HandlerInfo{}
+	put.SetType(putReputationNotification)
+	put.SetScriptHash(rp.reputationContract)
+	put.SetHandler(rp.handlePutReputation)
+	handlers = append(handlers, put)
+
+	return handlers
+}
+
+// TimersHandlers for the 'Timers' event producer.
+func (rp *Processor) TimersHandlers() []event.HandlerInfo {
+	return nil
+}

--- a/pkg/morph/client/reputation/client.go
+++ b/pkg/morph/client/reputation/client.go
@@ -1,0 +1,128 @@
+package reputation
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+)
+
+// Client is a wrapper over StaticClient
+// which makes calls with the names and arguments
+// of the NeoFS reputation contract.
+//
+// Working client must be created via constructor New.
+// Using the Client that has been created with new(Client)
+// expression (or just declaring a Client variable) is unsafe
+// and can lead to panic.
+type Client struct {
+	client *client.StaticClient // static reputation contract client
+
+	*cfg // contract method names
+}
+
+// Option is a client configuration change function.
+type Option func(*cfg)
+
+type cfg struct {
+	putMethod,
+	getMethod,
+	getByIDMethod,
+	listByEpochMethod string
+}
+
+const (
+	defaultPutMethod         = "put"
+	defaultGetMethod         = "get"
+	defaultGetByIDMethod     = "getByID"
+	defaultListByEpochMethod = "listByEpoch"
+)
+
+func defaultConfig() *cfg {
+	return &cfg{
+		putMethod:         defaultPutMethod,
+		getMethod:         defaultGetMethod,
+		getByIDMethod:     defaultGetByIDMethod,
+		listByEpochMethod: defaultListByEpochMethod,
+	}
+}
+
+// New creates, initializes and returns the Client instance.
+//
+// If StaticClient is nil, client.ErrNilStaticClient is returned.
+//
+// Other values are set according to provided options, or by default.
+//
+// If desired option satisfies the default value, it can be omitted.
+// If multiple options of the same config value are supplied,
+// the option with the highest index in the arguments will be used.
+func New(c *client.StaticClient, opts ...Option) (*Client, error) {
+	if c == nil {
+		return nil, client.ErrNilStaticClient
+	}
+
+	res := &Client{
+		client: c,
+		cfg:    defaultConfig(), // build default configuration
+	}
+
+	// apply options
+	for _, opt := range opts {
+		opt(res.cfg)
+	}
+
+	return res, nil
+}
+
+// WithPutMethod returns a client constructor option that
+// specifies the method name to put reputation value.
+//
+// Ignores empty value.
+//
+// If option not provided, "put" is used.
+func WithPutMethod(n string) Option {
+	return func(c *cfg) {
+		if n != "" {
+			c.putMethod = n
+		}
+	}
+}
+
+// WithGetMethod returns a client constructor option that
+// specifies the method name to get reputation value.
+//
+// Ignores empty value.
+//
+// If option not provided, "get" is used.
+func WithGetMethod(n string) Option {
+	return func(c *cfg) {
+		if n != "" {
+			c.getMethod = n
+		}
+	}
+}
+
+// WithGetByIDMethod returns a client constructor option that
+// specifies the method name to get reputation value by it's ID in the contract.
+//
+// Ignores empty value.
+//
+// If option not provided, "getByID" is used.
+func WithGetByIDMethod(n string) Option {
+	return func(c *cfg) {
+		if n != "" {
+			c.getByIDMethod = n
+		}
+	}
+}
+
+// WithListByEpochMethod returns a client constructor option that
+// specifies the method name to list reputation value IDs for certain epoch.
+//
+// Ignores empty value.
+//
+// If option not provided, "listByEpoch" is used.
+func WithListByEpochDMethod(n string) Option {
+	return func(c *cfg) {
+		if n != "" {
+			c.listByEpochMethod = n
+		}
+	}
+}

--- a/pkg/morph/client/reputation/get.go
+++ b/pkg/morph/client/reputation/get.go
@@ -1,0 +1,99 @@
+package reputation
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/pkg/errors"
+)
+
+// GetArgs groups the arguments of "get reputation value" test invocation.
+type GetArgs struct {
+	epoch  uint64
+	peerID []byte // object of reputation evaluation
+}
+
+// GetByIDArgs groups the arguments of "get reputation value by reputation id"
+// test invocation.
+type GetByIDArgs struct {
+	id []byte // id of reputation value in reputation contract
+}
+
+// GetResult groups the stack parameters returned by
+// "get" and "get by id" test invocations.
+type GetResult struct {
+	reputations [][]byte
+}
+
+// SetEpoch sets epoch of expected reputation value.
+func (g *GetArgs) SetEpoch(v uint64) {
+	g.epoch = v
+}
+
+// SetPeerID sets peer id of expected reputation value.
+func (g *GetArgs) SetPeerID(v []byte) {
+	g.peerID = v
+}
+
+// SetID sets id of expected reputation value in reputation contract.
+func (g *GetByIDArgs) SetID(v []byte) {
+	g.id = v
+}
+
+// Reputations returns slice of marshalled reputation values.
+func (g GetResult) Reputations() [][]byte {
+	return g.reputations
+}
+
+// Get invokes the call of "get reputation value" method of reputation contract.
+func (c *Client) Get(args GetArgs) (*GetResult, error) {
+	prms, err := c.client.TestInvoke(
+		c.getMethod,
+		int64(args.epoch),
+		args.peerID,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not perform test invocation (%s)", c.getMethod)
+	}
+
+	return parseReputations(prms, c.getMethod)
+}
+
+// GetByID invokes the call of "get reputation value by reputation id" method
+// of reputation contract.
+func (c *Client) GetByID(args GetByIDArgs) (*GetResult, error) {
+	prms, err := c.client.TestInvoke(
+		c.getByIDMethod,
+		args.id,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not perform test invocation (%s)", c.getByIDMethod)
+	}
+
+	return parseReputations(prms, c.getByIDMethod)
+}
+
+func parseReputations(items []stackitem.Item, method string) (*GetResult, error) {
+	if ln := len(items); ln != 1 {
+		return nil, errors.Errorf("unexpected stack item count (%s): %d", method, ln)
+	}
+
+	items, err := client.ArrayFromStackItem(items[0])
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get stack item array from stack item (%s)", method)
+	}
+
+	res := &GetResult{
+		reputations: make([][]byte, 0, len(items)),
+	}
+
+	for i := range items {
+		rawReputation, err := client.BytesFromStackItem(items[i])
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get byte array from stack item (%s)", method)
+		}
+
+		res.reputations = append(res.reputations, rawReputation)
+	}
+
+	return res, nil
+}

--- a/pkg/morph/client/reputation/list.go
+++ b/pkg/morph/client/reputation/list.go
@@ -1,0 +1,62 @@
+package reputation
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/pkg/errors"
+)
+
+// ListByEpochArgs groups the arguments of
+// "list reputation ids by epoch" test invoke call.
+type ListByEpochArgs struct {
+	epoch uint64
+}
+
+// ListByEpochResult groups the stack parameters
+// returned by "list reputation ids by epoch" test invoke.
+type ListByEpochResult struct {
+	ids [][]byte
+}
+
+// SetEpoch sets epoch of expected reputation ids.
+func (l *ListByEpochArgs) SetEpoch(v uint64) {
+	l.epoch = v
+}
+
+// IDs returns slice of reputation id values.
+func (l ListByEpochResult) IDs() [][]byte {
+	return l.ids
+}
+
+// ListByEpoch invokes the call of "list reputation ids by epoch" method of
+// reputation contract.
+func (c *Client) ListByEpoch(args ListByEpochArgs) (*ListByEpochResult, error) {
+	prms, err := c.client.TestInvoke(
+		c.listByEpochMethod,
+		int64(args.epoch),
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not perform test invocation (%s)", c.listByEpochMethod)
+	} else if ln := len(prms); ln != 1 {
+		return nil, errors.Errorf("unexpected stack item count (%s): %d", c.listByEpochMethod, ln)
+	}
+
+	items, err := client.ArrayFromStackItem(prms[0])
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get stack item array from stack item (%s)", c.listByEpochMethod)
+	}
+
+	res := &ListByEpochResult{
+		ids: make([][]byte, 0, len(items)),
+	}
+
+	for i := range items {
+		rawReputation, err := client.BytesFromStackItem(items[i])
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get byte array from stack item (%s)", c.listByEpochMethod)
+		}
+
+		res.ids = append(res.ids, rawReputation)
+	}
+
+	return res, nil
+}

--- a/pkg/morph/client/reputation/put.go
+++ b/pkg/morph/client/reputation/put.go
@@ -1,0 +1,48 @@
+package reputation
+
+import (
+	"github.com/pkg/errors"
+)
+
+// PutArgs groups the arguments of "put reputation value" invocation call.
+type PutArgs struct {
+	epoch  uint64
+	peerID []byte
+	value  []byte
+}
+
+// SetEpoch sets epoch of reputation value.
+func (p *PutArgs) SetEpoch(v uint64) {
+	p.epoch = v
+}
+
+// SetPeerID sets peer id of reputation value.
+func (p *PutArgs) SetPeerID(v []byte) {
+	p.peerID = v
+}
+
+// SetValue sets marshaled reputation value.
+func (p *PutArgs) SetValue(v []byte) {
+	p.value = v
+}
+
+// Put invokes direct call of "put reputation value" method of reputation contract.
+func (c *Client) Put(args PutArgs) error {
+	return errors.Wrapf(c.client.Invoke(
+		c.putMethod,
+		int64(args.epoch),
+		args.peerID,
+		args.value,
+	), "could not invoke method (%s)", c.putMethod)
+}
+
+// PutViaNotary invokes notary call of "put reputation value" method of
+// reputation contract.
+func (c *Client) PutViaNotary(args PutArgs) error {
+	return errors.Wrapf(c.client.NotaryInvoke(
+		c.putMethod,
+		int64(args.epoch),
+		args.peerID,
+		args.value,
+	), "could not invoke method (%s)", c.putMethod)
+}

--- a/pkg/morph/client/reputation/wrapper/get.go
+++ b/pkg/morph/client/reputation/wrapper/get.go
@@ -1,0 +1,84 @@
+package wrapper
+
+import (
+	reputationClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+)
+
+type (
+	// GetArgs groups the arguments of "get reputation value" test invocation.
+	GetArgs struct {
+		epoch  uint64
+		peerID reputation.PeerID
+	}
+
+	// GetByIDArgs groups the arguments of "get reputation value by
+	// reputation id" test invocation.
+	GetByIDArgs struct {
+		id ReputationID
+	}
+
+	// GetResults groups the result of "get reputation value" and
+	// "get reputation value by reputation id" test invocations.
+	GetResult struct {
+		reputations [][]byte // todo: replace with the slice of structures
+	}
+)
+
+// SetEpoch sets epoch of expected reputation value.
+func (g *GetArgs) SetEpoch(v uint64) {
+	g.epoch = v
+}
+
+// SetPeerID sets peer id of expected reputation value.
+func (g *GetArgs) SetPeerID(v reputation.PeerID) {
+	g.peerID = v
+}
+
+// SetID sets id of expected reputation value in reputation contract.
+func (g *GetByIDArgs) SetID(v ReputationID) {
+	g.id = v
+}
+
+// Reputations returns slice of reputation values.
+func (g GetResult) Reputations() [][]byte {
+	return g.reputations
+}
+
+// Get invokes the call of "get reputation value" method of reputation contract.
+func (w *ClientWrapper) Get(v GetArgs) (*GetResult, error) {
+	args := reputationClient.GetArgs{}
+	args.SetEpoch(v.epoch)
+	args.SetPeerID(v.peerID.Bytes())
+
+	data, err := (*reputationClient.Client)(w).Get(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseGetResult(data)
+}
+
+// GetByID invokes the call of "get reputation value by reputation id" method
+// of reputation contract.
+func (w *ClientWrapper) GetByID(v GetByIDArgs) (*GetResult, error) {
+	args := reputationClient.GetByIDArgs{}
+	args.SetID(v.id)
+
+	data, err := (*reputationClient.Client)(w).GetByID(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseGetResult(data)
+}
+
+func parseGetResult(data *reputationClient.GetResult) (*GetResult, error) {
+	rawReputations := data.Reputations()
+
+	// todo: unmarshal all reputation values into structure
+
+	return &GetResult{
+		reputations: rawReputations,
+	}, nil
+}

--- a/pkg/morph/client/reputation/wrapper/list.go
+++ b/pkg/morph/client/reputation/wrapper/list.go
@@ -1,0 +1,55 @@
+package wrapper
+
+import (
+	reputationClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation"
+)
+
+type (
+	// ReputationID is an ID of the reputation record in reputation contract.
+	ReputationID []byte
+
+	// ListByEpochArgs groups the arguments of
+	// "list reputation ids by epoch" test invoke call.
+	ListByEpochArgs struct {
+		epoch uint64
+	}
+
+	// ListByEpochResult groups the result of "list reputation ids by epoch"
+	// test invoke.
+	ListByEpochResult struct {
+		ids []ReputationID
+	}
+)
+
+// SetEpoch sets epoch of expected reputation ids.
+func (l *ListByEpochArgs) SetEpoch(v uint64) {
+	l.epoch = v
+}
+
+// IDs returns slice of reputation id values.
+func (l ListByEpochResult) IDs() []ReputationID {
+	return l.ids
+}
+
+// ListByEpoch invokes the call of "list reputation ids by epoch" method of
+// reputation contract.
+func (w *ClientWrapper) ListByEpoch(v ListByEpochArgs) (*ListByEpochResult, error) {
+	args := reputationClient.ListByEpochArgs{}
+	args.SetEpoch(v.epoch)
+
+	data, err := (*reputationClient.Client)(w).ListByEpoch(args)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := data.IDs()
+
+	result := make([]ReputationID, 0, len(ids))
+	for i := range ids {
+		result = append(result, ids[i])
+	}
+
+	return &ListByEpochResult{
+		ids: result,
+	}, nil
+}

--- a/pkg/morph/client/reputation/wrapper/put.go
+++ b/pkg/morph/client/reputation/wrapper/put.go
@@ -1,0 +1,51 @@
+package wrapper
+
+import (
+	reputationClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+)
+
+type (
+	// PutArgs groups the arguments of "put reputation value" invocation call.
+	PutArgs struct {
+		epoch  uint64
+		peerID reputation.PeerID
+		value  []byte // todo: replace with struct
+	}
+)
+
+// SetEpoch sets epoch of reputation value.
+func (p *PutArgs) SetEpoch(v uint64) {
+	p.epoch = v
+}
+
+// SetPeerID sets peer id of reputation value.
+func (p *PutArgs) SetPeerID(v reputation.PeerID) {
+	p.peerID = v
+}
+
+// SetValue sets reputation value.
+func (p *PutArgs) SetValue(v []byte) {
+	p.value = v
+}
+
+// Put invokes direct call of "put reputation value" method of reputation contract.
+func (w *ClientWrapper) Put(v PutArgs) error {
+	args := reputationClient.PutArgs{}
+	args.SetEpoch(v.epoch)
+	args.SetPeerID(v.peerID.Bytes())
+	args.SetValue(v.value) // todo: marshal reputation value to `value` bytes there
+
+	return (*reputationClient.Client)(w).Put(args)
+}
+
+// PutViaNotary invokes notary call of "put reputation value" method of
+// reputation contract.
+func (w *ClientWrapper) PutViaNotary(v PutArgs) error {
+	args := reputationClient.PutArgs{}
+	args.SetEpoch(v.epoch)
+	args.SetPeerID(v.peerID.Bytes())
+	args.SetValue(v.value) // todo: marshal reputation value to `value` bytes there
+
+	return (*reputationClient.Client)(w).PutViaNotary(args)
+}

--- a/pkg/morph/client/reputation/wrapper/wrapper.go
+++ b/pkg/morph/client/reputation/wrapper/wrapper.go
@@ -1,0 +1,14 @@
+package wrapper
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation"
+)
+
+// ClientWrapper is a wrapper over reputation contract
+// client which implements storage of reputation values.
+type ClientWrapper reputation.Client
+
+// WrapClient wraps reputation contract client and returns ClientWrapper instance.
+func WrapClient(c *reputation.Client) *ClientWrapper {
+	return (*ClientWrapper)(c)
+}

--- a/pkg/morph/event/reputation/put.go
+++ b/pkg/morph/event/reputation/put.go
@@ -1,0 +1,68 @@
+package reputation
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	"github.com/pkg/errors"
+)
+
+// Put structure of reputation.reputationPut notification from
+// morph chain.
+type Put struct {
+	epoch  uint64
+	peerID reputation.PeerID
+	value  []byte
+}
+
+// MorphEvent implements Neo:Morph Event interface.
+func (Put) MorphEvent() {}
+
+// Epoch returns epoch value of reputation data.
+func (p Put) Epoch() uint64 {
+	return p.epoch
+}
+
+// PeerID returns peer id of reputation data.
+func (p Put) PeerID() reputation.PeerID {
+	return p.peerID
+}
+
+// Value returns reputation structure.
+func (p Put) Value() []byte {
+	return p.value // consider returning parsed structure
+}
+
+// ParsePut from notification into reputation event structure.
+func ParsePut(prms []stackitem.Item) (event.Event, error) {
+	var (
+		ev  Put
+		err error
+	)
+
+	if ln := len(prms); ln != 3 {
+		return nil, event.WrongNumberOfParameters(3, ln)
+	}
+
+	epoch, err := client.IntFromStackItem(prms[0])
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get integer epoch number")
+	}
+
+	ev.epoch = uint64(epoch)
+
+	peerID, err := client.BytesFromStackItem(prms[1])
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get peer ID value")
+	}
+
+	ev.peerID = reputation.PeerIDFromBytes(peerID)
+
+	ev.value, err = client.BytesFromStackItem(prms[2])
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get reputation value")
+	}
+
+	return ev, nil
+}

--- a/pkg/morph/event/reputation/put_test.go
+++ b/pkg/morph/event/reputation/put_test.go
@@ -5,18 +5,33 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-api-go/pkg/reputation"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
-	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParsePut(t *testing.T) {
 	var (
+		peerID reputation.PeerID
+
+		value      reputation.GlobalTrust
+		trust      reputation.Trust
+		trustValue float64 = 64
+
 		epoch uint64 = 42
 
-		peerID = reputation.PeerIDFromBytes([]byte("peerID"))
-		value  = []byte("There should be marshalled structure")
+		rawPeerID = [33]byte{1, 2, 3, 4, 5, 6}
 	)
+
+	peerID.SetPublicKey(rawPeerID)
+
+	trust.SetValue(trustValue)
+	trust.SetPeer(&peerID)
+
+	value.SetTrust(&trust)
+
+	rawValue, err := value.Marshal()
+	require.NoError(t, err)
 
 	t.Run("wrong number of parameters", func(t *testing.T) {
 		prms := []stackitem.Item{
@@ -48,7 +63,7 @@ func TestParsePut(t *testing.T) {
 	t.Run("wrong value parameter", func(t *testing.T) {
 		_, err := ParsePut([]stackitem.Item{
 			stackitem.NewBigInteger(new(big.Int).SetUint64(epoch)),
-			stackitem.NewByteArray(peerID.Bytes()),
+			stackitem.NewByteArray(rawPeerID[:]),
 			stackitem.NewMap(),
 		})
 
@@ -58,8 +73,8 @@ func TestParsePut(t *testing.T) {
 	t.Run("correct behavior", func(t *testing.T) {
 		ev, err := ParsePut([]stackitem.Item{
 			stackitem.NewBigInteger(new(big.Int).SetUint64(epoch)),
-			stackitem.NewByteArray(peerID.Bytes()),
-			stackitem.NewByteArray(value),
+			stackitem.NewByteArray(rawPeerID[:]),
+			stackitem.NewByteArray(rawValue),
 		})
 		require.NoError(t, err)
 

--- a/pkg/morph/event/reputation/put_test.go
+++ b/pkg/morph/event/reputation/put_test.go
@@ -1,0 +1,72 @@
+package reputation
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePut(t *testing.T) {
+	var (
+		epoch uint64 = 42
+
+		peerID = reputation.PeerIDFromBytes([]byte("peerID"))
+		value  = []byte("There should be marshalled structure")
+	)
+
+	t.Run("wrong number of parameters", func(t *testing.T) {
+		prms := []stackitem.Item{
+			stackitem.NewMap(),
+			stackitem.NewMap(),
+		}
+
+		_, err := ParsePut(prms)
+		require.EqualError(t, err, event.WrongNumberOfParameters(3, len(prms)).Error())
+	})
+
+	t.Run("wrong epoch parameter", func(t *testing.T) {
+		_, err := ParsePut([]stackitem.Item{
+			stackitem.NewMap(),
+		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("wrong peerID parameter", func(t *testing.T) {
+		_, err := ParsePut([]stackitem.Item{
+			stackitem.NewBigInteger(new(big.Int).SetUint64(epoch)),
+			stackitem.NewMap(),
+		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("wrong value parameter", func(t *testing.T) {
+		_, err := ParsePut([]stackitem.Item{
+			stackitem.NewBigInteger(new(big.Int).SetUint64(epoch)),
+			stackitem.NewByteArray(peerID.Bytes()),
+			stackitem.NewMap(),
+		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("correct behavior", func(t *testing.T) {
+		ev, err := ParsePut([]stackitem.Item{
+			stackitem.NewBigInteger(new(big.Int).SetUint64(epoch)),
+			stackitem.NewByteArray(peerID.Bytes()),
+			stackitem.NewByteArray(value),
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, Put{
+			epoch:  epoch,
+			peerID: peerID,
+			value:  value,
+		}, ev)
+	})
+}

--- a/pkg/network/transport/reputation/grpc/service.go
+++ b/pkg/network/transport/reputation/grpc/service.go
@@ -35,3 +35,18 @@ func (s *Server) SendLocalTrust(ctx context.Context, r *reputation2.SendLocalTru
 
 	return resp.ToGRPCMessage().(*reputation2.SendLocalTrustResponse), nil
 }
+
+func (s *Server) SendIntermediateResult(ctx context.Context, r *reputation2.SendIntermediateResultRequest) (*reputation2.SendIntermediateResultResponse, error) {
+	req := new(reputation.SendIntermediateResultRequest)
+	if err := req.FromGRPCMessage(r); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.srv.SendIntermediateResult(ctx, req)
+	if err != nil {
+		// TODO: think about how we transport errors through gRPC
+		return nil, err
+	}
+
+	return resp.ToGRPCMessage().(*reputation2.SendIntermediateResultResponse), nil
+}

--- a/pkg/services/reputation/rpc/response.go
+++ b/pkg/services/reputation/rpc/response.go
@@ -35,3 +35,16 @@ func (s *responseService) SendLocalTrust(ctx context.Context, req *reputation.Se
 
 	return resp.(*reputation.SendLocalTrustResponse), nil
 }
+
+func (s *responseService) SendIntermediateResult(ctx context.Context, req *reputation.SendIntermediateResultRequest) (*reputation.SendIntermediateResultResponse, error) {
+	resp, err := s.respSvc.HandleUnaryRequest(ctx, req,
+		func(ctx context.Context, req interface{}) (util.ResponseMessage, error) {
+			return s.svc.SendIntermediateResult(ctx, req.(*reputation.SendIntermediateResultRequest))
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*reputation.SendIntermediateResultResponse), nil
+}

--- a/pkg/services/reputation/rpc/server.go
+++ b/pkg/services/reputation/rpc/server.go
@@ -9,4 +9,5 @@ import (
 // Server is an interface of the NeoFS API v2 Reputation service server.
 type Server interface {
 	SendLocalTrust(context.Context, *reputation.SendLocalTrustRequest) (*reputation.SendLocalTrustResponse, error)
+	SendIntermediateResult(context.Context, *reputation.SendIntermediateResultRequest) (*reputation.SendIntermediateResultResponse, error)
 }

--- a/pkg/services/reputation/rpc/sign.go
+++ b/pkg/services/reputation/rpc/sign.go
@@ -33,3 +33,16 @@ func (s *signService) SendLocalTrust(ctx context.Context, req *reputation.SendLo
 
 	return resp.(*reputation.SendLocalTrustResponse), nil
 }
+
+func (s *signService) SendIntermediateResult(ctx context.Context, req *reputation.SendIntermediateResultRequest) (*reputation.SendIntermediateResultResponse, error) {
+	resp, err := s.sigSvc.HandleUnaryRequest(ctx, req,
+		func(ctx context.Context, req interface{}) (util.ResponseMessage, error) {
+			return s.svc.SendIntermediateResult(ctx, req.(*reputation.SendIntermediateResultRequest))
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*reputation.SendIntermediateResultResponse), nil
+}


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neofs-contract/pull/65

- [x] Support reputation contract in morph/client
- [x] Add client wrapper
- [x] Support reputation put event 
- [x] Add reputation processor to inner ring node
- [x] Add comments
- [x] Use structure to represent reputation value instead of `[]byte`.