### PR TITLE
Iterate over all shards to return complete SplitInfoError

### DIFF
--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg"
+	"github.com/nspcc-dev/neofs-api-go/pkg/container"
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/util/test"
+	"github.com/nspcc-dev/tzhash/tz"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func testNewEngineWithShards(shards ...*shard.Shard) *StorageEngine {
+	engine := &StorageEngine{
+		cfg: &cfg{
+			log: zap.L(),
+		},
+		mtx:    new(sync.RWMutex),
+		shards: make(map[string]*shard.Shard, len(shards)),
+	}
+
+	for _, s := range shards {
+		engine.shards[s.ID().String()] = s
+	}
+
+	return engine
+}
+
+func testNewShard(t *testing.T, id int) *shard.Shard {
+	sid, err := generateShardID()
+	require.NoError(t, err)
+
+	s := shard.New(
+		shard.WithID(sid),
+		shard.WithLogger(zap.L()),
+		shard.WithBlobStorOptions(
+			blobstor.WithRootPath(fmt.Sprintf("%s.%d.blobstor", t.Name(), id)),
+			blobstor.WithBlobovniczaShallowWidth(2),
+			blobstor.WithBlobovniczaShallowDepth(2),
+			blobstor.WithRootPerm(0700),
+		),
+		shard.WithMetaBaseOptions(
+			meta.WithPath(fmt.Sprintf("%s.%d.metabase", t.Name(), id)),
+			meta.WithPermissions(0700),
+		))
+
+	require.NoError(t, s.Open())
+	require.NoError(t, s.Init())
+
+	return s
+}
+
+func testCID() *container.ID {
+	cs := [sha256.Size]byte{}
+	_, _ = rand.Read(cs[:])
+
+	id := container.NewID()
+	id.SetSHA256(cs)
+
+	return id
+}
+
+func testOID() *objectSDK.ID {
+	cs := [sha256.Size]byte{}
+	_, _ = rand.Read(cs[:])
+
+	id := objectSDK.NewID()
+	id.SetSHA256(cs)
+
+	return id
+}
+
+func generateRawObjectWithCID(t *testing.T, cid *container.ID) *object.RawObject {
+	version := pkg.NewVersion()
+	version.SetMajor(2)
+	version.SetMinor(1)
+
+	w, err := owner.NEO3WalletFromPublicKey(&test.DecodeKey(-1).PublicKey)
+	require.NoError(t, err)
+
+	ownerID := owner.NewID()
+	ownerID.SetNeo3Wallet(w)
+
+	csum := new(pkg.Checksum)
+	csum.SetSHA256(sha256.Sum256(w.Bytes()))
+
+	csumTZ := new(pkg.Checksum)
+	csumTZ.SetTillichZemor(tz.Sum(csum.Sum()))
+
+	obj := object.NewRaw()
+	obj.SetID(testOID())
+	obj.SetOwnerID(ownerID)
+	obj.SetContainerID(cid)
+	obj.SetVersion(version)
+	obj.SetPayloadChecksum(csum)
+	obj.SetPayloadHomomorphicHash(csumTZ)
+	obj.SetPayload([]byte{1, 2, 3, 4, 5})
+
+	return obj
+}
+
+func addAttribute(obj *object.RawObject, key, val string) {
+	attr := objectSDK.NewAttribute()
+	attr.SetKey(key)
+	attr.SetValue(val)
+
+	attrs := obj.Attributes()
+	attrs = append(attrs, attr)
+	obj.SetAttributes(attrs...)
+}

--- a/pkg/local_object_storage/engine/get.go
+++ b/pkg/local_object_storage/engine/get.go
@@ -5,8 +5,8 @@ import (
 
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"go.uber.org/zap"
 )
 
@@ -71,7 +71,7 @@ func (e *StorageEngine) Get(prm *GetPrm) (*GetRes, error) {
 					outSI = objectSDK.NewSplitInfo()
 				}
 
