### PR TITLE
object/search: Re-sign original requests during forwarding

### DIFF
--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -12,6 +12,8 @@ func (exec *execCtx) assemble() {
 		return
 	}
 
+	exec.assembling = true
+
 	exec.log.Debug("trying to assemble the object...")
 
 	splitInfo := exec.splitInfo()

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -41,6 +41,12 @@ type execCtx struct {
 	head bool
 
 	curProcEpoch uint64
+
+	// true when the processing of the initial request
+	// is turned to assembling stage. When false,
+	// initial request can be forwarded during network
+	// communication.
+	assembling bool
 }
 
 type execOption func(*execCtx)

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -32,6 +32,8 @@ type RangeHashPrm struct {
 	salt []byte
 }
 
+type RequestForwarder func(client.Client) (*objectSDK.Object, error)
+
 // HeadPrm groups parameters of Head service call.
 type HeadPrm struct {
 	commonPrm
@@ -43,6 +45,8 @@ type commonPrm struct {
 	common *util.CommonPrm
 
 	client.GetObjectParams
+
+	forwarder RequestForwarder
 }
 
 // ChunkWriter is an interface of target component
@@ -98,6 +102,10 @@ func (p *RangeHashPrm) SetSalt(salt []byte) {
 // SetCommonParameters sets common parameters of the operation.
 func (p *commonPrm) SetCommonParameters(common *util.CommonPrm) {
 	p.common = common
+}
+
+func (p *commonPrm) SetRequestForwarder(f RequestForwarder) {
+	p.forwarder = f
 }
 
 // SetHeaderWriter sets target component to write the object header.

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -80,6 +80,10 @@ func (c *clientCacheWrapper) get(addr string) (getClient, error) {
 }
 
 func (c *clientWrapper) getObject(exec *execCtx) (*objectSDK.Object, error) {
+	if !exec.assembling {
+		return exec.prm.forwarder(c.client)
+	}
+
 	if exec.headOnly() {
 		return c.client.GetObjectHeader(exec.context(),
 			new(client.ObjectHeaderParams).

--- a/pkg/services/object/get/v2/service.go
+++ b/pkg/services/object/get/v2/service.go
@@ -96,7 +96,7 @@ func (s *Service) Head(ctx context.Context, req *objectV2.HeadRequest) (*objectV
 	resp := new(objectV2.HeadResponse)
 	resp.SetBody(new(objectV2.HeadResponseBody))
 
-	p, err := s.toHeadPrm(req, resp)
+	p, err := s.toHeadPrm(ctx, req, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/object/get/v2/util.go
+++ b/pkg/services/object/get/v2/util.go
@@ -204,7 +204,7 @@ func (s *Service) toRangePrm(req *objectV2.GetRangeRequest, stream objectSvc.Get
 				return nil, errors.Wrap(err, "could not create Get payload range stream")
 			}
 
-			payload := make([]byte, body.GetRange().GetLength())
+			payload := make([]byte, 0, body.GetRange().GetLength())
 
 			resp := new(objectV2.GetRangeResponse)
 

--- a/pkg/services/object/search/exec.go
+++ b/pkg/services/object/search/exec.go
@@ -2,13 +2,10 @@ package searchsvc
 
 import (
 	"context"
-	"crypto/ecdsa"
 
-	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
-	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"go.uber.org/zap"
@@ -60,21 +57,6 @@ func (exec execCtx) context() context.Context {
 
 func (exec execCtx) isLocal() bool {
 	return exec.prm.common.LocalOnly()
-}
-
-func (exec execCtx) key() *ecdsa.PrivateKey {
-	return exec.prm.common.PrivateKey()
-}
-
-func (exec execCtx) callOptions() []client.CallOption {
-	return exec.prm.common.RemoteCallOptions(
-		util.WithNetmapEpoch(exec.curProcEpoch),
-		util.WithKey(exec.key()),
-	)
-}
-
-func (exec execCtx) remotePrm() *client.SearchObjectParams {
-	return &exec.prm.SearchObjectParams
 }
 
 func (exec *execCtx) containerID() *container.ID {

--- a/pkg/services/object/search/prm.go
+++ b/pkg/services/object/search/prm.go
@@ -13,6 +13,8 @@ type Prm struct {
 	common *util.CommonPrm
 
 	client.SearchObjectParams
+
+	forwarder RequestForwarder
 }
 
 // IDListWriter is an interface of target component
@@ -20,6 +22,10 @@ type Prm struct {
 type IDListWriter interface {
 	WriteIDs([]*objectSDK.ID) error
 }
+
+// RequestForwarder is a callback for forwarding of the
+// original Search requests.
+type RequestForwarder func(client.Client) ([]*objectSDK.ID, error)
 
 // SetCommonParameters sets common parameters of the operation.
 func (p *Prm) SetCommonParameters(common *util.CommonPrm) {
@@ -29,4 +35,10 @@ func (p *Prm) SetCommonParameters(common *util.CommonPrm) {
 // SetWriter sets target component to write list of object identifiers.
 func (p *Prm) SetWriter(w IDListWriter) {
 	p.writer = w
+}
+
+// SetRequestForwarder sets callback for forwarding
+// of the original request.
+func (p *Prm) SetRequestForwarder(f RequestForwarder) {
+	p.forwarder = f
 }

--- a/pkg/services/object/search/util.go
+++ b/pkg/services/object/search/util.go
@@ -76,9 +76,7 @@ func (c *clientConstructorWrapper) get(addr string) (searchClient, error) {
 }
 
 func (c *clientWrapper) searchObjects(exec *execCtx) ([]*objectSDK.ID, error) {
-	return c.client.SearchObject(exec.context(),
-		exec.remotePrm(),
-		exec.callOptions()...)
+	return exec.prm.forwarder(c.client)
 }
 
 func (e *storageEngineWrapper) search(exec *execCtx) ([]*objectSDK.ID, error) {

--- a/pkg/services/object/search/v2/util.go
+++ b/pkg/services/object/search/v2/util.go
@@ -1,13 +1,22 @@
 package searchsvc
 
 import (
+	"io"
+	"sync"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/token"
+	rpcclient "github.com/nspcc-dev/neofs-api-go/rpc/client"
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/nspcc-dev/neofs-api-go/v2/rpc"
+	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/nspcc-dev/neofs-api-go/v2/signature"
 	objectSvc "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
+	"github.com/pkg/errors"
 )
 
 func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStream) (*searchsvc.Prm, error) {
@@ -31,6 +40,67 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 	p.SetWriter(&streamWriter{
 		stream: stream,
 	})
+
+	if !commonPrm.LocalOnly() {
+		var onceResign sync.Once
+
+		p.SetRequestForwarder(func(c client.Client) ([]*objectSDK.ID, error) {
+			var err error
+
+			// once compose and resign forwarding request
+			onceResign.Do(func() {
+				// compose meta header of the local server
+				metaHdr := new(session.RequestMetaHeader)
+				metaHdr.SetTTL(meta.GetTTL() - 1)
+				// TODO: think how to set the other fields
+				metaHdr.SetOrigin(meta)
+
+				req.SetMetaHeader(metaHdr)
+
+				err = signature.SignServiceMessage(key, req)
+			})
+
+			if err != nil {
+				return nil, err
+			}
+
+			stream, err := rpc.SearchObjects(c.Raw(), req, rpcclient.WithContext(stream.Context()))
+			if err != nil {
+				return nil, err
+			}
+
+			// code below is copy-pasted from c.SearchObjects implementation,
+			// perhaps it is worth highlighting the utility function in neofs-api-go
+			var (
+				searchResult []*objectSDK.ID
+				resp         = new(objectV2.SearchResponse)
+			)
+
+			for {
+				// receive message from server stream
+				err := stream.Read(resp)
+				if err != nil {
+					if errors.Is(errors.Cause(err), io.EOF) {
+						break
+					}
+
+					return nil, errors.Wrap(err, "reading the response failed")
+				}
+
+				// verify response structure
+				if err := signature.VerifyServiceMessage(resp); err != nil {
+					return nil, errors.Wrapf(err, "could not verify %T", resp)
+				}
+
+				chunk := resp.GetBody().GetIDList()
+				for i := range chunk {
+					searchResult = append(searchResult, objectSDK.NewIDFromV2(chunk[i]))
+				}
+			}
+
+			return searchResult, nil
+		})
+	}
 
 	body := req.GetBody()
 	p.WithContainerID(container.NewIDFromV2(body.GetContainerID()))


### PR DESCRIPTION
In previous implementation node's Object Search V2 service handler created a
new request for each RPC. Now original requests are re-signed according to
API specification. Logical handler abstracts from this version-dependent
logic through `RequestForwarder` callback.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>