### PR TITLE
Feature/add tranport for local trusts

### DIFF
--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -380,7 +380,7 @@ func (c *usedSpaceService) AnnounceUsedSpace(ctx context.Context, req *container
 	var passedRoute []loadroute.ServerInfo
 
 	for hdr := req.GetVerificationHeader(); hdr != nil; hdr = hdr.GetOrigin() {
-		passedRoute = append(passedRoute, &onlyKeyRemoteServerInfo{
+		passedRoute = append(passedRoute, &containerOnlyKeyRemoteServerInfo{
 			key: hdr.GetBodySignature().GetKey(),
 		})
 	}
@@ -412,15 +412,15 @@ func (c *usedSpaceService) AnnounceUsedSpace(ctx context.Context, req *container
 
 var errNodeOutsideContainer = errors.New("node outside the container")
 
-type onlyKeyRemoteServerInfo struct {
+type containerOnlyKeyRemoteServerInfo struct {
 	key []byte
 }
 
-func (i *onlyKeyRemoteServerInfo) PublicKey() []byte {
+func (i *containerOnlyKeyRemoteServerInfo) PublicKey() []byte {
 	return i.key
 }
 
-func (*onlyKeyRemoteServerInfo) Address() string {
+func (*containerOnlyKeyRemoteServerInfo) Address() string {
 	return ""
 }
 

--- a/pkg/network/transport/reputation/grpc/service.go
+++ b/pkg/network/transport/reputation/grpc/service.go
@@ -8,8 +8,8 @@ import (
 	reputationrpc "github.com/nspcc-dev/neofs-node/pkg/services/reputation/rpc"
 )
 
-// Server wraps NeoFS API v2 Container service server
-// and provides gRPC Container service server interface.
+// Server wraps NeoFS API v2 Reputation service server
+// and provides gRPC Reputation service server interface.
 type Server struct {
 	srv reputationrpc.Server
 }

--- a/pkg/services/container/announcement/load/route/placement/builder.go
+++ b/pkg/services/container/announcement/load/route/placement/builder.go
@@ -36,11 +36,11 @@ func panicOnPrmValue(n string, v interface{}) {
 // Panics if at least one value of the parameters is invalid.
 //
 // The created Builder does not require additional
-// initialization and is completely ready for work
+// initialization and is completely ready for work.
 func New(prm Prm) *Builder {
 	switch {
 	case prm.PlacementBuilder == nil:
-		panicOnPrmValue("RemoteWriterProvider", prm.PlacementBuilder)
+		panicOnPrmValue("PlacementBuilder", prm.PlacementBuilder)
 	}
 
 	return &Builder{

--- a/pkg/services/reputation/local/controller/calls.go
+++ b/pkg/services/reputation/local/controller/calls.go
@@ -36,7 +36,7 @@ func (c *Controller) Report(prm ReportPrm) {
 	// report local trust values
 	reportCtx.report()
 
-	// finally stop and free the announcement
+	// finally stop and free the report
 	c.freeReport(prm.epoch, reportCtx.log)
 }
 

--- a/pkg/services/reputation/local/controller/controller.go
+++ b/pkg/services/reputation/local/controller/controller.go
@@ -19,7 +19,7 @@ type Prm struct {
 	LocalTrustSource IteratorProvider
 
 	// Place of recording the local values of
-	// the used space of containers.
+	// trust to other nodes.
 	//
 	// Must not be nil.
 	LocalTrustTarget WriterProvider

--- a/pkg/services/reputation/local/controller/deps.go
+++ b/pkg/services/reputation/local/controller/deps.go
@@ -28,7 +28,7 @@ type Writer interface {
 	// physical target. Implementations can cache values before
 	// Close operation.
 	//
-	// Put must not be called after Close.
+	// Write must not be called after Close.
 	Write(reputation.Trust) error
 
 	// Close exits with method-providing Writer.

--- a/pkg/services/reputation/local/route/calls.go
+++ b/pkg/services/reputation/local/route/calls.go
@@ -1,0 +1,132 @@
+package reputationroute
+
+import (
+	"sync"
+
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
+	"go.uber.org/zap"
+)
+
+type routeContext struct {
+	reputationcontroller.Context
+
+	passedRoute []ServerInfo
+}
+
+// NewRouteContext wraps the main context of value passing with its traversal route and epoch.
+func NewRouteContext(ctx reputationcontroller.Context, passed []ServerInfo) reputationcontroller.Context {
+	return &routeContext{
+		Context:     ctx,
+		passedRoute: passed,
+	}
+}
+
+type trustWriter struct {
+	router *Router
+
+	ctx *routeContext
+
+	routeMtx sync.RWMutex
+	mServers map[string]reputationcontroller.Writer
+}
+
+// InitWriter initializes and returns Writer that sends each value to its next route point.
+//
+// If ctx was created by NewRouteContext, then the traversed route is taken into account,
+// and the value will be sent to its continuation. Otherwise, the route will be laid
+// from scratch and the value will be sent to its primary point.
+//
+// After building a list of remote points of the next leg of the route, the value is sent
+// sequentially to all of them. If any transmissions (even all) fail, an error will not
+// be returned.
+//
+// Close of the composed Writer calls Close method on each internal Writer generated in
+// runtime and never returns an error.
+//
+// Always returns nil error.
+func (r *Router) InitWriter(ctx reputationcontroller.Context) (reputationcontroller.Writer, error) {
+	var (
+		routeCtx *routeContext
+		ok       bool
+	)
+
+	if routeCtx, ok = ctx.(*routeContext); !ok {
+		routeCtx = &routeContext{
+			Context:     ctx,
+			passedRoute: []ServerInfo{r.localSrvInfo},
+		}
+	}
+
+	return &trustWriter{
+		router:   r,
+		ctx:      routeCtx,
+		mServers: make(map[string]reputationcontroller.Writer),
+	}, nil
+}
+
+func (w *trustWriter) Write(a reputation.Trust) error {
+	w.routeMtx.Lock()
+	defer w.routeMtx.Unlock()
+
+	route, err := w.router.routeBuilder.NextStage(w.ctx.Epoch(), w.ctx.passedRoute)
+	if err != nil {
+		return err
+	} else if len(route) == 0 {
+		route = []ServerInfo{nil}
+	}
+
+	for _, remoteInfo := range route {
+		var endpoint string
+
+		if remoteInfo != nil {
+			endpoint = remoteInfo.Address()
+		}
+
+		remoteWriter, ok := w.mServers[endpoint]
+		if !ok {
+			provider, err := w.router.remoteProvider.InitRemote(remoteInfo)
+			if err != nil {
+				w.router.log.Debug("could not initialize writer provider",
+					zap.String("error", err.Error()),
+				)
+
+				continue
+			}
+
+			remoteWriter, err = provider.InitWriter(w.ctx)
+			if err != nil {
+				w.router.log.Debug("could not initialize writer",
+					zap.String("error", err.Error()),
+				)
+
+				continue
+			}
+
+			w.mServers[endpoint] = remoteWriter
+		}
+
+		err := remoteWriter.Write(a)
+		if err != nil {
+			w.router.log.Debug("could not write the value",
+				zap.String("error", err.Error()),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (w *trustWriter) Close() error {
+	for endpoint, wRemote := range w.mServers {
+		err := wRemote.Close()
+		if err != nil {
+			w.router.log.Debug("could not close remote server writer",
+				zap.String("endpoint", endpoint),
+				zap.String("error", err.Error()),
+			)
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/reputation/local/route/calls.go
+++ b/pkg/services/reputation/local/route/calls.go
@@ -65,11 +65,13 @@ func (r *Router) InitWriter(ctx reputationcontroller.Context) (reputationcontrol
 	}, nil
 }
 
-func (w *trustWriter) Write(a reputation.Trust) error {
+func (w *trustWriter) Write(t reputation.Trust) error {
 	w.routeMtx.Lock()
 	defer w.routeMtx.Unlock()
 
-	route, err := w.router.routeBuilder.NextStage(w.ctx.Epoch(), w.ctx.passedRoute)
+	localPeerID := reputation.PeerIDFromBytes(w.router.localSrvInfo.PublicKey())
+
+	route, err := w.router.routeBuilder.NextStage(w.ctx.Epoch(), localPeerID, w.ctx.passedRoute)
 	if err != nil {
 		return err
 	} else if len(route) == 0 {
@@ -106,7 +108,7 @@ func (w *trustWriter) Write(a reputation.Trust) error {
 			w.mServers[endpoint] = remoteWriter
 		}
 
-		err := remoteWriter.Write(a)
+		err := remoteWriter.Write(t)
 		if err != nil {
 			w.router.log.Debug("could not write the value",
 				zap.String("error", err.Error()),

--- a/pkg/services/reputation/local/route/deps.go
+++ b/pkg/services/reputation/local/route/deps.go
@@ -1,0 +1,29 @@
+package reputationroute
+
+import (
+	reputationcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
+)
+
+// ServerInfo describes a set of
+// characteristics of a point in a route.
+type ServerInfo interface {
+	// PublicKey returns public key of the node
+	// from the route in a binary representation.
+	PublicKey() []byte
+
+	// Returns network address of the node
+	// in the route.
+	//
+	// Can be empty.
+	Address() string
+}
+
+// RemoteWriterProvider describes the component
+// for sending values to a fixed route point.
+type RemoteWriterProvider interface {
+	// InitRemote must return WriterProvider to the route point
+	// corresponding to info.
+	//
+	// Nil info matches the end of the route.
+	InitRemote(info ServerInfo) (reputationcontroller.WriterProvider, error)
+}

--- a/pkg/services/reputation/local/route/deps.go
+++ b/pkg/services/reputation/local/route/deps.go
@@ -1,6 +1,7 @@
 package reputationroute
 
 import (
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	reputationcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
 )
 
@@ -16,6 +17,18 @@ type ServerInfo interface {
 	//
 	// Can be empty.
 	Address() string
+}
+
+// Builder groups methods to route values in the network.
+type Builder interface {
+	// NextStage must return next group of route points
+	// for passed epoch and PeerID of the current route point.
+	// Implementation must take into account already passed route points.
+	//
+	// Empty passed list means being at the starting point of the route.
+	//
+	// Must return empty list and no error if the endpoint of the route is reached.
+	NextStage(epoch uint64, p reputation.PeerID, passed []ServerInfo) ([]ServerInfo, error)
 }
 
 // RemoteWriterProvider describes the component

--- a/pkg/services/reputation/local/route/managers/builder.go
+++ b/pkg/services/reputation/local/route/managers/builder.go
@@ -1,0 +1,48 @@
+package managers
+
+import "fmt"
+
+// Prm groups the required parameters of the Builder's constructor.
+//
+// All values must comply with the requirements imposed on them.
+// Passing incorrect parameter values will result in constructor
+// failure (error or panic depending on the implementation).
+type Prm struct {
+	// Manager builder for current node.
+	//
+	// Must not be nil.
+	ManagerBuilder ManagerBuilder
+}
+
+// Builder represents component that routes node to its managers.
+//
+// For correct operation, Builder must be created using
+// the constructor (New) based on the required parameters
+// and optional components. After successful creation,
+// the Builder is immediately ready to work through API.
+type Builder struct {
+	managerBuilder ManagerBuilder
+}
+
+const invalidPrmValFmt = "invalid parameter %s (%T):%v"
+
+func panicOnPrmValue(n string, v interface{}) {
+	panic(fmt.Sprintf(invalidPrmValFmt, n, v, v))
+}
+
+// New creates a new instance of the Builder.
+//
+// Panics if at least one value of the parameters is invalid.
+//
+// The created Builder does not require additional
+// initialization and is completely ready for work.
+func New(prm Prm) *Builder {
+	switch {
+	case prm.ManagerBuilder == nil:
+		panicOnPrmValue("ManagerBuilder", prm.ManagerBuilder)
+	}
+
+	return &Builder{
+		managerBuilder: prm.ManagerBuilder,
+	}
+}

--- a/pkg/services/reputation/local/route/managers/calls.go
+++ b/pkg/services/reputation/local/route/managers/calls.go
@@ -1,0 +1,23 @@
+package managers
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationroute "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/route"
+	"github.com/pkg/errors"
+)
+
+// NextStage builds Manager list for node and returns it directly.
+//
+// If passed route has more than one point, then endpoint of the route is reached.
+func (b *Builder) NextStage(epoch uint64, p reputation.PeerID, passed []reputationroute.ServerInfo) ([]reputationroute.ServerInfo, error) {
+	if len(passed) > 1 {
+		return nil, nil
+	}
+
+	route, err := b.managerBuilder.BuildManagers(epoch, p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not build managers for epoch: %d", epoch)
+	}
+
+	return route, nil
+}

--- a/pkg/services/reputation/local/route/managers/deps.go
+++ b/pkg/services/reputation/local/route/managers/deps.go
@@ -1,0 +1,14 @@
+package managers
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationroute "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/route"
+)
+
+// ManagerBuilder defines an interface for providing a list
+// of Managers for specific epoch. Implementation depends on trust value.
+type ManagerBuilder interface {
+	// BuildManagers must compose list of managers. It depends on
+	// particular epoch and PeerID of the current route point.
+	BuildManagers(epoch uint64, p reputation.PeerID) ([]reputationroute.ServerInfo, error)
+}

--- a/pkg/services/reputation/local/route/opts.go
+++ b/pkg/services/reputation/local/route/opts.go
@@ -1,0 +1,28 @@
+package reputationroute
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"go.uber.org/zap"
+)
+
+// Option sets an optional parameter of Router.
+type Option func(*options)
+
+type options struct {
+	log *logger.Logger
+}
+
+func defaultOpts() *options {
+	return &options{
+		log: zap.L(),
+	}
+}
+
+// WithLogger returns Option to specify logging component.
+func WithLogger(l *logger.Logger) Option {
+	return func(o *options) {
+		if l != nil {
+			o.log = l
+		}
+	}
+}

--- a/pkg/services/reputation/local/route/router.go
+++ b/pkg/services/reputation/local/route/router.go
@@ -1,0 +1,80 @@
+package reputationroute
+
+import (
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+)
+
+// Prm groups the required parameters of the Router's constructor.
+//
+// All values must comply with the requirements imposed on them.
+// Passing incorrect parameter values will result in constructor
+// failure (error or panic depending on the implementation).
+type Prm struct {
+	// Characteristics of the local node's server.
+	//
+	// Must not be nil.
+	LocalServerInfo ServerInfo
+
+	// Component for sending values to a fixed route point.
+	//
+	// Must not be nil.
+	RemoteWriterProvider RemoteWriterProvider
+
+	// Route planner.
+	//
+	// Must not be nil.
+	Builder Builder
+}
+
+// Router represents component responsible for routing
+// local trust values over the network.
+//
+// For each fixed pair (node peer, epoch) there is a
+// single value route on the network. Router provides the
+// interface for writing values to the next point of the route.
+//
+// For correct operation, Router must be created using
+// the constructor (New) based on the required parameters
+// and optional components. After successful creation,
+// the Router is immediately ready to work through API.
+type Router struct {
+	log *logger.Logger
+
+	remoteProvider RemoteWriterProvider
+
+	routeBuilder Builder
+
+	localSrvInfo ServerInfo
+}
+
+const invalidPrmValFmt = "invalid parameter %s (%T):%v"
+
+func panicOnPrmValue(n string, v interface{}) {
+	panic(fmt.Sprintf(invalidPrmValFmt, n, v, v))
+}
+
+func New(prm Prm, opts ...Option) *Router {
+	switch {
+	case prm.RemoteWriterProvider == nil:
+		panicOnPrmValue("RemoteWriterProvider", prm.RemoteWriterProvider)
+	case prm.Builder == nil:
+		panicOnPrmValue("Builder", prm.Builder)
+	case prm.LocalServerInfo == nil:
+		panicOnPrmValue("LocalServerInfo", prm.LocalServerInfo)
+	}
+
+	o := defaultOpts()
+
+	for i := range opts {
+		opts[i](o)
+	}
+
+	return &Router{
+		log:            o.log,
+		remoteProvider: prm.RemoteWriterProvider,
+		routeBuilder:   prm.Builder,
+		localSrvInfo:   prm.LocalServerInfo,
+	}
+}

--- a/pkg/services/reputation/local/route/util.go
+++ b/pkg/services/reputation/local/route/util.go
@@ -1,0 +1,39 @@
+package reputationroute
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+)
+
+var errWrongRoute = errors.New("wrong route")
+
+// CheckRoute checks if the route is a route correctly constructed by the builder for value a.
+//
+// Returns nil if route is correct, otherwise an error clarifying the inconsistency.
+func CheckRoute(builder Builder, epoch uint64, peer reputation.PeerID, route []ServerInfo) error {
+	for i := 1; i < len(route); i++ {
+		servers, err := builder.NextStage(epoch, peer, route[:i])
+		if err != nil {
+			return err
+		} else if len(servers) == 0 {
+			break
+		}
+
+		found := false
+
+		for j := range servers {
+			if bytes.Equal(servers[j].PublicKey(), route[i].PublicKey()) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return errWrongRoute
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implement `Router` and its necessary dependencies for local `reputation.Trust`s. Add `Router` to `reputationServer`.

Fix some logical mistakes in the reputation controller's commentaries.