### PR TITLE
Fetch epoch duration from global config

### DIFF
--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -29,9 +29,9 @@ type (
 		cnrWrapper *container.Wrapper // to invoke stop container estimation
 		epoch      epochState         // to specify which epoch to stop
 
-		epochDuration      uint32 // in blocks
-		stopEstimationDMul uint32 // X: X/Y of epoch in blocks
-		stopEstimationDDiv uint32 // Y: X/Y of epoch in blocks
+		epochDuration      timers.BlockMeter // in blocks
+		stopEstimationDMul uint32            // X: X/Y of epoch in blocks
+		stopEstimationDDiv uint32            // Y: X/Y of epoch in blocks
 
 		collectBasicIncome    subEpochEventHandler
 		distributeBasicIncome subEpochEventHandler
@@ -74,7 +74,7 @@ func (s *Server) tickTimers() {
 
 func newEpochTimer(args *epochTimerArgs) *timers.BlockTimer {
 	epochTimer := timers.NewBlockTimer(
-		timers.StaticBlockMeter(args.epochDuration),
+		args.epochDuration,
 		func() {
 			args.nm.HandleNewEpochTick(timers.NewEpochTick{})
 		},

--- a/pkg/innerring/config/config.go
+++ b/pkg/innerring/config/config.go
@@ -46,3 +46,17 @@ func (c *GlobalConfig) AuditFee() (uint64, error) {
 
 	return c.nm.AuditFee()
 }
+
+func (c *GlobalConfig) EpochDuration() (uint32, error) {
+	value := c.cfg.GetUint32("timers.epoch")
+	if value != 0 {
+		return value, nil
+	}
+
+	epochDuration, err := c.nm.EpochDuration()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(epochDuration), nil
+}

--- a/pkg/innerring/config/config.go
+++ b/pkg/innerring/config/config.go
@@ -35,7 +35,7 @@ func (c *GlobalConfig) BasicIncomeRate() (uint64, error) {
 		return value, nil
 	}
 
-	return c.nm.BasinIncomeRate()
+	return c.nm.BasicIncomeRate()
 }
 
 func (c *GlobalConfig) AuditFee() (uint64, error) {

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -585,7 +585,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 		nm:                 netmapProcessor,
 		cnrWrapper:         cnrClient,
 		epoch:              server,
-		epochDuration:      cfg.GetUint32("timers.epoch"),
+		epochDuration:      globalConfig.EpochDuration,
 		stopEstimationDMul: cfg.GetUint32("timers.stop_estimation.mul"),
 		stopEstimationDDiv: cfg.GetUint32("timers.stop_estimation.div"),
 		collectBasicIncome: subEpochEventHandler{

--- a/pkg/innerring/invoke/netmap.go
+++ b/pkg/innerring/invoke/netmap.go
@@ -27,7 +27,7 @@ const (
 	setNewEpochMethod       = "newEpoch"
 	approvePeerMethod       = "addPeer"
 	updatePeerStateMethod   = "updateState"
-	setConfigMethod         = "setConfigMethod"
+	setConfigMethod         = "setConfig"
 	getNetmapSnapshotMethod = "netmap"
 )
 

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -8,7 +8,10 @@ import (
 const (
 	maxObjectSizeConfig   = "MaxObjectSize"
 	basicIncomeRateConfig = "BasicIncomeRate"
-	auditFee              = "AuditFee"
+	auditFeeConfig        = "AuditFee"
+	epochDurationConfig   = "EpochDuration"
+	containerFeeConfig    = "ContainerFee"
+	etIterationsConfig    = "EigenTrustIterations"
 )
 
 // MaxObjectSize receives max object size configuration
@@ -24,7 +27,7 @@ func (w *Wrapper) MaxObjectSize() (uint64, error) {
 
 // BasicIncomeRate returns basic income rate configuration value from network
 // config in netmap contract.
-func (w *Wrapper) BasinIncomeRate() (uint64, error) {
+func (w *Wrapper) BasicIncomeRate() (uint64, error) {
 	rate, err := w.readUInt64Config(basicIncomeRateConfig)
 	if err != nil {
 		return 0, errors.Wrapf(err, "(%T) could not get basic income rate", w)
@@ -36,12 +39,44 @@ func (w *Wrapper) BasinIncomeRate() (uint64, error) {
 // AuditFee returns audit fee configuration value from network
 // config in netmap contract.
 func (w *Wrapper) AuditFee() (uint64, error) {
-	fee, err := w.readUInt64Config(auditFee)
+	fee, err := w.readUInt64Config(auditFeeConfig)
 	if err != nil {
 		return 0, errors.Wrapf(err, "(%T) could not get audit fee", w)
 	}
 
 	return fee, nil
+}
+
+// EpochDuration returns number of sidechain blocks per one NeoFS epoch.
+func (w *Wrapper) EpochDuration() (uint64, error) {
+	epochDuration, err := w.readUInt64Config(epochDurationConfig)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get epoch duration", w)
+	}
+
+	return epochDuration, nil
+}
+
+// ContainerFee returns fee paid by container owner to each alphabet node
+// for container registration.
+func (w *Wrapper) ContainerFee() (uint64, error) {
+	fee, err := w.readUInt64Config(containerFeeConfig)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get container fee", w)
+	}
+
+	return fee, nil
+}
+
+// EigenTrustIterations returns global configuration value of iteration cycles
+// for EigenTrust algorithm per epoch.
+func (w *Wrapper) EigenTrustIterations() (uint64, error) {
+	iterations, err := w.readUInt64Config(etIterationsConfig)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get eigen trust iterations", w)
+	}
+
+	return iterations, nil
 }
 
 func (w *Wrapper) readUInt64Config(key string) (uint64, error) {

--- a/pkg/morph/client/util.go
+++ b/pkg/morph/client/util.go
@@ -48,6 +48,13 @@ func BytesFromStackItem(param stackitem.Item) ([]byte, error) {
 	switch param.Type() {
 	case stackitem.BufferT, stackitem.ByteArrayT:
 		return param.TryBytes()
+	case stackitem.IntegerT:
+		n, err := param.TryInteger()
+		if err != nil {
+			return nil, errors.Wrap(err, "can't parse integer bytes")
+		}
+
+		return n.Bytes(), nil
 	case stackitem.AnyT:
 		if param.Value() == nil {
 			return nil, nil

--- a/pkg/morph/client/util_test.go
+++ b/pkg/morph/client/util_test.go
@@ -74,6 +74,10 @@ func TestBytesFromStackItem(t *testing.T) {
 		val, err := BytesFromStackItem(stringByteItem)
 		require.NoError(t, err)
 		require.Equal(t, stringByteItem.Value().([]byte), val)
+
+		val, err = BytesFromStackItem(intItem)
+		require.NoError(t, err)
+		require.Equal(t, intItem.Value().(*big.Int).Bytes(), val)
 	})
 
 	t.Run("incorrect assert", func(t *testing.T) {


### PR DESCRIPTION
This pull request:
- adds more getters for global config values in netmap wrapper,
- makes inner ring block timer use global config to fetch epoch duration value,
- fixes configuration value sync between main chain and side chain.

Related to #363