### PR TITLE
Feature/add TLS encryption

### DIFF
--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -240,7 +241,17 @@ func getSDKClient(key *ecdsa.PrivateKey) (client.Client, error) {
 		return nil, errInvalidEndpoint
 	}
 
-	c, err := client.New(client.WithAddress(hostAddr), client.WithDefaultPrivateKey(key))
+	options := []client.Option{
+		client.WithAddress(hostAddr),
+		client.WithDefaultPrivateKey(key),
+	}
+
+	if netAddr.TLSEnabled() {
+		options = append(options, client.WithTLSConfig(&tls.Config{}))
+	}
+
+	c, err := client.New(options...)
+
 	return c, err
 }
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -354,6 +354,10 @@ func initCfg(path string) *cfg {
 		tlsKeyFile = viperCfg.GetString(cfgTLSKeyFile)
 	}
 
+	if tlsEnabled {
+		netAddr.AddTLS()
+	}
+
 	state := newNetworkState()
 
 	containerWorkerPool, err := ants.NewPool(notificationHandlerPoolSize)

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -201,7 +201,7 @@ type remoteLoadAnnounceProvider struct {
 	loadAddrSrc network.LocalAddressSource
 
 	clientCache interface {
-		Get(string) (apiClient.Client, error)
+		Get(*network.Address) (apiClient.Client, error)
 	}
 
 	deadEndProvider loadcontroller.WriterProvider
@@ -219,12 +219,12 @@ func (r *remoteLoadAnnounceProvider) InitRemote(srv loadroute.ServerInfo) (loadc
 		return loadcontroller.SimpleWriterProvider(new(nopLoadWriter)), nil
 	}
 
-	hostAddr, err := network.HostAddrFromMultiaddr(addr)
+	netAddr, err := network.AddressFromString(addr)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert address to IP format: %w", err)
 	}
 
-	c, err := r.clientCache.Get(hostAddr)
+	c, err := r.clientCache.Get(netAddr)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize API client: %w", err)
 	}

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -401,7 +401,7 @@ type reputationClientConstructor struct {
 	trustStorage *truststorage.Storage
 
 	basicConstructor interface {
-		Get(string) (client.Client, error)
+		Get(*network.Address) (client.Client, error)
 	}
 }
 
@@ -485,7 +485,7 @@ func (c *reputationClient) SearchObject(ctx context.Context, prm *client.SearchO
 	return ids, err
 }
 
