### PR TITLE
Add audit fee in settlement and unify transfer detail format

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -110,6 +110,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("audit.por.pool_size", "10")
 
 	cfg.SetDefault("settlement.basic_income_rate", 0)
+	cfg.SetDefault("settlement.audit_fee", 0)
 
 	cfg.SetDefault("indexer.cache_timeout", 15*time.Second)
 

--- a/pkg/innerring/config/config.go
+++ b/pkg/innerring/config/config.go
@@ -37,3 +37,12 @@ func (c *GlobalConfig) BasicIncomeRate() (uint64, error) {
 
 	return c.nm.BasinIncomeRate()
 }
+
+func (c *GlobalConfig) AuditFee() (uint64, error) {
+	value := c.cfg.GetUint64("settlement.audit_fee")
+	if value != 0 {
+		return value, nil
+	}
+
+	return c.nm.AuditFee()
+}

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -387,13 +387,13 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 
 	// create settlement processor dependencies
 	settlementDeps := &settlementDeps{
+		globalConfig:  globalConfig,
 		log:           server.log,
 		cnrSrc:        cnrClient,
 		auditClient:   server.auditClient,
 		nmSrc:         nmClient,
 		clientCache:   clientCache,
 		balanceClient: balClient,
-		cfg:           globalConfig,
 	}
 
 	auditCalcDeps := &auditSettlementDeps{

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -393,6 +393,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 		nmSrc:         nmClient,
 		clientCache:   clientCache,
 		balanceClient: balClient,
+		cfg:           globalConfig,
 	}
 
 	auditCalcDeps := &auditSettlementDeps{
@@ -402,7 +403,6 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 	basicSettlementDeps := &basicIncomeSettlementDeps{
 		settlementDeps: settlementDeps,
 		cnrClient:      cnrClient,
-		cfg:            globalConfig,
 	}
 
 	auditSettlementCalc := auditSettlement.NewCalculator(
@@ -413,6 +413,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 			SGStorage:           auditCalcDeps,
 			AccountStorage:      auditCalcDeps,
 			Exchanger:           auditCalcDeps,
+			AuditFeeFetcher:     auditCalcDeps,
 		},
 		auditSettlement.WithLogger(server.log),
 	)

--- a/pkg/innerring/processors/neofs/process_assets.go
+++ b/pkg/innerring/processors/neofs/process_assets.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	// txLogPrefix used for balance transfer comments in balance contract.
-	txLogPrefix = "mainnet:"
-
 	// lockAccountLifeTime defines amount of epochs when lock account is valid.
 	lockAccountLifetime uint64 = 20
 )
