### PR TITLE
Print transaction hashes in LE

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -155,7 +155,7 @@ func (c *Client) TransferGas(receiver util.Uint160, amount fixedn.Fixed8) error 
 
 	c.logger.Debug("native gas transfer invoke",
 		zap.String("to", receiver.StringLE()),
-		zap.Stringer("tx_hash", txHash))
+		zap.Stringer("tx_hash", txHash.Reverse()))
 
 	return nil
 }

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -119,7 +119,7 @@ func (c *Client) DepositNotary(amount fixedn.Fixed8, delta uint32) error {
 	c.logger.Debug("notary deposit invoke",
 		zap.Int64("amount", int64(amount)),
 		zap.Uint32("expire_at", bc+delta),
-		zap.Stringer("tx_hash", txHash))
+		zap.Stringer("tx_hash", txHash.Reverse()))
 
 	return nil
 }


### PR DESCRIPTION
neo-go JSON RPC server expect all hashes in LE, e.g. in `getapplicationlog` method.