### PR TITLE
Eigen trust timer in storage node

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -30,6 +30,7 @@ import (
 	nmwrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmap2 "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/timer"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	trustcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
@@ -226,6 +227,9 @@ type cfgGRPC struct {
 
 type cfgMorph struct {
 	client *client.Client
+
+	blockTimers     []*timer.BlockTimer // all combined timers
+	eigenTrustTimer *timer.BlockTimer   // timer for EigenTrust iterations
 }
 
 type cfgAccounting struct {

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -63,6 +63,7 @@ func bootUp(c *cfg) {
 	serveGRPC(c)
 	bootstrapNode(c)
 	startWorkers(c)
+	startBlockTimers(c)
 	serveMetrics(c)
 }
 

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
@@ -120,6 +121,11 @@ func listenMorphNotifications(c *cfg) {
 	setNetmapNotificationParser(c, newEpochNotification, netmapEvent.ParseNewEpoch)
 	registerNotificationHandlers(c.cfgNetmap.scriptHash, lis, c.cfgNetmap.parsers, c.cfgNetmap.subscribers)
 	registerNotificationHandlers(c.cfgContainer.scriptHash, lis, c.cfgContainer.parsers, c.cfgContainer.subscribers)
+
+	registerBlockHandler(lis, func(block *block.Block) {
+		c.log.Debug("new block", zap.Uint32("index", block.Index))
+		tickBlockTimers(c)
+	})
 }
 
 func registerNotificationHandlers(scHash util.Uint160, lis event.Listener, parsers map[event.Type]event.Parser,
@@ -147,4 +153,8 @@ func registerNotificationHandlers(scHash util.Uint160, lis event.Listener, parse
 			lis.RegisterHandler(hi)
 		}
 	}
+}
+
+func registerBlockHandler(lis event.Listener, handler event.BlockHandler) {
+	lis.RegisterBlockHandler(handler)
 }

--- a/cmd/neofs-node/timers.go
+++ b/cmd/neofs-node/timers.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"sync"
+
+	wrapNetmap "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/timer"
+)
+
+type (
+	// EigenTrustDuration is a structure that provides duration of one
+	// eigen trust iteration round in blocks for block timer.
+	EigenTrustDuration struct {
+		sync.Mutex
+
+		nm  *wrapNetmap.Wrapper
+		val uint32
+	}
+)
+
+// NewEigenTrustDuration returns instance of EigenTrustDuration.
+func NewEigenTrustDuration(nm *wrapNetmap.Wrapper) *EigenTrustDuration {
+	return &EigenTrustDuration{
+		nm: nm,
+	}
+}
+
+// Value returns number of blocks between two iterations of EigenTrust
+// calculation. This value is not changed between `Update` calls.
+func (e *EigenTrustDuration) Value() (uint32, error) {
+	e.Lock()
+	defer e.Unlock()
+
+	if e.val == 0 {
+		e.update()
+	}
+
+	return e.val, nil
+}
+
+// Update function recalculate duration of EigenTrust iteration based on
+// NeoFS epoch duration and amount of iteration rounds from global config.
+func (e *EigenTrustDuration) Update() {
+	e.Lock()
+	defer e.Unlock()
+
+	e.update()
+}
+
+func (e *EigenTrustDuration) update() {
+	iterationAmount, err := e.nm.EigenTrustIterations()
+	if err != nil {
+		return
+	}
+
+	epochDuration, err := e.nm.EpochDuration()
+	if err != nil {
+		return
+	}
+
+	e.val = uint32(epochDuration / iterationAmount)
+}
+
+func startBlockTimers(c *cfg) {
+	for i := range c.cfgMorph.blockTimers {
+		if err := c.cfgMorph.blockTimers[i].Reset(); err != nil {
+			fatalOnErr(err)
+		}
+	}
+}
+
+func tickBlockTimers(c *cfg) {
+	for i := range c.cfgMorph.blockTimers {
+		c.cfgMorph.blockTimers[i].Tick()
+	}
+}
+
+func newEigenTrustIterTimer(c *cfg, it *EigenTrustDuration, handler timer.BlockTickHandler) {
+	c.cfgMorph.eigenTrustTimer = timer.NewBlockTimer(
+		it.Value,
+		handler,
+	)
+
+	c.cfgMorph.blockTimers = append(c.cfgMorph.blockTimers, c.cfgMorph.eigenTrustTimer)
+}

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -22,11 +22,11 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/reputation"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement"
 	auditSettlement "github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement/audit"
-	"github.com/nspcc-dev/neofs-node/pkg/innerring/timers"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	auditWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/audit/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/subscriber"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/timer"
 	audittask "github.com/nspcc-dev/neofs-node/pkg/services/audit/taskmanager"
 	util2 "github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util/precision"
@@ -46,8 +46,8 @@ type (
 		// event producers
 		morphListener   event.Listener
 		mainnetListener event.Listener
-		blockTimers     []*timers.BlockTimer
-		epochTimer      *timers.BlockTimer
+		blockTimers     []*timer.BlockTimer
+		epochTimer      *timer.BlockTimer
 
 		// global state
 		morphClient   *client.Client

--- a/pkg/morph/timer/block.go
+++ b/pkg/morph/timer/block.go
@@ -1,4 +1,4 @@
-package timers
+package timer
 
 import (
 	"sync"

--- a/pkg/morph/timer/block_test.go
+++ b/pkg/morph/timer/block_test.go
@@ -1,13 +1,13 @@
-package timers_test
+package timer_test
 
 import (
 	"testing"
 
-	"github.com/nspcc-dev/neofs-node/pkg/innerring/timers"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/timer"
 	"github.com/stretchr/testify/require"
 )
 
-func tickN(t *timers.BlockTimer, n uint32) {
+func tickN(t *timer.BlockTimer, n uint32) {
 	for i := uint32(0); i < n; i++ {
 		t.Tick()
 	}
@@ -17,7 +17,7 @@ func TestBlockTimer(t *testing.T) {
 	blockDur := uint32(10)
 	baseCallCounter := uint32(0)
 
-	bt := timers.NewBlockTimer(timers.StaticBlockMeter(blockDur), func() {
+	bt := timer.NewBlockTimer(timer.StaticBlockMeter(blockDur), func() {
 		baseCallCounter++
 	})
 
@@ -59,7 +59,7 @@ func TestDeltaPulse(t *testing.T) {
 	blockDur := uint32(9)
 	baseCallCounter := uint32(0)
 
-	bt := timers.NewBlockTimer(timers.StaticBlockMeter(blockDur), func() {
+	bt := timer.NewBlockTimer(timer.StaticBlockMeter(blockDur), func() {
 		baseCallCounter++
 	})
 
@@ -69,7 +69,7 @@ func TestDeltaPulse(t *testing.T) {
 
 	bt.OnDelta(1, div, func() {
 		deltaCallCounter++
-	}, timers.WithPulse())
+	}, timer.WithPulse())
 
 	require.NoError(t, bt.Reset())
 
@@ -85,7 +85,7 @@ func TestDeltaReset(t *testing.T) {
 	blockDur := uint32(6)
 	baseCallCounter := 0
 
-	bt := timers.NewBlockTimer(timers.StaticBlockMeter(blockDur), func() {
+	bt := timer.NewBlockTimer(timer.StaticBlockMeter(blockDur), func() {
 		baseCallCounter++
 	})
 


### PR DESCRIPTION
There is a small inconsistency that can happen in neofs-dev-env environment with timer calculation. Storage node takes epoch duration from global config, however inner ring may override this value in local config. In this case eigen trust iteration duration won't be correlated with actual epoch duration.

To fix that, I plan to remove epoch duration value from inner ring config in neofs-dev-env and provide simple functionы to change global config values (similar to `make prepare.ir`).