### PR TITLE
metabase: Delete graves regardless of the presence of objects

### DIFF
--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -102,3 +102,16 @@ func TestDeleteAllChildren(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ex)
 }
+
+func TestGraveOnlyDelete(t *testing.T) {
+	db := newDB(t)
+	defer releaseDB(db)
+
+	addr := generateAddress()
+
+	// inhume non-existent object by address
+	require.NoError(t, meta.Inhume(db, addr, nil))
+
+	// delete the object data
+	require.NoError(t, meta.Delete(db, addr))
+}


### PR DESCRIPTION
`Inhume` operation can be performed on already deleted objects, and in this
case the entry will be added to the graveyard. `Delete` operation finishes
with error if object is not presented in metabase. However, the entry in the
cemetery must be deleted regardless of the presence of the object.

Additionally, now `Delete` does not return an error in the absence of an
object.

Closes #461.