### PR TITLE
Refactor/divide main reputation onto subpkgs

### DIFF
--- a/cmd/neofs-node/reputation/local/managers.go
+++ b/cmd/neofs-node/reputation/local/managers.go
@@ -1,0 +1,106 @@
+package local
+
+import (
+	"bytes"
+
+	"github.com/nspcc-dev/hrw"
+	apiNetmap "github.com/nspcc-dev/neofs-api-go/pkg/netmap"
+	netmapcore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationrouter "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common/router"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/managers"
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"go.uber.org/zap"
+)
+
+// managerBuilder is implementation of reputation ManagerBuilder interface.
+// It sorts nodes in NetMap with HRW algorithms and
+// takes the next node after the current one as the only manager.
+type managerBuilder struct {
+	log   *logger.Logger
+	nmSrc netmapcore.Source
+}
+
+// ManagersPrm groups the required parameters of the managerBuilder's constructor.
+//
+// All values must comply with the requirements imposed on them.
+// Passing incorrect parameter values will result in constructor
+// failure (error or panic depending on the implementation).
+type ManagersPrm struct {
+	NetMapSource netmapcore.Source
+}
+
+// NewManagerBuilder creates a new instance of the managerBuilder.
+//
+// Panics if at least one value of the parameters is invalid.
+//
+// The created managerBuilder does not require additional
+// initialization and is completely ready for work.
+func NewManagerBuilder(prm ManagersPrm, opts ...MngOption) managers.ManagerBuilder {
+	switch {
+	case prm.NetMapSource == nil:
+		panicOnPrmValue("NetMapSource", prm.NetMapSource)
+	}
+
+	o := defaultMngOpts()
+
+	for i := range opts {
+		opts[i](o)
+	}
+
+	return &managerBuilder{
+		log:   o.log,
+		nmSrc: prm.NetMapSource,
+	}
+}
+
+// BuildManagers sorts nodes in NetMap with HRW algorithms and
+// takes the next node after the current one as the only manager.
+func (mb *managerBuilder) BuildManagers(epoch uint64, p reputation.PeerID) ([]reputationrouter.ServerInfo, error) {
+	nm, err := mb.nmSrc.GetNetMapByEpoch(epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	// make a copy to keep order consistency of the origin netmap after sorting
+	nodes := make([]*apiNetmap.Node, len(nm.Nodes))
+
+	copy(nodes, nm.Nodes)
+
+	hrw.SortSliceByValue(nodes, epoch)
+
+	for i := range nodes {
+		if bytes.Equal(nodes[i].PublicKey(), p.Bytes()) {
+			managerIndex := i + 1
+
+			if managerIndex == len(nodes) {
+				managerIndex = 0
+			}
+
+			return []reputationrouter.ServerInfo{nodes[managerIndex]}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+type mngOptions struct {
+	log *logger.Logger
+}
+
+type MngOption func(*mngOptions)
+
+func defaultMngOpts() *mngOptions {
+	return &mngOptions{
+		log: zap.L(),
+	}
+}
+
+// WithLogger returns MngOption to specify logging component.
+func WithLogger(l *logger.Logger) MngOption {
+	return func(o *mngOptions) {
+		if l != nil {
+			o.log = l
+		}
+	}
+}

--- a/cmd/neofs-node/reputation/local/remote.go
+++ b/cmd/neofs-node/reputation/local/remote.go
@@ -1,0 +1,137 @@
+package local
+
+import (
+	"crypto/ecdsa"
+
+	apiClient "github.com/nspcc-dev/neofs-api-go/pkg/client"
+	reputationapi "github.com/nspcc-dev/neofs-api-go/pkg/reputation"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
+	reputationrouter "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common/router"
+	trustcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
+	"github.com/pkg/errors"
+)
+
+type clientCache interface {
+	Get(string) (apiClient.Client, error)
+}
+
+// remoteTrustProvider is implementation of reputation RemoteWriterProvider interface.
+type remoteTrustProvider struct {
+	localAddrSrc    network.LocalAddressSource
+	deadEndProvider reputationcommon.WriterProvider
+	key             *ecdsa.PrivateKey
+
+	clientCache clientCache
+}
+
+// RemoteProviderPrm groups the required parameters of the remoteTrustProvider's constructor.
+//
+// All values must comply with the requirements imposed on them.
+// Passing incorrect parameter values will result in constructor
+// failure (error or panic depending on the implementation).
+type RemoteProviderPrm struct {
+	LocalAddrSrc    network.LocalAddressSource
+	DeadEndProvider reputationcommon.WriterProvider
+	Key             *ecdsa.PrivateKey
+	ClientCache     clientCache
+}
+
+func NewRemoteTrustProvider(prm RemoteProviderPrm) reputationrouter.RemoteWriterProvider {
+	switch {
+	case prm.LocalAddrSrc == nil:
+		panicOnPrmValue("LocalAddrSrc", prm.LocalAddrSrc)
+	case prm.DeadEndProvider == nil:
+		panicOnPrmValue("DeadEndProvider", prm.DeadEndProvider)
+	case prm.Key == nil:
+		panicOnPrmValue("Key", prm.Key)
+	case prm.ClientCache == nil:
+		panicOnPrmValue("ClientCache", prm.ClientCache)
+	}
+
+	return &remoteTrustProvider{
+		localAddrSrc:    prm.LocalAddrSrc,
+		deadEndProvider: prm.DeadEndProvider,
+		key:             prm.Key,
+		clientCache:     prm.ClientCache,
+	}
+}
+
+func (rtp *remoteTrustProvider) InitRemote(srv reputationrouter.ServerInfo) (reputationcommon.WriterProvider, error) {
+	if srv == nil {
+		return rtp.deadEndProvider, nil
+	}
+
+	addr := srv.Address()
+
+	if rtp.localAddrSrc.LocalAddress().String() == srv.Address() {
+		// if local => return no-op writer
+		return trustcontroller.SimpleWriterProvider(new(NopReputationWriter)), nil
+	}
+
+	ipAddr, err := network.IPAddrFromMultiaddr(addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not convert address to IP format")
+	}
+
+	c, err := rtp.clientCache.Get(ipAddr)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not initialize API client")
+	}
+
+	return &RemoteTrustWriterProvider{
+		client: c,
+		key:    rtp.key,
+	}, nil
+}
+
+type RemoteTrustWriterProvider struct {
+	client apiClient.Client
+	key    *ecdsa.PrivateKey
+}
+
+func (rtwp *RemoteTrustWriterProvider) InitWriter(ctx reputationcommon.Context) (reputationcommon.Writer, error) {
+	return &RemoteTrustWriter{
+		ctx:    ctx,
+		client: rtwp.client,
+		key:    rtwp.key,
+	}, nil
+}
+
+type RemoteTrustWriter struct {
+	ctx    reputationcommon.Context
+	client apiClient.Client
+	key    *ecdsa.PrivateKey
+
+	buf []*reputationapi.Trust
+}
+
+func (rtp *RemoteTrustWriter) Write(t reputation.Trust) error {
+	apiTrust := reputationapi.NewTrust()
+
+	apiPeer := reputationapi.NewPeerID()
+	apiPeer.SetPublicKey(t.Peer())
+
+	apiTrust.SetValue(t.Value().Float64())
+	apiTrust.SetPeer(apiPeer)
+
+	rtp.buf = append(rtp.buf, apiTrust)
+
+	return nil
+}
+
+func (rtp *RemoteTrustWriter) Close() error {
+	prm := apiClient.SendLocalTrustPrm{}
+
+	prm.SetEpoch(rtp.ctx.Epoch())
+	prm.SetTrusts(rtp.buf)
+
+	_, err := rtp.client.SendLocalTrust(
+		rtp.ctx,
+		prm,
+		apiClient.WithKey(rtp.key),
+	)
+
+	return err
+}

--- a/cmd/neofs-node/reputation/local/storage.go
+++ b/cmd/neofs-node/reputation/local/storage.go
@@ -1,0 +1,120 @@
+package local
+
+import (
+	"bytes"
+	"encoding/hex"
+
+	netmapcore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
+	trustcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
+	truststorage "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/storage"
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type TrustStorage struct {
+	Log *logger.Logger
+
+	Storage *truststorage.Storage
+
+	NmSrc netmapcore.Source
+
+	LocalKey []byte
+}
+
+func (s *TrustStorage) InitIterator(ctx reputationcommon.Context) (trustcontroller.Iterator, error) {
+	epochStorage, err := s.Storage.DataForEpoch(ctx.Epoch())
+	if err != nil && !errors.Is(err, truststorage.ErrNoPositiveTrust) {
+		return nil, err
+	}
+
+	return &TrustIterator{
+		ctx:          ctx,
+		storage:      s,
+		epochStorage: epochStorage,
+	}, nil
+}
+
+func (s *TrustStorage) InitWriter(ctx reputationcommon.Context) (reputationcommon.Writer, error) {
+	return &TrustLogger{
+		ctx: ctx,
+		log: s.Log,
+	}, nil
+}
+
+type TrustIterator struct {
+	ctx reputationcommon.Context
+
+	storage *TrustStorage
+
+	epochStorage *truststorage.EpochTrustValueStorage
+}
+
+func (it *TrustIterator) Iterate(h reputation.TrustHandler) error {
+	if it.epochStorage != nil {
+		err := it.epochStorage.Iterate(h)
+		if !errors.Is(err, truststorage.ErrNoPositiveTrust) {
+			return err
+		}
+	}
+
+	nm, err := it.storage.NmSrc.GetNetMapByEpoch(it.ctx.Epoch())
+	if err != nil {
+		return err
+	}
+
+	// find out if local node is presented in netmap
+	localIndex := -1
+
+	for i := range nm.Nodes {
+		if bytes.Equal(nm.Nodes[i].PublicKey(), it.storage.LocalKey) {
+			localIndex = i
+		}
+	}
+
+	ln := len(nm.Nodes)
+	if localIndex >= 0 && ln > 0 {
+		ln--
+	}
+
+	// calculate Pj http://ilpubs.stanford.edu:8090/562/1/2002-56.pdf Chapter 4.5.
+	p := reputation.TrustOne.Div(reputation.TrustValueFromInt(ln))
+
+	for i := range nm.Nodes {
+		if i == localIndex {
+			continue
+		}
+
+		trust := reputation.Trust{}
+		trust.SetPeer(reputation.PeerIDFromBytes(nm.Nodes[i].PublicKey()))
+		trust.SetValue(p)
+
+		if err := h(trust); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type TrustLogger struct {
+	ctx reputationcommon.Context
+
+	log *logger.Logger
+}
+
+func (l *TrustLogger) Write(t reputation.Trust) error {
+	l.log.Info("received local trust",
+		zap.Uint64("epoch", l.ctx.Epoch()),
+		zap.String("peer", hex.EncodeToString(t.Peer().Bytes())),
+		zap.Stringer("value", t.Value()),
+	)
+
+	return nil
+}
+
+func (*TrustLogger) Close() error {
+	return nil
+}

--- a/cmd/neofs-node/reputation/local/util.go
+++ b/cmd/neofs-node/reputation/local/util.go
@@ -1,0 +1,45 @@
+package local
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
+)
+
+type EpochContext struct {
+	context.Context
+	E uint64
+}
+
+func (ctx *EpochContext) Epoch() uint64 {
+	return ctx.E
+}
+
+type NopReputationWriter struct{}
+
+func (NopReputationWriter) Write(reputation.Trust) error {
+	return nil
+}
+
+func (NopReputationWriter) Close() error {
+	return nil
+}
+
+type OnlyKeyRemoteServerInfo struct {
+	Key []byte
+}
+
+func (i *OnlyKeyRemoteServerInfo) PublicKey() []byte {
+	return i.Key
+}
+
+func (*OnlyKeyRemoteServerInfo) Address() string {
+	return ""
+}
+
+const invalidPrmValFmt = "invalid parameter %s (%T):%v"
+
+func panicOnPrmValue(n string, v interface{}) {
+	panic(fmt.Sprintf(invalidPrmValFmt, n, v, v))
+}


### PR DESCRIPTION
Split `cmd/reputation` into sub packages for future refactoring. Add constructors with params and options where it is necessary.