### PR TITLE
Don't send UpdateState tx at shutdown by default

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -107,6 +107,8 @@ const (
 	cfgReBootstrapEnabled  = "bootstrap.periodic.enabled"
 	cfgReBootstrapInterval = "bootstrap.periodic.interval"
 
+	cfgShutdownOfflineEnabled = "shutdown.offline.enabled"
+
 	cfgObjectPutPoolSize       = "pool.object.put.size"
 	cfgObjectGetPoolSize       = "pool.object.get.size"
 	cfgObjectHeadPoolSize      = "pool.object.head.size"
@@ -251,6 +253,8 @@ type cfgNetmap struct {
 
 	reBootstrapEnabled  bool
 	reBootstrapInterval uint64 // in epochs
+
+	goOfflineEnabled bool // send `UpdateState(offline)` tx at shutdown
 }
 
 type BootstrapType uint32
@@ -354,6 +358,7 @@ func initCfg(path string) *cfg {
 			state:               state,
 			reBootstrapInterval: viperCfg.GetUint64(cfgReBootstrapInterval),
 			reBootstrapEnabled:  viperCfg.GetBool(cfgReBootstrapEnabled),
+			goOfflineEnabled:    viperCfg.GetBool(cfgShutdownOfflineEnabled),
 		},
 		cfgNodeInfo: cfgNodeInfo{
 			bootType:   StorageNode,

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -85,7 +85,9 @@ func shutdown(c *cfg) {
 		closer()
 	}
 
-	goOffline(c)
+	if c.cfgNetmap.goOfflineEnabled {
+		goOffline(c)
+	}
 
 	c.wg.Wait()
 }


### PR DESCRIPTION
If `shutdown.offline.enabled` config option set to true, then  send netmap.UpdateState(offline) tx at the shutdown. This config
option is not set by default.

Fixes #462 