### PR TITLE
Support disabled notary work flow in inner ring

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -117,4 +117,8 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("indexer.cache_timeout", 15*time.Second)
 
 	cfg.SetDefault("locode.db.path", "")
+
+	// extra fee values for working mode without notary contract
+	cfg.SetDefault("fee.main_chain", 5000_0000)   // 0.5 Fixed8
+	cfg.SetDefault("fee.side_chain", 2_0000_0000) // 2.0 Fixed8
 }

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -49,6 +49,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("metrics.shutdown_ttl", "30s")
 
 	cfg.SetDefault("without_mainnet", false)
+	cfg.SetDefault("without_notary", false)
 
 	cfg.SetDefault("morph.endpoint.client", "")
 	cfg.SetDefault("morph.endpoint.notification", "")
@@ -58,7 +59,6 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("mainnet.endpoint.client", "")
 	cfg.SetDefault("mainnet.endpoint.notification", "")
 	cfg.SetDefault("mainnet.dial_timeout", "10s")
-	cfg.SetDefault("mainnet.notary_deposit", true)
 
 	cfg.SetDefault("key", "") // inner ring node key
 

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -50,6 +50,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 
 	cfg.SetDefault("without_mainnet", false)
 	cfg.SetDefault("without_notary", false)
+	cfg.SetDefault("without_main_notary", false)
 
 	cfg.SetDefault("morph.endpoint.client", "")
 	cfg.SetDefault("morph.endpoint.notification", "")