-func (c *reputationClientConstructor) Get(addr string) (client.Client, error) {
+func (c *reputationClientConstructor) Get(addr *network.Address) (client.Client, error) {
 	cl, err := c.basicConstructor.Get(addr)
 	if err != nil {
 		return nil, err
@@ -494,9 +494,9 @@ func (c *reputationClientConstructor) Get(addr string) (client.Client, error) {
 	nm, err := netmap.GetLatestNetworkMap(c.nmSrc)
 	if err == nil {
 		for i := range nm.Nodes {
-			hostAddr, err := network.HostAddrFromMultiaddr(nm.Nodes[i].Address())
+			netAddr, err := network.AddressFromString(nm.Nodes[i].Address())
 			if err == nil {
-				if hostAddr == addr {
+				if netAddr.Equal(addr) {
 					prm := truststorage.UpdatePrm{}
 					prm.SetPeer(reputation.PeerIDFromBytes(nm.Nodes[i].PublicKey()))
 

--- a/cmd/neofs-node/reputation/common/remote.go
+++ b/cmd/neofs-node/reputation/common/remote.go
@@ -11,7 +11,7 @@ import (
 )
 
 type clientCache interface {
-	Get(string) (apiClient.Client, error)
+	Get(*network.Address) (apiClient.Client, error)
 }
 
 // clientKeyRemoteProvider must provide remote writer and take into account
@@ -77,12 +77,12 @@ func (rtp *remoteTrustProvider) InitRemote(srv reputationcommon.ServerInfo) (rep
 		return trustcontroller.SimpleWriterProvider(new(NopReputationWriter)), nil
 	}
 
-	hostAddr, err := network.HostAddrFromMultiaddr(addr)
+	netAddr, err := network.AddressFromString(addr)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert address to IP format: %w", err)
 	}
 
-	c, err := rtp.clientCache.Get(hostAddr)
+	c, err := rtp.clientCache.Get(netAddr)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize API client: %w", err)
 	}

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -118,14 +118,14 @@ func (ap *Processor) findStorageGroups(cid *container.ID, shuffled netmap.Nodes)
 			zap.Int("total_tries", ln),
 		)
 
-		addr, err := network.HostAddrFromMultiaddr(shuffled[i].Address())
+		netAddr, err := network.AddressFromString(shuffled[i].Address())
 		if err != nil {
 			log.Warn("can't parse remote address", zap.String("error", err.Error()))
 
 			continue
 		}
 
-		cli, err := ap.clientCache.Get(addr)
+		cli, err := ap.clientCache.Get(netAddr)
 		if err != nil {
 			log.Warn("can't setup remote connection", zap.String("error", err.Error()))
 

--- a/pkg/innerring/processors/audit/processor.go
+++ b/pkg/innerring/processors/audit/processor.go
@@ -14,6 +14,7 @@ import (
 	wrapContainer "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	wrapNetmap "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/audit"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
@@ -28,7 +29,7 @@ type (
 
 	// NeoFSClientCache is an interface for cache of neofs RPC clients
 	NeoFSClientCache interface {
-		Get(address string) (SDKClient.Client, error)
+		Get(address *network.Address) (SDKClient.Client, error)
 	}
 
 	TaskManager interface {

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -22,7 +22,7 @@ type (
 	ClientCache struct {
 		log   *zap.Logger
 		cache interface {
-			Get(string) (client.Client, error)
+			Get(address *network.Address) (client.Client, error)
 		}
 		key *ecdsa.PrivateKey
 
@@ -48,7 +48,7 @@ func newClientCache(p *clientCacheParams) *ClientCache {
 	}
 }
 
-func (c *ClientCache) Get(address string) (client.Client, error) {
+func (c *ClientCache) Get(address *network.Address) (client.Client, error) {
 	// Because cache is used by `ClientCache` exclusively,
 	// client will always have valid key.
 	return c.cache.Get(address)
@@ -74,7 +74,7 @@ func (c *ClientCache) getSG(ctx context.Context, addr *object.Address, nm *netma
 	getParams.WithAddress(addr)
 
 	for _, node := range placement.FlattenNodes(nodes) {
-		addr, err := network.HostAddrFromMultiaddr(node.Address())
+		netAddr, err := network.AddressFromString(node.Address())
 		if err != nil {
 			c.log.Warn("can't parse remote address",
 				zap.String("address", node.Address()),
@@ -83,10 +83,10 @@ func (c *ClientCache) getSG(ctx context.Context, addr *object.Address, nm *netma
 			continue
 		}
 
-		cli, err := c.Get(addr)
+		cli, err := c.Get(netAddr)
 		if err != nil {
 			c.log.Warn("can't setup remote connection",
-				zap.String("address", addr),
+				zap.String("address", netAddr.String()),
 				zap.String("error", err.Error()))
 
 			continue
@@ -136,14 +136,14 @@ func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.
 	headParams.WithMainFields()
 	headParams.WithAddress(objAddress)
 
-	addr, err := network.HostAddrFromMultiaddr(node.Address())
+	netAddr, err := network.AddressFromString(node.Address())
 	if err != nil {
 		return nil, fmt.Errorf("can't parse remote address %s: %w", node.Address(), err)
 	}
 
-	cli, err := c.Get(addr)
+	cli, err := c.Get(netAddr)
 	if err != nil {
-		return nil, fmt.Errorf("can't setup remote connection with %s: %w", addr, err)
+		return nil, fmt.Errorf("can't setup remote connection with %s: %w", netAddr, err)
 	}
 
 	cctx, cancel := context.WithTimeout(task.AuditContext(), c.headTimeout)
@@ -172,14 +172,14 @@ func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id *obje
 	rangeParams.WithRangeList(rng)
 	rangeParams.WithSalt(nil) // it MUST be nil for correct hash concatenation in PDP game
 
-	addr, err := network.HostAddrFromMultiaddr(node.Address())
+	netAddr, err := network.AddressFromString(node.Address())
 	if err != nil {
 		return nil, fmt.Errorf("can't parse remote address %s: %w", node.Address(), err)
 	}
 
-	cli, err := c.Get(addr)
+	cli, err := c.Get(netAddr)
 	if err != nil {
-		return nil, fmt.Errorf("can't setup remote connection with %s: %w", addr, err)
+		return nil, fmt.Errorf("can't setup remote connection with %s: %w", netAddr, err)
 	}
 
 	cctx, cancel := context.WithTimeout(task.AuditContext(), c.rangeTimeout)

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -31,6 +31,22 @@ type LocalAddressSource interface {
 	LocalAddress() *Address
 }
 
+// Encapsulate wraps this Address around another. For example:
+//
+//		/ip4/1.2.3.4 encapsulate /tcp/80 = /ip4/1.2.3.4/tcp/80
+//
+func (a *Address) Encapsulate(addr *Address) {
+	a.ma = a.ma.Encapsulate(addr.ma)
+}
+
+// Decapsulate removes an Address wrapping. For example:
+//
+//		/ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
+//
+func (a *Address) Decapsulate(addr *Address) {
+	a.ma = a.ma.Decapsulate(addr.ma)
+}
+
 // String returns multiaddr string
 func (a Address) String() string {
 	return a.ma.String()

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -36,6 +36,11 @@ func (a Address) String() string {
 	return a.ma.String()
 }
 
+// Equal compares Address's.
+func (a Address) Equal(addr *Address) bool {
+	return a.ma.Equal(addr.ma)
+}
+
 // IPAddrString returns network endpoint address in string format.
 func (a Address) IPAddrString() (string, error) {
 	ip, err := manet.ToNetAddr(a.ma)

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -82,6 +82,66 @@ func TestAddress_HostAddrString(t *testing.T) {
 	})
 }
 
+func TestAddress_Encapsulate(t *testing.T) {
+	ma1, ma2 := "/dns4/neofs.bigcorp.com/tcp/8080", "/tls"
+
+	testcases := []struct {
+		ma1  multiaddr.Multiaddr
+		ma2  multiaddr.Multiaddr
+		want string
+	}{
+		{
+			buildMultiaddr(ma1, t),
+			buildMultiaddr(ma2, t),
+			ma1 + ma2,
+		},
+		{
+			buildMultiaddr(ma2, t),
+			buildMultiaddr(ma1, t),
+			ma2 + ma1,
+		},
+	}
+
+	for _, testcase := range testcases {
+		addr1 := &Address{testcase.ma1}
+		addr2 := &Address{testcase.ma2}
+
+		addr1.Encapsulate(addr2)
+
+		require.Equal(t, addr1.String(), testcase.want)
+	}
+}
+
+func TestAddress_Decapsulate(t *testing.T) {
+	ma1, ma2 := "/dns4/neofs.bigcorp.com/tcp/8080", "/tls"
+
+	testcases := []struct {
+		ma1  multiaddr.Multiaddr
+		ma2  multiaddr.Multiaddr
+		want string
+	}{
+		{
+			buildMultiaddr(ma1+ma2, t),
+			buildMultiaddr(ma2, t),
+			ma1,
+		},
+		{
+			buildMultiaddr(ma2+ma1, t),
+			buildMultiaddr(ma1, t),
+			ma2,
+		},
+	}
+
+	for _, testcase := range testcases {
+		addr1 := &Address{testcase.ma1}
+		addr2 := &Address{testcase.ma2}
+
+		addr1.Decapsulate(addr2)
+
+		require.Equal(t, addr1.String(), testcase.want)
+	}
+}
+
 func buildMultiaddr(s string, t *testing.T) multiaddr.Multiaddr {
 	ma, err := multiaddr.NewMultiaddr(s)
 	require.NoError(t, err)

--- a/pkg/network/tls.go
+++ b/pkg/network/tls.go
@@ -1,0 +1,67 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+// There is implementation of TLS protocol for
+// github.com/multiformats/go-multiaddr library in this file.
+//
+// After addition TLS protocol via `multiaddr.AddProtocol` function
+// the library is ready to parse "tls" protocol with empty body, e.g.:
+//
+//		"/dns4/localhost/tcp/8080/tls"
+
+const (
+	tlsProtocolName = "tls"
+
+	// tlsProtocolCode is chosen according to its draft version's code in
+	// original multiaddr repository: https://github.com/multiformats/multicodec.
+	tlsProtocolCode = 0x01c0
+)
+
+// tls var is used for (un)wrapping other multiaddrs around TLS multiaddr.
+var tls multiaddr.Multiaddr
+
+func init() {
+	tlsProtocol := multiaddr.Protocol{
+		Name:  tlsProtocolName,
+		Code:  tlsProtocolCode,
+		Size:  0,
+		VCode: multiaddr.CodeToVarint(tlsProtocolCode),
+	}
+
+	err := multiaddr.AddProtocol(tlsProtocol)
+	if err != nil {
+		panic(fmt.Errorf("could not add 'TLS' protocol to multiadd library: %w", err))
+	}
+
+	tls, err = multiaddr.NewMultiaddr("/" + tlsProtocolName)
+	if err != nil {
+		panic(fmt.Errorf("could not init 'TLS' protocol with multiadd library: %w", err))
+	}
+}
+
+// TLSEnabled searches for wrapped TLS protocol in multiaddr.
+func (a Address) TLSEnabled() bool {
+	for _, protoc := range a.ma.Protocols() {
+		if protoc.Code == tlsProtocolCode {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AddTLS encapsulates a Address if there is no TLS yet.
+func (a *Address) AddTLS() {
+	// not need to add TLS if it is
+	// already included
+	if a.TLSEnabled() {
+		return
+	}
+
+	a.ma = a.ma.Encapsulate(tls)
+}

--- a/pkg/network/tls_test.go
+++ b/pkg/network/tls_test.go
@@ -1,0 +1,48 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddress_TLSEnabled(t *testing.T) {
+	testCases := [...]struct {
+		input   string
+		wantTLS bool
+	}{
+		{"/dns4/localhost/tcp/8080", false},
+		{"/dns4/localhost/tcp/8080/tls", true},
+		{"/tls/dns4/localhost/tcp/8080", true},
+	}
+
+	for _, test := range testCases {
+		addr := Address{
+			ma: buildMultiaddr(test.input, t),
+		}
+
+		require.Equal(t, test.wantTLS, addr.TLSEnabled(), test.input)
+	}
+}
+
+func TestAddress_AddTLS(t *testing.T) {
+	input, tls := "/dns4/localhost/tcp/8080", tls.String()
+
+	testCases := [...]struct {
+		input string
+		want  string
+	}{
+		{input, input + tls},
+		{input + tls, input + tls},
+	}
+
+	for _, test := range testCases {
+		addr := Address{
+			ma: buildMultiaddr(test.input, t),
+		}
+
+		addr.AddTLS()
+
+		require.Equal(t, test.want, addr.String(), test.input)
+	}
+}

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -271,28 +271,18 @@ func (exec *execCtx) headChild(id *objectSDK.ID) (*object.Object, bool) {
 }
 
 func (exec execCtx) remoteClient(node *network.Address) (getClient, bool) {
-	hostAddr, err := node.HostAddrString()
-
 	log := exec.log.With(zap.Stringer("node", node))
+
+	c, err := exec.svc.clientCache.get(node)
 
 	switch {
 	default:
 		exec.status = statusUndefined
 		exec.err = err
 
-		log.Debug("could not calculate node IP address")
+		log.Debug("could not construct remote node client")
 	case err == nil:
-		c, err := exec.svc.clientCache.get(hostAddr)
-
-		switch {
-		default:
-			exec.status = statusUndefined
-			exec.err = err
-
-			log.Debug("could not construct remote node client")
-		case err == nil:
-			return c, true
-		}
+		return c, true
 	}
 
 	return nil, false

--- a/pkg/services/object/get/get_test.go
+++ b/pkg/services/object/get/get_test.go
@@ -80,8 +80,13 @@ func (p *testPlacementBuilder) BuildPlacement(addr *objectSDK.Address, _ *netmap
 	return vs, nil
 }
 
-func (c *testClientCache) get(addr string) (getClient, error) {
-	v, ok := c.clients[addr]
+func (c *testClientCache) get(mAddr *network.Address) (getClient, error) {
+	hostAddr, err := mAddr.HostAddrString()
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := c.clients[hostAddr]
 	if !ok {
 		return nil, errors.New("could not construct client")
 	}

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
@@ -34,7 +35,7 @@ type cfg struct {
 	}
 
 	clientCache interface {
-		get(string) (getClient, error)
+		get(*network.Address) (getClient, error)
 	}
 
 	traverserGenerator interface {
@@ -92,7 +93,7 @@ func WithLocalStorageEngine(e *engine.StorageEngine) Option {
 }
 
 type ClientConstructor interface {
-	Get(string) (client.Client, error)
+	Get(*network.Address) (client.Client, error)
 }
 
 // WithClientConstructor returns option to set constructor of remote node clients.

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 )
 
 type SimpleObjectWriter struct {
@@ -71,7 +72,7 @@ func (s *SimpleObjectWriter) Object() *object.Object {
 	return s.obj.Object()
 }
 
-func (c *clientCacheWrapper) get(addr string) (getClient, error) {
+func (c *clientCacheWrapper) get(addr *network.Address) (getClient, error) {
 	clt, err := c.cache.Get(addr)
 
 	return &clientWrapper{

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ClientConstructor interface {
-	Get(string) (client.Client, error)
+	Get(*network.Address) (client.Client, error)
 }
 
 // RemoteHeader represents utility for getting
@@ -66,14 +66,9 @@ func (h *RemoteHeader) Head(ctx context.Context, prm *RemoteHeadPrm) (*object.Ob
 		return nil, fmt.Errorf("(%T) could not receive private key: %w", h, err)
 	}
 
-	addr, err := prm.node.HostAddrString()
+	c, err := h.clientCache.Get(prm.node)
 	if err != nil {
-		return nil, err
-	}
-
-	c, err := h.clientCache.Get(addr)
-	if err != nil {
-		return nil, fmt.Errorf("(%T) could not create SDK client %s: %w", h, addr, err)
+		return nil, fmt.Errorf("(%T) could not create SDK client %s: %w", h, prm.node, err)
 	}
 
 	p := new(client.ObjectHeaderParams).
@@ -91,7 +86,7 @@ func (h *RemoteHeader) Head(ctx context.Context, prm *RemoteHeadPrm) (*object.Ob
 		client.WithKey(key),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("(%T) could not head object in %s: %w", h, addr, err)
+		return nil, fmt.Errorf("(%T) could not head object in %s: %w", h, prm.node, err)
 	}
 
 	return object.NewFromSDK(hdr), nil

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -54,14 +54,9 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		return nil, fmt.Errorf("(%T) could not receive private key: %w", t, err)
 	}
 
-	addr, err := t.addr.HostAddrString()
+	c, err := t.clientConstructor.Get(t.addr)
 	if err != nil {
-		return nil, err
-	}
-
-	c, err := t.clientConstructor.Get(addr)
-	if err != nil {
-		return nil, fmt.Errorf("(%T) could not create SDK client %s: %w", t, addr, err)
+		return nil, fmt.Errorf("(%T) could not create SDK client %s: %w", t, t.addr, err)
 	}
 
 	id, err := c.PutObject(t.ctx, new(client.PutObjectParams).
@@ -75,7 +70,7 @@ func (t *remoteTarget) Close() (*transformer.AccessIdentifiers, error) {
 		)...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("(%T) could not put object to %s: %w", t, addr, err)
+		return nil, fmt.Errorf("(%T) could not put object to %s: %w", t, t.addr, err)
 	}
 
 	return new(transformer.AccessIdentifiers).

--- a/pkg/services/object/put/service.go
+++ b/pkg/services/object/put/service.go
@@ -30,7 +30,7 @@ type Service struct {
 type Option func(*cfg)
 
 type ClientConstructor interface {
-	Get(string) (client.Client, error)
+	Get(*network.Address) (client.Client, error)
 }
 
 type cfg struct {

--- a/pkg/services/object/search/exec.go
+++ b/pkg/services/object/search/exec.go
@@ -118,28 +118,17 @@ func (exec *execCtx) generateTraverser(cid *container.ID) (*placement.Traverser,
 }
 
 func (exec execCtx) remoteClient(node *network.Address) (searchClient, bool) {
-	hostAddr, err := node.HostAddrString()
-
 	log := exec.log.With(zap.Stringer("node", node))
 
+	c, err := exec.svc.clientConstructor.get(node)
 	switch {
 	default:
 		exec.status = statusUndefined
 		exec.err = err
 
-		log.Debug("could not calculate node IP address")
+		log.Debug("could not construct remote node client")
 	case err == nil:
-		c, err := exec.svc.clientConstructor.get(hostAddr)
-
-		switch {
-		default:
-			exec.status = statusUndefined
-			exec.err = err
-
-			log.Debug("could not construct remote node client")
-		case err == nil:
-			return c, true
-		}
+		return c, true
 	}
 
 	return nil, false

--- a/pkg/services/object/search/search_test.go
+++ b/pkg/services/object/search/search_test.go
@@ -82,8 +82,13 @@ func (p *testPlacementBuilder) BuildPlacement(addr *objectSDK.Address, _ *netmap
 	return res, nil
 }
 
-func (c *testClientCache) get(addr string) (searchClient, error) {
-	v, ok := c.clients[addr]
+func (c *testClientCache) get(mAddr *network.Address) (searchClient, error) {
+	hostAddr, err := mAddr.HostAddrString()
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := c.clients[hostAddr]
 	if !ok {
 		return nil, errors.New("could not construct client")
 	}

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
@@ -26,7 +27,7 @@ type searchClient interface {
 }
 
 type ClientConstructor interface {
-	Get(string) (client.Client, error)
+	Get(*network.Address) (client.Client, error)
 }
 
 type cfg struct {
@@ -37,7 +38,7 @@ type cfg struct {
 	}
 
 	clientConstructor interface {
-		get(string) (searchClient, error)
+		get(*network.Address) (searchClient, error)
 	}
 
 	traverserGenerator interface {

--- a/pkg/services/object/search/util.go
+++ b/pkg/services/object/search/util.go
@@ -8,6 +8,7 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
+	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 )
@@ -67,7 +68,7 @@ func (w *uniqueIDWriter) WriteIDs(list []*objectSDK.ID) error {
 	return w.writer.WriteIDs(list)
 }
 
-func (c *clientConstructorWrapper) get(addr string) (searchClient, error) {
+func (c *clientConstructorWrapper) get(addr *network.Address) (searchClient, error) {
 	clt, err := c.constructor.Get(addr)
 
 	return &clientWrapper{


### PR DESCRIPTION
Add TLS(turns on with config(env vars)) to GRPC server and client.

In `network` pkg add implementation of `tls` protocol for `multiaddr` lib.

Make CLI support multiaddresess with `/tls` protocol.

Closes #455.