### PR TITLE
Feature/add async worker notification handler

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -87,12 +87,16 @@ const (
 	cfgAccountingFee      = "accounting.fee"
 
 	// config keys for cfgNetmap
-	cfgNetmapContract = "netmap.scripthash"
-	cfgNetmapFee      = "netmap.fee"
+	cfgNetmapContract          = "netmap.scripthash"
+	cfgNetmapFee               = "netmap.fee"
+	cfgNetmapWorkerPoolEnabled = "netmap.async_worker.enabled"
+	cfgNetmapWorkerPoolSize    = "netmap.async_worker.size"
 
 	// config keys for cfgContainer
-	cfgContainerContract = "container.scripthash"
-	cfgContainerFee      = "container.fee"
+	cfgContainerContract          = "container.scripthash"
+	cfgContainerFee               = "container.fee"
+	cfgContainerWorkerPoolEnabled = "container.async_worker.enabled"
+	cfgContainerWorkerPoolSize    = "container.async_worker.size"
 
 	cfgGCQueueSize = "gc.queuesize"
 	cfgGCQueueTick = "gc.duration.sleep"
@@ -235,6 +239,7 @@ type cfgContainer struct {
 
 	parsers     map[event.Type]event.Parser
 	subscribers map[event.Type][]event.Handler
+	workerPool  util2.WorkerPool // pool for asynchronous handlers
 }
 
 type cfgNetmap struct {
@@ -246,6 +251,7 @@ type cfgNetmap struct {
 	parsers map[event.Type]event.Parser
 
 	subscribers map[event.Type][]event.Handler
+	workerPool  util2.WorkerPool // pool for asynchronous handlers
 
 	state *networkState
 
@@ -332,6 +338,13 @@ func initCfg(path string) *cfg {
 
 	state := newNetworkState()
 
+	// initialize async workers if it is configured so
+	containerWorkerPool, err := initContainerWorkerPool(viperCfg)
+	fatalOnErr(err)
+
+	netmapWorkerPool, err := initNetmapWorkerPool(viperCfg)
+	fatalOnErr(err)
+
 	c := &cfg{
 		ctx:         context.Background(),
 		internalErr: make(chan error),
@@ -347,11 +360,13 @@ func initCfg(path string) *cfg {
 		cfgContainer: cfgContainer{
 			scriptHash: u160Container,
 			fee:        fixedn.Fixed8(viperCfg.GetInt(cfgContainerFee)),
+			workerPool: containerWorkerPool,
 		},
 		cfgNetmap: cfgNetmap{
 			scriptHash:          u160Netmap,
 			fee:                 fixedn.Fixed8(viperCfg.GetInt(cfgNetmapFee)),
 			state:               state,
+			workerPool:          netmapWorkerPool,
 			reBootstrapInterval: viperCfg.GetUint64(cfgReBootstrapInterval),
 			reBootstrapEnabled:  viperCfg.GetBool(cfgReBootstrapEnabled),
 		},
@@ -423,9 +438,13 @@ func defaultConfiguration(v *viper.Viper) {
 
 	v.SetDefault(cfgContainerContract, "9d2ca84d7fb88213c4baced5a6ed4dc402309039")
 	v.SetDefault(cfgContainerFee, "1")
+	v.SetDefault(cfgContainerWorkerPoolEnabled, true)
+	v.SetDefault(cfgContainerWorkerPoolSize, 10)
 
 	v.SetDefault(cfgNetmapContract, "75194459637323ea8837d2afe8225ec74a5658c3")
 	v.SetDefault(cfgNetmapFee, "1")
+	v.SetDefault(cfgNetmapWorkerPoolEnabled, true)
+	v.SetDefault(cfgNetmapWorkerPoolSize, 10)
 
 	v.SetDefault(cfgLogLevel, "info")
 	v.SetDefault(cfgLogFormat, "console")
@@ -709,6 +728,26 @@ func initObjectPool(cfg *viper.Viper) (pool cfgObjectRoutines) {
 	}
 
 	return pool
+}
+
+func initNetmapWorkerPool(v *viper.Viper) (util2.WorkerPool, error) {
+	if v.GetBool(cfgNetmapWorkerPoolEnabled) {
+		// return async worker pool
+		return ants.NewPool(v.GetInt(cfgNetmapWorkerPoolSize))
+	}
+
+	// return sync worker pool
+	return util2.SyncWorkerPool{}, nil
+}
+
+func initContainerWorkerPool(v *viper.Viper) (util2.WorkerPool, error) {
+	if v.GetBool(cfgContainerWorkerPoolEnabled) {
+		// return async worker pool
+		return ants.NewPool(v.GetInt(cfgContainerWorkerPoolSize))
+	}
+
+	// return sync worker pool
+	return util2.SyncWorkerPool{}, nil
 }
 
 func (c *cfg) LocalNodeInfo() (*netmapV2.NodeInfo, error) {

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -138,6 +138,7 @@ func initContainerService(c *cfg) {
 	)
 }
 
+// addContainerNotificationHandler adds handler that will be executed synchronously
 func addContainerNotificationHandler(c *cfg, sTyp string, h event.Handler) {
 	typ := event.TypeFromString(sTyp)
 
@@ -146,6 +147,19 @@ func addContainerNotificationHandler(c *cfg, sTyp string, h event.Handler) {
 	}
 
 	c.cfgContainer.subscribers[typ] = append(c.cfgContainer.subscribers[typ], h)
+}
+
+// addContainerAsyncNotificationHandler adds handler that will be executed asynchronously via container workerPool
+func addContainerAsyncNotificationHandler(c *cfg, sTyp string, h event.Handler) {
+	addContainerNotificationHandler(
+		c,
+		sTyp,
+		event.WorkerPoolHandler(
+			c.cfgContainer.workerPool,
+			h,
+			c.log,
+		),
+	)
 }
 
 func setContainerNotificationParser(c *cfg, sTyp string, p event.Parser) {

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -106,14 +106,14 @@ func initContainerService(c *cfg) {
 	)
 
 	setContainerNotificationParser(c, startEstimationNotifyEvent, containerEvent.ParseStartEstimation)
-	addContainerNotificationHandler(c, startEstimationNotifyEvent, func(ev event.Event) {
+	addContainerAsyncNotificationHandler(c, startEstimationNotifyEvent, func(ev event.Event) {
 		ctrl.Start(loadcontroller.StartPrm{
 			Epoch: ev.(containerEvent.StartEstimation).Epoch(),
 		})
 	})
 
 	setContainerNotificationParser(c, stopEstimationNotifyEvent, containerEvent.ParseStopEstimation)
-	addContainerNotificationHandler(c, stopEstimationNotifyEvent, func(ev event.Event) {
+	addContainerAsyncNotificationHandler(c, stopEstimationNotifyEvent, func(ev event.Event) {
 		ctrl.Stop(loadcontroller.StopPrm{
 			Epoch: ev.(containerEvent.StopEstimation).Epoch(),
 		})

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -74,7 +74,7 @@ func initNetmapService(c *cfg) {
 	})
 
 	if c.cfgNetmap.reBootstrapEnabled {
-		addNewEpochNotificationHandler(c, func(ev event.Event) {
+		addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {
 			n := ev.(netmapEvent.NewEpoch).EpochNumber()
 
 			if n%c.cfgNetmap.reBootstrapInterval == 0 {
@@ -86,7 +86,7 @@ func initNetmapService(c *cfg) {
 		})
 	}
 
-	addNewEpochNotificationHandler(c, func(ev event.Event) {
+	addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {
 		e := ev.(netmapEvent.NewEpoch).EpochNumber()
 
 		ni, err := c.netmapLocalNodeState(e)

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -167,8 +167,22 @@ func (c *cfg) localNodeInfoFromNetmap(nm *netmapSDK.Netmap) *netmapSDK.NodeInfo 
 	return nil
 }
 
+// addNewEpochNotificationHandler adds handler that will be executed synchronously
 func addNewEpochNotificationHandler(c *cfg, h event.Handler) {
 	addNetmapNotificationHandler(c, newEpochNotification, h)
+}
+
+// addNewEpochAsyncNotificationHandler adds handler that will be executed asynchronously via netmap workerPool
+func addNewEpochAsyncNotificationHandler(c *cfg, h event.Handler) {
+	addNetmapNotificationHandler(
+		c,
+		newEpochNotification,
+		event.WorkerPoolHandler(
+			c.cfgNetmap.workerPool,
+			h,
+			c.log,
+		),
+	)
 }
 
 func goOffline(c *cfg) {

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -309,15 +309,17 @@ func initReputationService(c *cfg) {
 		LocalTrustTarget: router,
 	})
 
-	addNewEpochNotificationHandler(c, func(ev event.Event) {
-		var reportPrm trustcontroller.ReportPrm
+	addNewEpochAsyncNotificationHandler(
+		c,
+		func(ev event.Event) {
+			var reportPrm trustcontroller.ReportPrm
 
-		// report collected values from previous epoch
-		reportPrm.SetEpoch(ev.(netmap.NewEpoch).EpochNumber() - 1)
+			// report collected values from previous epoch
+			reportPrm.SetEpoch(ev.(netmap.NewEpoch).EpochNumber() - 1)
 
-		// TODO: implement and use worker pool [neofs-node#440]
-		go c.cfgReputation.localTrustCtrl.Report(reportPrm)
-	})
+			c.cfgReputation.localTrustCtrl.Report(reportPrm)
+		},
+	)
 
 	v2reputationgrpc.RegisterReputationServiceServer(c.cfgGRPC.server,
 		grpcreputation.New(

--- a/pkg/morph/event/utils.go
+++ b/pkg/morph/event/utils.go
@@ -1,6 +1,10 @@
 package event
 
-import "github.com/nspcc-dev/neo-go/pkg/util"
+import (
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	util2 "github.com/nspcc-dev/neofs-node/pkg/util"
+	"go.uber.org/zap"
+)
 
 type scriptHashValue struct {
 	hash util.Uint160
@@ -33,4 +37,19 @@ func (s *typeValue) SetType(v Type) {
 // GetType is an event type getter.
 func (s typeValue) GetType() Type {
 	return s.typ
+}
+
+// WorkerPoolHandler sets closure over worker pool w with passed handler h.
+func WorkerPoolHandler(w util2.WorkerPool, h Handler, log *zap.Logger) Handler {
+	return func(e Event) {
+		err := w.Submit(func() {
+			h(e)
+		})
+
+		if err != nil {
+			log.Warn("could not Submit handler to worker pool",
+				zap.String("error", err.Error()),
+			)
+		}
+	}
 }


### PR DESCRIPTION
Closes #440.

Added 1 notification worker pool per one contract(one in `cfgNetmap` and one in `cfgContainer` structs). Added `WorkerPoolHandler` func that creates a closure over worker pool with `event.Handler`. It is assumed that every async handler will be created using that func in the future.

In `containter` and `netmap` files of the `main` pkg added function that creates closures over handler with appropriate worker pool => to make handler execute asynchronously it is only needed to add handlers with appropriate `add...AsyncNotificationHandler()` func with the same signature.

Behavior can be configured with env vars: 
1. make all async operations sync with `NEOFS_*contract_name*_ASYNC_WORKER_ENABLED=false` (default is `true`)
2. choose the size of worker pool with `NEOFS_*contract_name*_ASYNC_WORKER_SIZE` (default is `10`)