@@ -28,7 +25,7 @@ func (np *Processor) processDeposit(deposit *neofsEvent.Deposit) {
 		&invoke.MintBurnParams{
 			ScriptHash: deposit.To().BytesBE(),
 			Amount:     np.converter.ToBalancePrecision(deposit.Amount()),
-			Comment:    append([]byte(txLogPrefix), deposit.ID()...),
+			Comment:    deposit.ID(),
 		})
 	if err != nil {
 		np.log.Error("can't transfer assets to balance contract", zap.Error(err))
@@ -87,11 +84,6 @@ func (np *Processor) processWithdraw(withdraw *neofsEvent.Withdraw) {
 		return
 	}
 
-	if len(withdraw.ID()) < util.Uint160Size {
-		np.log.Error("tx id size is less than script hash size")
-		return
-	}
-
 	// create lock account
 	// fixme: check collision there, consider reversed script hash
 	lock, err := util.Uint160DecodeBytesBE(withdraw.ID()[:util.Uint160Size])
@@ -127,7 +119,7 @@ func (np *Processor) processCheque(cheque *neofsEvent.Cheque) {
 		&invoke.MintBurnParams{
 			ScriptHash: cheque.LockAccount().BytesBE(),
 			Amount:     np.converter.ToBalancePrecision(cheque.Amount()),
-			Comment:    append([]byte(txLogPrefix), cheque.ID()...),
+			Comment:    cheque.ID(),
 		})
 	if err != nil {
 		np.log.Error("can't transfer assets to fed contract", zap.Error(err))

--- a/pkg/innerring/processors/settlement/audit/calculate.go
+++ b/pkg/innerring/processors/settlement/audit/calculate.go
@@ -65,8 +65,9 @@ func (c *Calculator) Calculate(p *CalculatePrm) {
 	log.Info("calculate audit settlements")
 
 	log.Debug("getting results for the previous epoch")
+	prevEpoch := p.Epoch - 1
 
-	auditResults, err := c.prm.ResultStorage.AuditResultsForEpoch(p.Epoch - 1)
+	auditResults, err := c.prm.ResultStorage.AuditResultsForEpoch(prevEpoch)
 	if err != nil {
 		log.Error("could not collect audit results")
 		return
@@ -99,7 +100,7 @@ func (c *Calculator) Calculate(p *CalculatePrm) {
 
 	log.Debug("processing transfers")
 
-	common.TransferAssets(c.prm.Exchanger, table)
+	common.TransferAssets(c.prm.Exchanger, table, common.AuditSettlementDetails(prevEpoch))
 }
 
 func (c *Calculator) processResult(ctx *singleResultCtx) {

--- a/pkg/innerring/processors/settlement/audit/prm.go
+++ b/pkg/innerring/processors/settlement/audit/prm.go
@@ -19,6 +19,8 @@ type CalculatorPrm struct {
 	AccountStorage common.AccountStorage
 
 	Exchanger common.Exchanger
+
+	AuditFeeFetcher FeeFetcher
 }
 
 // ResultStorage is an interface of storage of the audit results.
@@ -38,4 +40,10 @@ type SGInfo interface {
 type SGStorage interface {
 	// Must return information about the storage group by address.
 	SGInfo(*object.Address) (SGInfo, error)
+}
+
+// FeeFetcher wraps AuditFee method that returns audit fee price from
+// the network configuration.
+type FeeFetcher interface {
+	AuditFee() (uint64, error)
 }

--- a/pkg/innerring/processors/settlement/basic/collect.go
+++ b/pkg/innerring/processors/settlement/basic/collect.go
@@ -70,7 +70,7 @@ func (inc *IncomeSettlementContext) Collect() {
 		})
 	}
 
-	common.TransferAssets(inc.exchange, txTable)
+	common.TransferAssets(inc.exchange, txTable, common.BasicIncomeCollectionDetails(inc.epoch))
 }
 
 // avgEstimation returns estimation value for single container. Right now it

--- a/pkg/innerring/processors/settlement/basic/distribute.go
+++ b/pkg/innerring/processors/settlement/basic/distribute.go
@@ -41,7 +41,7 @@ func (inc *IncomeSettlementContext) Distribute() {
 		})
 	})
 
-	common.TransferAssets(inc.exchange, txTable)
+	common.TransferAssets(inc.exchange, txTable, common.BasicIncomeDistributionDetails(inc.epoch))
 }
 
 func normalizedValue(n, total, limit *big.Int) *big.Int {

--- a/pkg/innerring/processors/settlement/common/details.go
+++ b/pkg/innerring/processors/settlement/common/details.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"encoding/binary"
+)
+
+var (
+	auditPrefix                   = []byte{0x40}
+	basicIncomeCollectionPrefix   = []byte{0x41}
+	basicIncomeDistributionPrefix = []byte{0x42}
+)
+
+func AuditSettlementDetails(epoch uint64) []byte {
+	return details(auditPrefix, epoch)
+}
+
+func BasicIncomeCollectionDetails(epoch uint64) []byte {
+	return details(basicIncomeCollectionPrefix, epoch)
+}
+
+func BasicIncomeDistributionDetails(epoch uint64) []byte {
+	return details(basicIncomeDistributionPrefix, epoch)
+}
+
+func details(prefix []byte, epoch uint64) []byte {
+	prefixLen := len(prefix)
+	buf := make([]byte, prefixLen+8)
+
+	copy(buf, prefix)
+	binary.LittleEndian.PutUint64(buf[prefixLen:], epoch)
+
+	return buf
+}

--- a/pkg/innerring/processors/settlement/common/details_test.go
+++ b/pkg/innerring/processors/settlement/common/details_test.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditSettlementDetails(t *testing.T) {
+	var n uint64 = 1994 // 0x7CA
+	exp := []byte{0x40, 0xCA, 0x07, 0, 0, 0, 0, 0, 0}
+	got := AuditSettlementDetails(n)
+	require.Equal(t, exp, got)
+}
+
+func TestBasicIncomeCollectionDetails(t *testing.T) {
+	var n uint64 = 1994 // 0x7CA
+	exp := []byte{0x41, 0xCA, 0x07, 0, 0, 0, 0, 0, 0}
+	got := BasicIncomeCollectionDetails(n)
+	require.Equal(t, exp, got)
+}
+
+func TestBasicIncomeDistributionDetails(t *testing.T) {
+	var n uint64 = 1994 // 0x7CA
+	exp := []byte{0x42, 0xCA, 0x07, 0, 0, 0, 0, 0, 0}
+	got := BasicIncomeDistributionDetails(n)
+	require.Equal(t, exp, got)
+}

