### PR TITLE
Increase duration of notary deposit

### DIFF
--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -110,8 +110,9 @@ const (
 	mainnetPrefix = "mainnet"
 
 	// extra blocks to overlap two deposits, we do that to make sure that
-	// there won't be any blocks without deposited assets in notary contract.
-	notaryExtraBlocks = 100
+	// there won't be any blocks without deposited assets in notary contract;
+	// make sure it is bigger than any extra rounding value in notary client.
+	notaryExtraBlocks = 300
 	// amount of tries before notary deposit timeout.
 	notaryDepositTimeout = 100
 )


### PR DESCRIPTION
Extra blocks for notary deposit must not be less than extra blocks at notary tx rounding.

Consider you make notary deposit every 1000 block for next 1100 blocks. At block 555 you made notary deposit up to 1655.

At block 1554 you want to send notary tx. Notary client uses rounding to calculate `until` value. By default notary client rounds with up to 150 block ahead, thus for tx at 1554 `until` will be 1700.

1700 is bigger than deposit limit at 1655 and tx will fail. However if extra blocks for notary deposit will be 200, then this case
won't be possible. 