@@ -75,7 +76,8 @@ func defaultConfiguration(cfg *viper.Viper) {
 
 	cfg.SetDefault("timers.epoch", "0")
 	cfg.SetDefault("timers.emit", "0")
-	cfg.SetDefault("timers.notary", "1000")
+	cfg.SetDefault("timers.main_notary", "1000")
+	cfg.SetDefault("timers.side_notary", "1000")
 	cfg.SetDefault("timers.stop_estimation.mul", 1)
 	cfg.SetDefault("timers.stop_estimation.div", 1)
 	cfg.SetDefault("timers.collect_basic_income.mul", 1)
@@ -83,7 +85,8 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("timers.distribute_basic_income.mul", 1)
 	cfg.SetDefault("timers.distribute_basic_income.div", 1)
 
-	cfg.SetDefault("notary.deposit_amount", 1_0000_0000) // 1.0 Fixed8
+	cfg.SetDefault("notary.side.deposit_amount", 1_0000_0000) // 1.0 Fixed8
+	cfg.SetDefault("notary.main.deposit_amount", 2000_0000)   // 0.2 Fixed8
 
 	cfg.SetDefault("workers.netmap", "10")
 	cfg.SetDefault("workers.balance", "10")

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -58,6 +58,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("mainnet.endpoint.client", "")
 	cfg.SetDefault("mainnet.endpoint.notification", "")
 	cfg.SetDefault("mainnet.dial_timeout", "10s")
+	cfg.SetDefault("mainnet.notary_deposit", true)
 
 	cfg.SetDefault("key", "") // inner ring node key
 
@@ -67,6 +68,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("contracts.container", "")
 	cfg.SetDefault("contracts.audit", "")
 	cfg.SetDefault("contracts.proxy", "")
+	cfg.SetDefault("contracts.processing", "")
 	cfg.SetDefault("contracts.reputation", "")
 	// alphabet contracts
 	cfg.SetDefault("contracts.alphabet.amount", 7)

--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -26,6 +26,8 @@ type (
 	epochTimerArgs struct {
 		l *zap.Logger
 
+		notaryDisabled bool
+
 		nm *netmap.Processor // to handle new epoch tick
 
 		cnrWrapper *container.Wrapper // to invoke stop container estimation
@@ -93,7 +95,14 @@ func newEpochTimer(args *epochTimerArgs) *timer.BlockTimer {
 				return
 			}
 
-			err := args.cnrWrapper.StopEstimationNotary(epochN - 1)
+			var err error
+
+			if args.notaryDisabled {
+				err = args.cnrWrapper.StopEstimation(epochN - 1)
+			} else {
+				err = args.cnrWrapper.StopEstimationNotary(epochN - 1)
+			}
+
 			if err != nil {
 				args.l.Warn("can't stop epoch estimation",
 					zap.Uint64("epoch", epochN),

--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -48,7 +48,7 @@ type (
 	notaryDepositArgs struct {
 		l *zap.Logger
 
-		depositor func() (util.Uint256, error)
+		depositor func() (util.Uint256, util.Uint256, error)
 
 		notaryDuration uint32 // in blocks
 	}
@@ -145,7 +145,7 @@ func newNotaryDepositTimer(args *notaryDepositArgs) *timer.BlockTimer {
 	return timer.NewBlockTimer(
 		timer.StaticBlockMeter(args.notaryDuration),
 		func() {
-			_, err := args.depositor()
+			_, _, err := args.depositor()
 			if err != nil {
 				args.l.Warn("can't deposit notary contract",
 					zap.String("error", err.Error()))

--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -93,7 +93,7 @@ func newEpochTimer(args *epochTimerArgs) *timer.BlockTimer {
 				return
 			}
 
-			err := args.cnrWrapper.StopEstimation(epochN - 1)
+			err := args.cnrWrapper.StopEstimationNotary(epochN - 1)
 			if err != nil {
 				args.l.Warn("can't stop epoch estimation",
 					zap.Uint64("epoch", epochN),

--- a/pkg/innerring/config/fee.go
+++ b/pkg/innerring/config/fee.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
+	"github.com/spf13/viper"
+)
+
+// FeeConfig is an instance that returns extra fee values for contract
+// invocations without notary support.
+type FeeConfig struct {
+	mainchain, sidechain fixedn.Fixed8
+}
+
+func NewFeeConfig(v *viper.Viper) *FeeConfig {
+	return &FeeConfig{
+		mainchain: fixedn.Fixed8(v.GetInt64("fee.main_chain")),
+		sidechain: fixedn.Fixed8(v.GetInt64("fee.side_chain")),
+	}
+}
+
+func (f FeeConfig) MainChainFee() fixedn.Fixed8 {
+	return f.mainchain
+}
+
+func (f FeeConfig) SideChainFee() fixedn.Fixed8 {
+	return f.sidechain
+}

--- a/pkg/innerring/invoke/alphabet.go
+++ b/pkg/innerring/invoke/alphabet.go
@@ -22,9 +22,13 @@ func AlphabetEmit(cli *client.Client, con util.Uint160) error {
 }
 
 // AlphabetVote invokes vote method on alphabet contract.
-func AlphabetVote(cli *client.Client, con util.Uint160, epoch uint64, keys keys.PublicKeys) error {
+func AlphabetVote(cli *client.Client, con util.Uint160, fee SideFeeProvider, epoch uint64, keys keys.PublicKeys) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), voteMethod, int64(epoch), keys)
 	}
 
 	return cli.NotaryInvoke(con, voteMethod, int64(epoch), keys)

--- a/pkg/innerring/invoke/balance.go
+++ b/pkg/innerring/invoke/balance.go
@@ -32,9 +32,17 @@ const (
 )
 
 // Mint assets in contract.
-func Mint(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
+func Mint(cli *client.Client, con util.Uint160, fee SideFeeProvider, p *MintBurnParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), mintMethod,
+			p.ScriptHash,
+			p.Amount,
+			p.Comment,
+		)
 	}
 
 	return cli.NotaryInvoke(con, mintMethod,
@@ -45,9 +53,17 @@ func Mint(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
 }
 
 // Burn minted assets.
-func Burn(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
+func Burn(cli *client.Client, con util.Uint160, fee SideFeeProvider, p *MintBurnParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), burnMethod,
+			p.ScriptHash,
+			p.Amount,
+			p.Comment,
+		)
 	}
 
 	return cli.NotaryInvoke(con, burnMethod,
@@ -58,9 +74,19 @@ func Burn(cli *client.Client, con util.Uint160, p *MintBurnParams) error {
 }
 
 // LockAsset invokes Lock method.
-func LockAsset(cli *client.Client, con util.Uint160, p *LockParams) error {
+func LockAsset(cli *client.Client, con util.Uint160, fee SideFeeProvider, p *LockParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), lockMethod,
+			p.ID,
+			p.User.BytesBE(),
+			p.LockAccount.BytesBE(),
+			p.Amount,
+			int64(p.Until),
+		)
 	}
 
 	return cli.NotaryInvoke(con, lockMethod,

--- a/pkg/innerring/invoke/chain.go
+++ b/pkg/innerring/invoke/chain.go
@@ -5,8 +5,23 @@ import (
 	"crypto/ecdsa"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 	crypto "github.com/nspcc-dev/neofs-crypto"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+)
+
+type (
+	// SideFeeProvider is an interface that used by invoker package method to
+	// get extra fee for all non notary smart contract invocations in side chain.
+	SideFeeProvider interface {
+		SideChainFee() fixedn.Fixed8
+	}
+
+	// MainFeeProvider is an interface that used by invoker package method to
+	// get extra fee for all non notary smart contract invocations in main chain.
+	MainFeeProvider interface {
+		MainChainFee() fixedn.Fixed8
+	}
 )
 
 // InnerRingIndex returns index of the `key` in the inner ring list from sidechain

--- a/pkg/innerring/invoke/container.go
+++ b/pkg/innerring/invoke/container.go
@@ -14,7 +14,7 @@ type (
 		Signature []byte
 	}
 
-	// ContainerParams for container put invocation.
+	// RemoveContainerParams for container delete invocation.
 	RemoveContainerParams struct {
 		ContainerID []byte
 		Signature   []byte
@@ -27,9 +27,17 @@ const (
 )
 
 // RegisterContainer invokes Put method.
-func RegisterContainer(cli *client.Client, con util.Uint160, p *ContainerParams) error {
+func RegisterContainer(cli *client.Client, con util.Uint160, fee SideFeeProvider, p *ContainerParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), putContainerMethod,
+			p.Container,
+			p.Signature,
+			p.Key.Bytes(),
+		)
 	}
 
 	return cli.NotaryInvoke(con, putContainerMethod,
@@ -39,10 +47,17 @@ func RegisterContainer(cli *client.Client, con util.Uint160, p *ContainerParams)
 	)
 }
 
-// RegisterContainer invokes Delete method.
-func RemoveContainer(cli *client.Client, con util.Uint160, p *RemoveContainerParams) error {
+// RemoveContainer invokes Delete method.
+func RemoveContainer(cli *client.Client, con util.Uint160, fee SideFeeProvider, p *RemoveContainerParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.SideChainFee(), deleteContainerMethod,
+			p.ContainerID,
+			p.Signature,
+		)
 	}
 
 	return cli.NotaryInvoke(con, deleteContainerMethod,

--- a/pkg/innerring/invoke/enhanced.go
+++ b/pkg/innerring/invoke/enhanced.go
@@ -19,8 +19,8 @@ import (
 )
 
 // NewContainerClient creates wrapper to access data from container contract.
-func NewContainerClient(cli *client.Client, contract util.Uint160) (*wrapContainer.Wrapper, error) {
-	staticClient, err := client.NewStatic(cli, contract, extraFee)
+func NewContainerClient(cli *client.Client, contract util.Uint160, fee SideFeeProvider) (*wrapContainer.Wrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, fee.SideChainFee())
 	if err != nil {
 		return nil, fmt.Errorf("can't create container static client: %w", err)
 	}
@@ -34,8 +34,8 @@ func NewContainerClient(cli *client.Client, contract util.Uint160) (*wrapContain
 }
 
 // NewNetmapClient creates wrapper to access data from netmap contract.
-func NewNetmapClient(cli *client.Client, contract util.Uint160) (*wrapNetmap.Wrapper, error) {
-	staticClient, err := client.NewStatic(cli, contract, extraFee)
+func NewNetmapClient(cli *client.Client, contract util.Uint160, fee SideFeeProvider) (*wrapNetmap.Wrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, fee.SideChainFee())
 	if err != nil {
 		return nil, fmt.Errorf("can't create netmap static client: %w", err)
 	}
@@ -49,8 +49,8 @@ func NewNetmapClient(cli *client.Client, contract util.Uint160) (*wrapNetmap.Wra
 }
 
 // NewAuditClient creates wrapper to work with Audit contract.
-func NewAuditClient(cli *client.Client, contract util.Uint160) (*auditWrapper.ClientWrapper, error) {
-	staticClient, err := client.NewStatic(cli, contract, extraFee)
+func NewAuditClient(cli *client.Client, contract util.Uint160, fee SideFeeProvider) (*auditWrapper.ClientWrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, fee.SideChainFee())
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +59,8 @@ func NewAuditClient(cli *client.Client, contract util.Uint160) (*auditWrapper.Cl
 }
 
 // NewBalanceClient creates wrapper to work with Balance contract.
-func NewBalanceClient(cli *client.Client, contract util.Uint160) (*balanceWrapper.Wrapper, error) {
-	staticClient, err := client.NewStatic(cli, contract, extraFee)
+func NewBalanceClient(cli *client.Client, contract util.Uint160, fee SideFeeProvider) (*balanceWrapper.Wrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, fee.SideChainFee())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create static client of Balance contract")
 	}
@@ -74,8 +74,8 @@ func NewBalanceClient(cli *client.Client, contract util.Uint160) (*balanceWrappe
 }
 
 // NewReputationClient creates wrapper to work with reputation contract.
-func NewReputationClient(cli *client.Client, contract util.Uint160) (*reputationWrapper.ClientWrapper, error) {
-	staticClient, err := client.NewStatic(cli, contract, 0)
+func NewReputationClient(cli *client.Client, contract util.Uint160, fee SideFeeProvider) (*reputationWrapper.ClientWrapper, error) {
+	staticClient, err := client.NewStatic(cli, contract, fee.SideChainFee())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create static client of reputation contract")
 	}

--- a/pkg/innerring/invoke/neofs.go
+++ b/pkg/innerring/invoke/neofs.go
@@ -36,7 +36,7 @@ func CashOutCheque(cli *client.Client, con util.Uint160, p *ChequeParams) error 
 		return client.ErrNilClient
 	}
 
-	return cli.Invoke(con, extraFee, chequeMethod,
+	return cli.NotaryInvoke(con, chequeMethod,
 		p.ID,
 		p.User.BytesBE(),
 		p.Amount,
@@ -50,5 +50,5 @@ func AlphabetUpdate(cli *client.Client, con util.Uint160, id []byte, list keys.P
 		return client.ErrNilClient
 	}
 
-	return cli.Invoke(con, extraFee, alphabetUpdateMethod, id, list)
+	return cli.NotaryInvoke(con, alphabetUpdateMethod, id, list)
 }

--- a/pkg/innerring/invoke/neofs.go
+++ b/pkg/innerring/invoke/neofs.go
@@ -31,9 +31,18 @@ const (
 )
 
 // CashOutCheque invokes Cheque method.
-func CashOutCheque(cli *client.Client, con util.Uint160, p *ChequeParams) error {
+func CashOutCheque(cli *client.Client, con util.Uint160, fee MainFeeProvider, p *ChequeParams) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.MainChainFee(), chequeMethod,
+			p.ID,
+			p.User.BytesBE(),
+			p.Amount,
+			p.LockAccount.BytesBE(),
+		)
 	}
 
 	return cli.NotaryInvoke(con, chequeMethod,
@@ -45,9 +54,13 @@ func CashOutCheque(cli *client.Client, con util.Uint160, p *ChequeParams) error 
 }
 
 // AlphabetUpdate invokes alphabetUpdate method.
-func AlphabetUpdate(cli *client.Client, con util.Uint160, id []byte, list keys.PublicKeys) error {
+func AlphabetUpdate(cli *client.Client, con util.Uint160, fee MainFeeProvider, id []byte, list keys.PublicKeys) error {
 	if cli == nil {
 		return client.ErrNilClient
+	}
+
+	if !cli.NotaryEnabled() {
+		return cli.Invoke(con, fee.MainChainFee(), alphabetUpdateMethod, id, list)
 	}
 
 	return cli.NotaryInvoke(con, alphabetUpdateMethod, id, list)

--- a/pkg/innerring/notary.go
+++ b/pkg/innerring/notary.go
@@ -1,0 +1,95 @@
+package innerring
+
+import (
+	"context"
+
+	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/spf13/viper"
+)
+
+type (
+	notaryConfig struct {
+		amount   fixedn.Fixed8 // amount of deposited GAS to notary contract
+		duration uint32        // lifetime of notary deposit in blocks
+		disabled bool          // true if notary disabled on chain
+	}
+)
+
+func (s *Server) depositMainNotary() (tx util.Uint256, err error) {
+	return s.mainnetClient.DepositNotary(
+		s.mainNotaryConfig.amount,
+		s.mainNotaryConfig.duration+notaryExtraBlocks,
+	)
+}
+
+func (s *Server) depositSideNotary() (tx util.Uint256, err error) {
+	return s.morphClient.DepositNotary(
+		s.sideNotaryConfig.amount,
+		s.sideNotaryConfig.duration+notaryExtraBlocks,
+	)
+}
+
+func (s *Server) awaitMainNotaryDeposit(ctx context.Context, tx util.Uint256) error {
+	return awaitNotaryDepositInClient(ctx, s.mainnetClient, tx)
+}
+
+func (s *Server) awaitSideNotaryDeposit(ctx context.Context, tx util.Uint256) error {
+	return awaitNotaryDepositInClient(ctx, s.morphClient, tx)
+}
+
+func (s *Server) initNotary(ctx context.Context, deposit depositor, await awaiter, msg string) error {
+	tx, err := deposit()
+	if err != nil {
+		return err
+	}
+
+	s.log.Info(msg)
+
+	return await(ctx, tx)
+}
+
+func awaitNotaryDepositInClient(ctx context.Context, cli *client.Client, txHash util.Uint256) error {
+	for i := 0; i < notaryDepositTimeout; i++ {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		ok, err := cli.TxHalt(txHash)
+		if err == nil {
+			if ok {
+				return nil
+			}
+
+			return errDepositFail
+		}
+
+		cli.Wait(ctx, 1)
+	}
+
+	return errDepositTimeout
+}
+
+func parseNotaryConfigs(cfg *viper.Viper) (main, side *notaryConfig) {
+	main = new(notaryConfig)
+	side = new(notaryConfig)
+
+	if cfg.GetBool("without_notary") {
+		main.disabled = true
+		side.disabled = true
+
+		return
+	}
+
+	main.disabled = cfg.GetBool("without_main_notary")
+	main.amount = fixedn.Fixed8(cfg.GetInt64("notary.main.deposit_amount"))
+	main.duration = cfg.GetUint32("timers.main_notary")
+
+	side.amount = fixedn.Fixed8(cfg.GetInt64("notary.side.deposit_amount"))
+	side.duration = cfg.GetUint32("timers.side_notary")
+
+	return
+}

--- a/pkg/innerring/processors/audit/processor.go
+++ b/pkg/innerring/processors/audit/processor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	SDKClient "github.com/nspcc-dev/neofs-api-go/pkg/client"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/invoke"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	wrapContainer "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
@@ -66,6 +67,7 @@ type (
 		AuditContract     util.Uint160
 		MorphClient       *client.Client
 		IRList            Indexer
+		FeeProvider       *config.FeeConfig
 		ClientCache       NeoFSClientCache
 		RPCSearchTimeout  time.Duration
 		TaskManager       TaskManager
@@ -94,6 +96,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/audit: neo:morph client is not set")
 	case p.IRList == nil:
 		return nil, errors.New("ir/audit: global state is not set")
+	case p.FeeProvider == nil:
+		return nil, errors.New("ir/audit: fee provider is not set")
 	case p.ClientCache == nil:
 		return nil, errors.New("ir/audit: neofs RPC client cache is not set")
 	case p.TaskManager == nil:
@@ -110,13 +114,13 @@ func New(p *Params) (*Processor, error) {
 	}
 
 	// creating enhanced client for getting network map
-	netmapClient, err := invoke.NewNetmapClient(p.MorphClient, p.NetmapContract)
+	netmapClient, err := invoke.NewNetmapClient(p.MorphClient, p.NetmapContract, p.FeeProvider)
 	if err != nil {
 		return nil, err
 	}
 
 	// creating enhanced client for getting containers
-	containerClient, err := invoke.NewContainerClient(p.MorphClient, p.ContainerContract)
+	containerClient, err := invoke.NewContainerClient(p.MorphClient, p.ContainerContract, p.FeeProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/innerring/processors/balance/process_assets.go
+++ b/pkg/innerring/processors/balance/process_assets.go
@@ -14,7 +14,7 @@ func (bp *Processor) processLock(lock *balanceEvent.Lock) {
 		return
 	}
 
-	err := invoke.CashOutCheque(bp.mainnetClient, bp.neofsContract,
+	err := invoke.CashOutCheque(bp.mainnetClient, bp.neofsContract, bp.feeProvider,
 		&invoke.ChequeParams{
 			ID:          lock.ID(),
 			Amount:      bp.converter.ToFixed8(lock.Amount()),

--- a/pkg/innerring/processors/balance/processor.go
+++ b/pkg/innerring/processors/balance/processor.go
@@ -2,6 +2,7 @@ package balance
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	balanceEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/balance"
@@ -30,6 +31,7 @@ type (
 		mainnetClient   *client.Client
 		alphabetState   AlphabetState
 		converter       PrecisionConverter
+		feeProvider     *config.FeeConfig
 	}
 
 	// Params of the processor constructor.
@@ -41,6 +43,7 @@ type (
 		MainnetClient   *client.Client
 		AlphabetState   AlphabetState
 		Converter       PrecisionConverter
+		FeeProvider     *config.FeeConfig
 	}
 )
 
@@ -59,6 +62,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/balance: global state is not set")
 	case p.Converter == nil:
 		return nil, errors.New("ir/balance: balance precision converter is not set")
+	case p.FeeProvider == nil:
+		return nil, errors.New("ir/balance: fee provider is not set")
 	}
 
 	p.Log.Debug("balance worker pool", zap.Int("size", p.PoolSize))
@@ -76,6 +81,7 @@ func New(p *Params) (*Processor, error) {
 		mainnetClient:   p.MainnetClient,
 		alphabetState:   p.AlphabetState,
 		converter:       p.Converter,
+		feeProvider:     p.FeeProvider,
 	}, nil
 }
 

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -37,7 +37,7 @@ func (cp *Processor) processContainerPut(put *containerEvent.Put) {
 		return
 	}
 
-	err := invoke.RegisterContainer(cp.morphClient, cp.containerContract,
+	err := invoke.RegisterContainer(cp.morphClient, cp.containerContract, cp.feeProvider,
 		&invoke.ContainerParams{
 			Key:       put.PublicKey(),
 			Container: cnrData,
@@ -56,7 +56,7 @@ func (cp *Processor) processContainerDelete(delete *containerEvent.Delete) {
 		return
 	}
 
-	err := invoke.RemoveContainer(cp.morphClient, cp.containerContract,
+	err := invoke.RemoveContainer(cp.morphClient, cp.containerContract, cp.feeProvider,
 		&invoke.RemoveContainerParams{
 			ContainerID: delete.ContainerID(),
 			Signature:   delete.Signature(),

--- a/pkg/innerring/processors/container/processor.go
+++ b/pkg/innerring/processors/container/processor.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
@@ -23,6 +24,7 @@ type (
 		containerContract util.Uint160
 		morphClient       *client.Client
 		alphabetState     AlphabetState
+		feeProvider       *config.FeeConfig
 	}
 
 	// Params of the processor constructor.
@@ -32,6 +34,7 @@ type (
 		ContainerContract util.Uint160
 		MorphClient       *client.Client
 		AlphabetState     AlphabetState
+		FeeProvider       *config.FeeConfig
 	}
 )
 
@@ -49,6 +52,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/container: neo:morph client is not set")
 	case p.AlphabetState == nil:
 		return nil, errors.New("ir/container: global state is not set")
+	case p.FeeProvider == nil:
+		return nil, errors.New("ir/container: fee provider is not set")
 	}
 
 	p.Log.Debug("container worker pool", zap.Int("size", p.PoolSize))
@@ -64,6 +69,7 @@ func New(p *Params) (*Processor, error) {
 		containerContract: p.ContainerContract,
 		morphClient:       p.MorphClient,
 		alphabetState:     p.AlphabetState,
+		feeProvider:       p.FeeProvider,
 	}, nil
 }
 

--- a/pkg/innerring/processors/neofs/process_assets.go
+++ b/pkg/innerring/processors/neofs/process_assets.go
@@ -21,7 +21,7 @@ func (np *Processor) processDeposit(deposit *neofsEvent.Deposit) {
 	}
 
 	// send transferX to balance contract
-	err := invoke.Mint(np.morphClient, np.balanceContract,
+	err := invoke.Mint(np.morphClient, np.balanceContract, np.feeProvider,
 		&invoke.MintBurnParams{
 			ScriptHash: deposit.To().BytesBE(),
 			Amount:     np.converter.ToBalancePrecision(deposit.Amount()),
@@ -94,7 +94,7 @@ func (np *Processor) processWithdraw(withdraw *neofsEvent.Withdraw) {
 
 	curEpoch := np.epochState.EpochCounter()
 
-	err = invoke.LockAsset(np.morphClient, np.balanceContract,
+	err = invoke.LockAsset(np.morphClient, np.balanceContract, np.feeProvider,
 		&invoke.LockParams{
 			ID:          withdraw.ID(),
 			User:        withdraw.User(),
@@ -115,7 +115,7 @@ func (np *Processor) processCheque(cheque *neofsEvent.Cheque) {
 		return
 	}
 
-	err := invoke.Burn(np.morphClient, np.balanceContract,
+	err := invoke.Burn(np.morphClient, np.balanceContract, np.feeProvider,
 		&invoke.MintBurnParams{
 			ScriptHash: cheque.LockAccount().BytesBE(),
 			Amount:     np.converter.ToBalancePrecision(cheque.Amount()),

--- a/pkg/innerring/processors/neofs/process_config.go
+++ b/pkg/innerring/processors/neofs/process_config.go
@@ -14,7 +14,7 @@ func (np *Processor) processConfig(config *neofsEvent.Config) {
 		return
 	}
 
-	err := invoke.SetConfig(np.morphClient, np.netmapContract,
+	err := invoke.SetConfig(np.morphClient, np.netmapContract, np.feeProvider,
 		&invoke.SetConfigArgs{
 			ID:    config.ID(),
 			Key:   config.Key(),

--- a/pkg/innerring/processors/neofs/processor.go
+++ b/pkg/innerring/processors/neofs/processor.go
@@ -6,6 +6,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	neofsEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/neofs"
@@ -41,6 +42,7 @@ type (
 		epochState          EpochState
 		alphabetState       AlphabetState
 		converter           PrecisionConverter
+		feeProvider         *config.FeeConfig
 		mintEmitLock        *sync.Mutex
 		mintEmitCache       *lru.Cache
 		mintEmitThreshold   uint64
@@ -59,6 +61,7 @@ type (
 		EpochState          EpochState
 		AlphabetState       AlphabetState
 		Converter           PrecisionConverter
+		FeeProvider         *config.FeeConfig
 		MintEmitCacheSize   int
 		MintEmitThreshold   uint64 // in epochs
 		MintEmitValue       fixedn.Fixed8
@@ -86,6 +89,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/neofs: global state is not set")
 	case p.Converter == nil:
 		return nil, errors.New("ir/neofs: balance precision converter is not set")
+	case p.FeeProvider == nil:
+		return nil, errors.New("ir/neofs: fee provider is not set")
 	}
 
 	p.Log.Debug("neofs worker pool", zap.Int("size", p.PoolSize))
@@ -110,6 +115,7 @@ func New(p *Params) (*Processor, error) {
 		epochState:          p.EpochState,
 		alphabetState:       p.AlphabetState,
 		converter:           p.Converter,
+		feeProvider:         p.FeeProvider,
 		mintEmitLock:        new(sync.Mutex),
 		mintEmitCache:       lruCache,
 		mintEmitThreshold:   p.MintEmitThreshold,

--- a/pkg/innerring/processors/netmap/process_cleanup.go
+++ b/pkg/innerring/processors/netmap/process_cleanup.go
@@ -25,10 +25,11 @@ func (np *Processor) processNetmapCleanupTick(epoch uint64) {
 
 		np.log.Info("vote to remove node from netmap", zap.String("key", s))
 
-		err = invoke.UpdatePeerState(np.morphClient, np.netmapContract, &invoke.UpdatePeerArgs{
-			Key:    key,
-			Status: netmap.NodeStateOffline,
-		})
+		err = invoke.UpdatePeerState(np.morphClient, np.netmapContract, np.feeProvider,
+			&invoke.UpdatePeerArgs{
+				Key:    key,
+				Status: netmap.NodeStateOffline,
+			})
 		if err != nil {
 			np.log.Error("can't invoke netmap.UpdateState", zap.Error(err))
 		}

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -27,7 +27,12 @@ func (np *Processor) processNewEpoch(epoch uint64) {
 	}
 
 	if epoch > 0 { // estimates are invalid in genesis epoch
-		err = np.containerWrp.StartEstimationNotary(epoch - 1)
+		if np.notaryDisabled {
+			err = np.containerWrp.StartEstimation(epoch - 1)
+		} else {
+			err = np.containerWrp.StartEstimationNotary(epoch - 1)
+		}
+
 		if err != nil {
 			np.log.Warn("can't start container size estimation",
 				zap.Uint64("epoch", epoch),
@@ -52,7 +57,7 @@ func (np *Processor) processNewEpochTick() {
 	nextEpoch := np.epochState.EpochCounter() + 1
 	np.log.Debug("next epoch", zap.Uint64("value", nextEpoch))
 
-	err := invoke.SetNewEpoch(np.morphClient, np.netmapContract, nextEpoch)
+	err := invoke.SetNewEpoch(np.morphClient, np.netmapContract, np.feeProvider, nextEpoch)
 	if err != nil {
 		np.log.Error("can't invoke netmap.NewEpoch", zap.Error(err))
 	}

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -27,7 +27,7 @@ func (np *Processor) processNewEpoch(epoch uint64) {
 	}
 
 	if epoch > 0 { // estimates are invalid in genesis epoch
-		err = np.containerWrp.StartEstimation(epoch - 1)
+		err = np.containerWrp.StartEstimationNotary(epoch - 1)
 		if err != nil {
 			np.log.Warn("can't start container size estimation",
 				zap.Uint64("epoch", epoch),

--- a/pkg/innerring/processors/netmap/process_peers.go
+++ b/pkg/innerring/processors/netmap/process_peers.go
@@ -66,7 +66,8 @@ func (np *Processor) processAddPeer(node []byte) {
 		np.log.Info("approving network map candidate",
 			zap.String("key", keyString))
 
-		if err := invoke.ApprovePeer(np.morphClient, np.netmapContract, node); err != nil {
+		err := invoke.ApprovePeer(np.morphClient, np.netmapContract, np.feeProvider, node)
+		if err != nil {
 			np.log.Error("can't invoke netmap.AddPeer", zap.Error(err))
 		}
 	}
@@ -92,7 +93,7 @@ func (np *Processor) processUpdatePeer(ev netmapEvent.UpdatePeer) {
 	// again before new epoch will tick
 	np.netmapSnapshot.flag(hex.EncodeToString(ev.PublicKey().Bytes()))
 
-	err := invoke.UpdatePeerState(np.morphClient, np.netmapContract,
+	err := invoke.UpdatePeerState(np.morphClient, np.netmapContract, np.feeProvider,
 		&invoke.UpdatePeerArgs{
 			Key:    ev.PublicKey(),
 			Status: ev.Status(),

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -3,6 +3,7 @@ package netmap
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	container "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -64,6 +65,9 @@ type (
 		handleAlphabetSync     event.Handler
 
 		nodeValidator NodeValidator
+
+		notaryDisabled bool
+		feeProvider    *config.FeeConfig
 	}
 
 	// Params of the processor constructor.
@@ -84,6 +88,9 @@ type (
 		AlphabetSyncHandler     event.Handler
 
 		NodeValidator NodeValidator
+
+		NotaryDisabled bool
+		FeeProvider    *config.FeeConfig
 	}
 )
 
@@ -116,6 +123,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/netmap: container contract wrapper is not set")
 	case p.NodeValidator == nil:
 		return nil, errors.New("ir/netmap: node validator is not set")
+	case p.FeeProvider == nil:
+		return nil, errors.New("ir/netmap: fee provider is not set")
 	}
 
 	p.Log.Debug("netmap worker pool", zap.Int("size", p.PoolSize))
@@ -142,6 +151,9 @@ func New(p *Params) (*Processor, error) {
 		handleAlphabetSync: p.AlphabetSyncHandler,
 
 		nodeValidator: p.NodeValidator,
+
+		notaryDisabled: p.NotaryDisabled,
+		feeProvider:    p.FeeProvider,
 	}, nil
 }
 

--- a/pkg/innerring/processors/reputation/process_put.go
+++ b/pkg/innerring/processors/reputation/process_put.go
@@ -41,7 +41,14 @@ func (rp *Processor) processPut(epoch uint64, id reputation.PeerID, value reputa
 	args.SetPeerID(id)
 	args.SetValue(value)
 
-	err := rp.reputationWrp.PutViaNotary(args)
+	var err error
+
+	if rp.notaryDisabled {
+		err = rp.reputationWrp.Put(args)
+	} else {
+		err = rp.reputationWrp.PutViaNotary(args)
+	}
+
 	if err != nil {
 		rp.log.Warn("can't send approval tx for reputation value",
 			zap.String("peer_id", hex.EncodeToString(id.ToV2().GetValue())),

--- a/pkg/innerring/processors/reputation/processor.go
+++ b/pkg/innerring/processors/reputation/processor.go
@@ -26,6 +26,8 @@ type (
 		log  *zap.Logger
 		pool *ants.Pool
 
+		notaryDisabled bool
+
 		reputationContract util.Uint160
 
 		epochState    EpochState
@@ -38,6 +40,7 @@ type (
 	Params struct {
 		Log                *zap.Logger
 		PoolSize           int
+		NotaryDisabled     bool
 		ReputationContract util.Uint160
 		EpochState         EpochState
 		AlphabetState      AlphabetState
@@ -72,6 +75,7 @@ func New(p *Params) (*Processor, error) {
 	return &Processor{
 		log:                p.Log,
 		pool:               pool,
+		notaryDisabled:     p.NotaryDisabled,
 		reputationContract: p.ReputationContract,
 		epochState:         p.EpochState,
 		alphabetState:      p.AlphabetState,

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -84,7 +84,7 @@ func (s *Server) voteForSidechainValidator(validators keys.PublicKeys) error {
 	epoch := s.EpochCounter()
 
 	s.contracts.alphabet.iterate(func(letter glagoliticLetter, contract util.Uint160) {
-		err := invoke.AlphabetVote(s.morphClient, contract, epoch, validators)
+		err := invoke.AlphabetVote(s.morphClient, contract, s.feeConfig, epoch, validators)
 		if err != nil {
 			s.log.Warn("can't invoke vote method in alphabet contract",
 				zap.Int8("alphabet_index", int8(letter)),

--- a/pkg/morph/client/container/estimations.go
+++ b/pkg/morph/client/container/estimations.go
@@ -21,6 +21,13 @@ func (e *StopEstimation) SetEpoch(v int64) {
 }
 
 func (c *Client) StartEstimation(args StartEstimation) error {
+	return errors.Wrapf(c.client.Invoke(
+		c.startEstimation,
+		args.epoch,
+	), "could not invoke method (%s)", c.startEstimation)
+}
+
+func (c *Client) StartEstimationNotary(args StartEstimation) error {
 	return errors.Wrapf(c.client.NotaryInvoke(
 		c.startEstimation,
 		args.epoch,
@@ -28,6 +35,13 @@ func (c *Client) StartEstimation(args StartEstimation) error {
 }
 
 func (c *Client) StopEstimation(args StopEstimation) error {
+	return errors.Wrapf(c.client.Invoke(
+		c.stopEstimation,
+		args.epoch,
+	), "could not invoke method (%s)", c.stopEstimation)
+}
+
+func (c *Client) StopEstimationNotary(args StopEstimation) error {
 	return errors.Wrapf(c.client.NotaryInvoke(
 		c.stopEstimation,
 		args.epoch,

--- a/pkg/morph/client/container/wrapper/estimations.go
+++ b/pkg/morph/client/container/wrapper/estimations.go
@@ -12,10 +12,28 @@ func (w *Wrapper) StartEstimation(epoch uint64) error {
 	return w.client.StartEstimation(args)
 }
 
+// StartEstimationNotary votes to produce start estimation notification through
+// notary contract.
+func (w *Wrapper) StartEstimationNotary(epoch uint64) error {
+	args := container.StartEstimation{}
+	args.SetEpoch(int64(epoch))
+
+	return w.client.StartEstimationNotary(args)
+}
+
 // StopEstimation votes to produce stop estimation notification.
 func (w *Wrapper) StopEstimation(epoch uint64) error {
 	args := container.StopEstimation{}
 	args.SetEpoch(int64(epoch))
 
 	return w.client.StopEstimation(args)
+}
+
+// StopEstimationNotary votes to produce stop estimation notification through
+// notary contract.
+func (w *Wrapper) StopEstimationNotary(epoch uint64) error {
+	args := container.StopEstimation{}
+	args.SetEpoch(int64(epoch))
+
+	return w.client.StopEstimationNotary(args)
 }

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -12,6 +12,8 @@ const (
 	epochDurationConfig   = "EpochDuration"
 	containerFeeConfig    = "ContainerFee"
 	etIterationsConfig    = "EigenTrustIterations"
+	irCandidateFeeConfig  = "InnerRingCandidateFee"
+	withdrawFeeConfig     = "WithdrawFee"
 )
 
 // MaxObjectSize receives max object size configuration
@@ -77,6 +79,28 @@ func (w *Wrapper) EigenTrustIterations() (uint64, error) {
 	}
 
 	return iterations, nil
+}
+
+// InnerRingCandidateFee returns global configuration value of fee payed by
+// node to be in inner ring candidates list.
+func (w *Wrapper) InnerRingCandidateFee() (uint64, error) {
+	fee, err := w.readUInt64Config(irCandidateFeeConfig)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get inner ring candidate fee", w)
+	}
+
+	return fee, nil
+}
+
+// WithdrawFee returns global configuration value of fee payed by user to
+// withdraw assets from NeoFS contract.
+func (w *Wrapper) WithdrawFee() (uint64, error) {
+	fee, err := w.readUInt64Config(withdrawFeeConfig)
+	if err != nil {
+		return 0, errors.Wrapf(err, "(%T) could not get withdraw fee", w)
+	}
+
+	return fee, nil
 }
 
 func (w *Wrapper) readUInt64Config(key string) (uint64, error) {

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -81,7 +81,7 @@ func (w *Wrapper) EigenTrustIterations() (uint64, error) {
 	return iterations, nil
 }
 
-// InnerRingCandidateFee returns global configuration value of fee payed by
+// InnerRingCandidateFee returns global configuration value of fee paid by
 // node to be in inner ring candidates list.
 func (w *Wrapper) InnerRingCandidateFee() (uint64, error) {
 	fee, err := w.readUInt64Config(irCandidateFeeConfig)
@@ -92,7 +92,7 @@ func (w *Wrapper) InnerRingCandidateFee() (uint64, error) {
 	return fee, nil
 }
 
-// WithdrawFee returns global configuration value of fee payed by user to
+// WithdrawFee returns global configuration value of fee paid by user to
 // withdraw assets from NeoFS contract.
 func (w *Wrapper) WithdrawFee() (uint64, error) {
 	fee, err := w.readUInt64Config(withdrawFeeConfig)

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -89,6 +89,12 @@ func (c *Client) EnableNotarySupport(proxy util.Uint160, opts ...NotaryOption) e
 	return nil
 }
 
+// NotaryEnabled returns true if notary support was enabled in this instance
+// of client by calling `EnableNotarySupport()`. Otherwise returns false.
+func (c *Client) NotaryEnabled() bool {
+	return c.notary != nil
+}
+
 // DepositNotary calls notary deposit method. Deposit is required to operate
 // with notary contract. It used by notary contract in to produce fallback tx
 // if main tx failed to create. Deposit isn't last forever, so it should

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -19,17 +19,12 @@ import (
 
 type (
 	notary struct {
-		// extra fee to check witness of proxy contract
-		// neo-go does not have an option to calculate it exactly right now
-		extraVerifyFee int64
-
 		txValidTime  uint32 // minimum amount of blocks when mainTx will be valid
 		roundTime    uint32 // extra amount of blocks to synchronize sidechain height diff of inner ring nodes
 		fallbackTime uint32 // amount of blocks before fallbackTx will be sent
 
 		notary util.Uint160
 		proxy  util.Uint160
-		netmap util.Uint160
 	}
 
 	notaryCfg struct {
@@ -79,7 +74,6 @@ func (c *Client) EnableNotarySupport(proxy, netmap util.Uint160, opts ...NotaryO
 	c.notary = &notary{
 		notary:       notaryContract,
 		proxy:        proxy,
-		netmap:       netmap,
 		txValidTime:  cfg.txValidTime,
 		roundTime:    cfg.roundTime,
 		fallbackTime: cfg.fallbackTime,


### PR DESCRIPTION
In this PR:
- notary subsystem in notary client now supports custom sources for alphabet keys instead of only committee,
- inner ring adds processing contract to the config,
- inner ring adds extra fee config, used in `invoke` package,
- `neofs.UpdateAlphabet` and `neofs.Cheques` now may be invoked via notary,
- `invoke` package function wrappers may call methods via notary or directly by checking if provided client enabled notary.
