### PR TITLE
Use host addresses as transport endpoints

### DIFF
--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -235,12 +235,12 @@ func getSDKClient(key *ecdsa.PrivateKey) (client.Client, error) {
 		return nil, err
 	}
 
-	ipAddr, err := netAddr.IPAddrString()
+	hostAddr, err := netAddr.HostAddrString()
 	if err != nil {
 		return nil, errInvalidEndpoint
 	}
 
-	c, err := client.New(client.WithAddress(ipAddr), client.WithDefaultPrivateKey(key))
+	c, err := client.New(client.WithAddress(hostAddr), client.WithDefaultPrivateKey(key))
 	return c, err
 }
 

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -228,12 +228,12 @@ func (r *remoteLoadAnnounceProvider) InitRemote(srv loadroute.ServerInfo) (loadc
 		return loadcontroller.SimpleWriterProvider(new(nopLoadWriter)), nil
 	}
 
-	ipAddr, err := network.IPAddrFromMultiaddr(addr)
+	hostAddr, err := network.HostAddrFromMultiaddr(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not convert address to IP format")
 	}
 
-	c, err := r.clientCache.Get(ipAddr)
+	c, err := r.clientCache.Get(hostAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize API client")
 	}

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -492,9 +492,9 @@ func (c *reputationClientConstructor) Get(addr string) (client.Client, error) {
 	nm, err := netmap.GetLatestNetworkMap(c.nmSrc)
 	if err == nil {
 		for i := range nm.Nodes {
-			ipAddr, err := network.IPAddrFromMultiaddr(nm.Nodes[i].Address())
+			hostAddr, err := network.HostAddrFromMultiaddr(nm.Nodes[i].Address())
 			if err == nil {
-				if ipAddr == addr {
+				if hostAddr == addr {
 					prm := truststorage.UpdatePrm{}
 					prm.SetPeer(reputation.PeerIDFromBytes(nm.Nodes[i].PublicKey()))
 

--- a/cmd/neofs-node/reputation/common/remote.go
+++ b/cmd/neofs-node/reputation/common/remote.go
@@ -76,12 +76,12 @@ func (rtp *remoteTrustProvider) InitRemote(srv reputationcommon.ServerInfo) (rep
 		return trustcontroller.SimpleWriterProvider(new(NopReputationWriter)), nil
 	}
 
-	ipAddr, err := network.IPAddrFromMultiaddr(addr)
+	hostAddr, err := network.HostAddrFromMultiaddr(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not convert address to IP format")
 	}
 
-	c, err := rtp.clientCache.Get(ipAddr)
+	c, err := rtp.clientCache.Get(hostAddr)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not initialize API client")
 	}

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -117,7 +117,7 @@ func (ap *Processor) findStorageGroups(cid *container.ID, shuffled netmap.Nodes)
 			zap.Int("total_tries", ln),
 		)
 
-		addr, err := network.IPAddrFromMultiaddr(shuffled[i].Address())
+		addr, err := network.HostAddrFromMultiaddr(shuffled[i].Address())
 		if err != nil {
 			log.Warn("can't parse remote address", zap.String("error", err.Error()))
 

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -74,7 +74,7 @@ func (c *ClientCache) getSG(ctx context.Context, addr *object.Address, nm *netma
 	getParams.WithAddress(addr)
 
 	for _, node := range placement.FlattenNodes(nodes) {
-		addr, err := network.IPAddrFromMultiaddr(node.Address())
+		addr, err := network.HostAddrFromMultiaddr(node.Address())
 		if err != nil {
 			c.log.Warn("can't parse remote address",
 				zap.String("address", node.Address()),
@@ -136,7 +136,7 @@ func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.
 	headParams.WithMainFields()
 	headParams.WithAddress(objAddress)
 
-	addr, err := network.IPAddrFromMultiaddr(node.Address())
+	addr, err := network.HostAddrFromMultiaddr(node.Address())
 	if err != nil {
 		return nil, fmt.Errorf("can't parse remote address %s: %w", node.Address(), err)
 	}
@@ -172,7 +172,7 @@ func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id *obje
 	rangeParams.WithRangeList(rng)
 	rangeParams.WithSalt(nil) // it MUST be nil for correct hash concatenation in PDP game
 
-	addr, err := network.IPAddrFromMultiaddr(node.Address())
+	addr, err := network.HostAddrFromMultiaddr(node.Address())
 	if err != nil {
 		return nil, fmt.Errorf("can't parse remote address %s: %w", node.Address(), err)
 	}

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -83,6 +83,13 @@ func multiaddrStringFromHostAddr(host string) (string, error) {
 		return "", err
 	}
 
+	// Empty address in host `:8080` generates `/dns4//tcp/8080` multiaddr
+	// which is invalid. It could be `/tcp/8080` but this breaks
+	// `manet.DialArgs`. The solution is to manually parse it as 0.0.0.0
+	if endpoint == "" {
+		return "/ip4/0.0.0.0/tcp/" + port, nil
+	}
+
 	var (
 		prefix = "/dns4"
 		addr   = endpoint

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -46,6 +46,16 @@ func (a Address) IPAddrString() (string, error) {
 	return ip.String(), nil
 }
 
+// HostAddrString returns host address in string format.
+func (a Address) HostAddrString() (string, error) {
+	_, host, err := manet.DialArgs(a.ma)
+	if err != nil {
+		return "", errors.Wrap(err, "could not get host addr")
+	}
+
+	return host, nil
+}
+
 // AddressFromString restores address from a multiaddr string representation.
 func AddressFromString(s string) (*Address, error) {
 	ma, err := multiaddr.NewMultiaddr(s)

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -106,12 +106,12 @@ func IsLocalAddress(src LocalAddressSource, addr *Address) bool {
 	return src.LocalAddress().ma.Equal(addr.ma)
 }
 
-// IPAddrFromMultiaddr converts "/dns4/localhost/tcp/8080" to "192.168.0.1:8080".
-func IPAddrFromMultiaddr(multiaddr string) (string, error) {
+// HostAddrFromMultiaddr converts "/dns4/localhost/tcp/8080" to "localhost:8080".
+func HostAddrFromMultiaddr(multiaddr string) (string, error) {
 	address, err := AddressFromString(multiaddr)
 	if err != nil {
 		return "", err
 	}
 
-	return address.IPAddrString()
+	return address.HostAddrString()
 }

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -28,3 +28,42 @@ func TestAddress_NetAddr(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ip+":"+port, netAddr)
 }
+
+func TestAddress_HostAddrString(t *testing.T) {
+	t.Run("valid addresses", func(t *testing.T) {
+		testcases := []struct {
+			ma  multiaddr.Multiaddr
+			exp string
+		}{
+			{buildMultiaddr("/dns4/neofs.bigcorp.com/tcp/8080", t), "neofs.bigcorp.com:8080"},
+			{buildMultiaddr("/ip4/172.16.14.1/tcp/8080", t), "172.16.14.1:8080"},
+		}
+
+		for _, testcase := range testcases {
+			addr := Address{testcase.ma}
+
+			got, err := addr.HostAddrString()
+			require.NoError(t, err)
+
+			require.Equal(t, testcase.exp, got)
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		testcases := []multiaddr.Multiaddr{
+			buildMultiaddr("/tcp/8080", t),
+		}
+
+		for _, testcase := range testcases {
+			addr := Address{testcase}
+			_, err := addr.HostAddrString()
+			require.Error(t, err)
+		}
+	})
+}
+
+func buildMultiaddr(s string, t *testing.T) multiaddr.Multiaddr {
+	ma, err := multiaddr.NewMultiaddr(s)
+	require.NoError(t, err)
+	return ma
+}

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -29,6 +29,26 @@ func TestAddress_NetAddr(t *testing.T) {
 	require.Equal(t, ip+":"+port, netAddr)
 }
 
+func TestAddressFromString(t *testing.T) {
+	t.Run("valid addresses", func(t *testing.T) {
+		testcases := []struct {
+			inp string
+			exp multiaddr.Multiaddr
+		}{
+			{":8080", buildMultiaddr("/ip4/0.0.0.0/tcp/8080", t)},
+			{"example.com:7070", buildMultiaddr("/dns4/example.com/tcp/7070", t)},
+			{"213.44.87.1:32512", buildMultiaddr("/ip4/213.44.87.1/tcp/32512", t)},
+			{"[2004:eb1::1]:8080", buildMultiaddr("/ip6/2004:eb1::1/tcp/8080", t)},
+		}
+
+		for _, testcase := range testcases {
+			addr, err := AddressFromString(testcase.inp)
+			require.NoError(t, err)
+			require.Equal(t, testcase.exp, addr.ma, testcase.inp)
+		}
+	})
+}
+
 func TestAddress_HostAddrString(t *testing.T) {
 	t.Run("valid addresses", func(t *testing.T) {
 		testcases := []struct {

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -271,7 +271,7 @@ func (exec *execCtx) headChild(id *objectSDK.ID) (*object.Object, bool) {
 }
 
 func (exec execCtx) remoteClient(node *network.Address) (getClient, bool) {
-	ipAddr, err := node.IPAddrString()
+	hostAddr, err := node.HostAddrString()
 
 	log := exec.log.With(zap.Stringer("node", node))
 
@@ -282,7 +282,7 @@ func (exec execCtx) remoteClient(node *network.Address) (getClient, bool) {
 
 		log.Debug("could not calculate node IP address")
 	case err == nil:
-		c, err := exec.svc.clientCache.get(ipAddr)
+		c, err := exec.svc.clientCache.get(hostAddr)
 
 		switch {
 		default:

--- a/pkg/services/object/get/get_test.go
+++ b/pkg/services/object/get/get_test.go
@@ -411,7 +411,7 @@ func testNodeMatrix(t testing.TB, dim []int) ([]netmap.Nodes, [][]string) {
 			na, err := network.AddressFromString(a)
 			require.NoError(t, err)
 
-			as[j], err = na.IPAddrString()
+			as[j], err = na.HostAddrString()
 			require.NoError(t, err)
 
 			ni := netmap.NewNodeInfo()

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -65,7 +65,7 @@ func (h *RemoteHeader) Head(ctx context.Context, prm *RemoteHeadPrm) (*object.Ob
 		return nil, errors.Wrapf(err, "(%T) could not receive private key", h)
 	}
 
-	addr, err := prm.node.IPAddrString()
+	addr, err := prm.node.HostAddrString()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -54,7 +54,7 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		return nil, errors.Wrapf(err, "(%T) could not receive private key", t)
 	}
 
-	addr, err := t.addr.IPAddrString()
+	addr, err := t.addr.HostAddrString()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/object/search/exec.go
+++ b/pkg/services/object/search/exec.go
@@ -118,7 +118,7 @@ func (exec *execCtx) generateTraverser(cid *container.ID) (*placement.Traverser,
 }
 
 func (exec execCtx) remoteClient(node *network.Address) (searchClient, bool) {
-	ipAddr, err := node.IPAddrString()
+	hostAddr, err := node.HostAddrString()
 
 	log := exec.log.With(zap.Stringer("node", node))
 
@@ -129,7 +129,7 @@ func (exec execCtx) remoteClient(node *network.Address) (searchClient, bool) {
 
 		log.Debug("could not calculate node IP address")
 	case err == nil:
-		c, err := exec.svc.clientConstructor.get(ipAddr)
+		c, err := exec.svc.clientConstructor.get(hostAddr)
 
 		switch {
 		default:

--- a/pkg/services/object/search/search_test.go
+++ b/pkg/services/object/search/search_test.go
@@ -209,7 +209,7 @@ func testNodeMatrix(t testing.TB, dim []int) ([]netmap.Nodes, [][]string) {
 			na, err := network.AddressFromString(a)
 			require.NoError(t, err)
 
-			as[j], err = na.IPAddrString()
+			as[j], err = na.HostAddrString()
 			require.NoError(t, err)
 
 			ni := netmap.NewNodeInfo()


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neofs-node/issues/455

To enable TLS support we can't operate with IP addresses directly. Certificates are issued with host names so it is required to
pass them into RPC client. DNS resolving should be done by transport layer and not be a part of node. Therefore `IPAddrString` usage is removed from code.

Also there is fix for incorrect port-only host address parsing (`:8080`). This leads to `/dns4/tcp/8080` multiaddress which is incorrect. In this case `dns4` section should be omitted, but it breaks `manet.DialArgs`. To solve this issue we explicitly set 0.0.0.0 address.