-				meta.MergeSplitInfo(siErr.SplitInfo(), outSI)
+				util.MergeSplitInfo(siErr.SplitInfo(), outSI)
 
 				// stop iterating over shards if SplitInfo structure is complete
 				if outSI.Link() != nil && outSI.LastPart() != nil {

--- a/pkg/local_object_storage/engine/head.go
+++ b/pkg/local_object_storage/engine/head.go
@@ -3,8 +3,8 @@ package engine
 import (
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -86,7 +86,7 @@ func (e *StorageEngine) Head(prm *HeadPrm) (*HeadRes, error) {
 					outSI = objectSDK.NewSplitInfo()
 				}
 
-				meta.MergeSplitInfo(siErr.SplitInfo(), outSI)
+				util.MergeSplitInfo(siErr.SplitInfo(), outSI)
 
 				// stop iterating over shards if SplitInfo structure is complete
 				if outSI.Link() != nil && outSI.LastPart() != nil {

--- a/pkg/local_object_storage/engine/head_test.go
+++ b/pkg/local_object_storage/engine/head_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"os"
+	"testing"
+
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadRaw(t *testing.T) {
+	defer os.RemoveAll(t.Name())
+
+	cid := testCID()
+	splitID := objectSDK.NewSplitID()
+
+	parent := generateRawObjectWithCID(t, cid)
+	addAttribute(parent, "foo", "bar")
+
+	parentAddr := objectSDK.NewAddress()
+	parentAddr.SetContainerID(cid)
+	parentAddr.SetObjectID(parent.ID())
+
+	child := generateRawObjectWithCID(t, cid)
+	child.SetParent(parent.Object().SDK())
+	child.SetParentID(parent.ID())
+	child.SetSplitID(splitID)
+
+	link := generateRawObjectWithCID(t, cid)
+	link.SetParent(parent.Object().SDK())
+	link.SetParentID(parent.ID())
+	link.SetChildren(child.ID())
+	link.SetSplitID(splitID)
+
+	t.Run("virtual object split in different shards", func(t *testing.T) {
+		s1 := testNewShard(t, 1)
+		s2 := testNewShard(t, 2)
+
+		e := testNewEngineWithShards(s1, s2)
+		defer e.Close()
+
+		putPrmLeft := new(shard.PutPrm).WithObject(child.Object())
+		putPrmLink := new(shard.PutPrm).WithObject(link.Object())
+
+		// put most left object in one shard
+		_, err := s1.Put(putPrmLeft)
+		require.NoError(t, err)
+
+		// put link object in another shard
+		_, err = s2.Put(putPrmLink)
+		require.NoError(t, err)
+
+		// head with raw flag should return SplitInfoError
+		headPrm := new(HeadPrm).WithAddress(parentAddr).WithRaw(true)
+		_, err = e.Head(headPrm)
+		require.Error(t, err)
+
+		si, ok := err.(*objectSDK.SplitInfoError)
+		require.True(t, ok)
+
+		// SplitInfoError should contain info from both shards
+		require.Equal(t, splitID, si.SplitInfo().SplitID())
+		require.Equal(t, child.ID(), si.SplitInfo().LastPart())
+		require.Equal(t, link.ID(), si.SplitInfo().Link())
+	})
+}

--- a/pkg/local_object_storage/engine/range.go
+++ b/pkg/local_object_storage/engine/range.go
@@ -5,8 +5,8 @@ import (
 
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"go.uber.org/zap"
 )
 
@@ -90,7 +90,7 @@ func (e *StorageEngine) GetRange(prm *RngPrm) (*RngRes, error) {
 					outSI = objectSDK.NewSplitInfo()
 				}
 
-				meta.MergeSplitInfo(siErr.SplitInfo(), outSI)
+				util.MergeSplitInfo(siErr.SplitInfo(), outSI)
 
 				// stop iterating over shards if SplitInfo structure is complete
 				if outSI.Link() != nil && outSI.LastPart() != nil {

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -24,7 +24,7 @@ func (e *StorageEngine) AddShard(opts ...shard.Option) (*shard.ID, error) {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
-	id, err := e.generateShardID()
+	id, err := generateShardID()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not generate shard ID")
 	}
@@ -37,7 +37,7 @@ func (e *StorageEngine) AddShard(opts ...shard.Option) (*shard.ID, error) {
 	return id, nil
 }
 
-func (e *StorageEngine) generateShardID() (*shard.ID, error) {
+func generateShardID() (*shard.ID, error) {
 	uid, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -9,6 +9,7 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"go.etcd.io/bbolt"
 )
 
@@ -416,7 +417,7 @@ func updateSplitInfo(tx *bbolt.Tx, addr *objectSDK.Address, from *objectSDK.Spli
 		return fmt.Errorf("can't unmarshal split info from root index: %w", err)
 	}
 
-	result := MergeSplitInfo(from, to)
+	result := util.MergeSplitInfo(from, to)
 
 	rawSplitInfo, err = result.Marshal()
 	if err != nil {
@@ -446,22 +447,6 @@ func splitInfoFromObject(obj *object.Object) (*objectSDK.SplitInfo, error) {
 	}
 
 	return info, nil
-}
-
-// MergeSplitInfo ignores conflicts and rewrites `to` with non empty values
-// from `from`.
-func MergeSplitInfo(from, to *objectSDK.SplitInfo) *objectSDK.SplitInfo {
-	to.SetSplitID(from.SplitID()) // overwrite SplitID and ignore conflicts
-
-	if lp := from.LastPart(); lp != nil {
-		to.SetLastPart(lp)
-	}
-
-	if link := from.Link(); link != nil {
-		to.SetLink(link)
-	}
-
-	return to
 }
 
 // isLinkObject returns true if object contains parent header and list

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -416,7 +416,7 @@ func updateSplitInfo(tx *bbolt.Tx, addr *objectSDK.Address, from *objectSDK.Spli
 		return fmt.Errorf("can't unmarshal split info from root index: %w", err)
 	}
 
-	result := mergeSplitInfo(from, to)
+	result := MergeSplitInfo(from, to)
 
 	rawSplitInfo, err = result.Marshal()
 	if err != nil {
@@ -448,9 +448,9 @@ func splitInfoFromObject(obj *object.Object) (*objectSDK.SplitInfo, error) {
 	return info, nil
 }
 
-// mergeSplitInfo ignores conflicts and rewrites `to` with non empty values
+// MergeSplitInfo ignores conflicts and rewrites `to` with non empty values
 // from `from`.
-func mergeSplitInfo(from, to *objectSDK.SplitInfo) *objectSDK.SplitInfo {
+func MergeSplitInfo(from, to *objectSDK.SplitInfo) *objectSDK.SplitInfo {
 	to.SetSplitID(from.SplitID()) // overwrite SplitID and ignore conflicts
 
 	if lp := from.LastPart(); lp != nil {

--- a/pkg/local_object_storage/util/splitinfo.go
+++ b/pkg/local_object_storage/util/splitinfo.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+)
+
+// MergeSplitInfo ignores conflicts and rewrites `to` with non empty values
+// from `from`.
+func MergeSplitInfo(from, to *objectSDK.SplitInfo) *objectSDK.SplitInfo {
+	to.SetSplitID(from.SplitID()) // overwrite SplitID and ignore conflicts
+
+	if lp := from.LastPart(); lp != nil {
+		to.SetLastPart(lp)
+	}
+
+	if link := from.Link(); link != nil {
+		to.SetLink(link)
+	}
+
+	return to
+}

--- a/pkg/local_object_storage/util/splitinfo_test.go
+++ b/pkg/local_object_storage/util/splitinfo_test.go
@@ -1,0 +1,66 @@
+package util_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeSplitInfo(t *testing.T) {
+	uid, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	splitID := object.NewSplitID()
+	splitID.SetUUID(uid)
+
+	var rawLinkID, rawLastID [32]byte
+	linkID := object.NewID()
+	lastID := object.NewID()
+
+	_, err = rand.Read(rawLinkID[:])
+	require.NoError(t, err)
+	linkID.SetSHA256(rawLinkID)
+
+	_, err = rand.Read(rawLastID[:])
+	require.NoError(t, err)
+	lastID.SetSHA256(rawLastID)
+
+	target := object.NewSplitInfo() // target is SplitInfo struct with all fields set
+	target.SetSplitID(splitID)
+	target.SetLastPart(lastID)
+	target.SetLink(linkID)
+
+	t.Run("merge empty", func(t *testing.T) {
+		to := object.NewSplitInfo()
+
+		result := util.MergeSplitInfo(target, to)
+		require.Equal(t, result, target)
+	})
+
+	t.Run("merge link", func(t *testing.T) {
+		from := object.NewSplitInfo()
+		from.SetSplitID(splitID)
+		from.SetLastPart(lastID)
+
+		to := object.NewSplitInfo()
+		to.SetLink(linkID)
+
+		result := util.MergeSplitInfo(from, to)
+		require.Equal(t, result, target)
+	})
+	t.Run("merge last", func(t *testing.T) {
+		from := object.NewSplitInfo()
+		from.SetSplitID(splitID)
+		from.SetLink(linkID)
+
+		to := object.NewSplitInfo()
+		to.SetLastPart(lastID)
+
+		result := util.MergeSplitInfo(from, to)
+		require.Equal(t, result, target)
+	})
+}


### PR DESCRIPTION
Closes #391

Issue fixed for head, get and range requests.
Unit test covers `engine.Head` invocation.