--- a/pkg/innerring/processors/settlement/common/types.go
+++ b/pkg/innerring/processors/settlement/common/types.go
@@ -50,5 +50,5 @@ type Exchanger interface {
 	// Must transfer amount of GASe-12 from sender to recipient.
 	//
 	// Amount must be positive.
-	Transfer(sender, recipient *owner.ID, amount *big.Int)
+	Transfer(sender, recipient *owner.ID, amount *big.Int, details []byte)
 }

--- a/pkg/innerring/processors/settlement/common/util.go
+++ b/pkg/innerring/processors/settlement/common/util.go
@@ -56,7 +56,7 @@ func (t *TransferTable) Iterate(f func(*TransferTx)) {
 	}
 }
 
-func TransferAssets(e Exchanger, t *TransferTable) {
+func TransferAssets(e Exchanger, t *TransferTable, details []byte) {
 	t.Iterate(func(tx *TransferTx) {
 		sign := tx.Amount.Sign()
 		if sign == 0 {
@@ -68,6 +68,6 @@ func TransferAssets(e Exchanger, t *TransferTable) {
 			tx.Amount.Neg(tx.Amount)
 		}
 
-		e.Transfer(tx.From, tx.To, tx.Amount)
+		e.Transfer(tx.From, tx.To, tx.Amount, details)
 	})
 }

--- a/pkg/innerring/settlement.go
+++ b/pkg/innerring/settlement.go
@@ -28,6 +28,7 @@ import (
 
 type globalConfig interface {
 	BasicIncomeRate() (uint64, error)
+	AuditFee() (uint64, error)
 }
 
 type settlementDeps struct {
@@ -42,6 +43,8 @@ type settlementDeps struct {
 	clientCache *ClientCache
 
 	balanceClient *balanceClient.Wrapper
+
+	cfg globalConfig
 }
 
 type auditSettlementDeps struct {
@@ -51,7 +54,6 @@ type auditSettlementDeps struct {
 type basicIncomeSettlementDeps struct {
 	*settlementDeps
 	cnrClient *containerClient.Wrapper
-	cfg       globalConfig
 }
 
 type basicSettlementConstructor struct {
@@ -225,6 +227,10 @@ func (s settlementDeps) transfer(sender, recipient *owner.ID, amount *big.Int, d
 
 func (a auditSettlementDeps) Transfer(sender, recipient *owner.ID, amount *big.Int) {
 	a.transfer(sender, recipient, amount, transferAuditDetails)
+}
+
+func (a auditSettlementDeps) AuditFee() (uint64, error) {
+	return a.cfg.AuditFee()
 }
 
 func (b basicIncomeSettlementDeps) Transfer(sender, recipient *owner.ID, amount *big.Int) {

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -8,6 +8,7 @@ import (
 const (
 	maxObjectSizeConfig   = "MaxObjectSize"
 	basicIncomeRateConfig = "BasicIncomeRate"
+	auditFee              = "AuditFee"
 )
 
 // MaxObjectSize receives max object size configuration
@@ -30,6 +31,17 @@ func (w *Wrapper) BasinIncomeRate() (uint64, error) {
 	}
 
 	return rate, nil
+}
+
+// AuditFee returns audit fee configuration value from network
+// config in netmap contract.
+func (w *Wrapper) AuditFee() (uint64, error) {
+	fee, err := w.readUInt64Config(auditFee)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get audit fee", w)
+	}
+
+	return fee, nil
 }
 
 func (w *Wrapper) readUInt64Config(key string) (uint64, error) {


### PR DESCRIPTION
At settlement processing, alphabet nodes will transfer `AuditFee` from container owner to inner ring node that performed audit. `AuditFee` value takes from global configuration in network map contract.

Also this PR unifies format of transfer details.  Unified format uses transfer type as the first byte and extra details next. List of transfer types used in contracts defined in `details.go`. It includes:
- audit settlement,
- basic income collection,
- basic income distribution.

Closes #464 