### PR TITLE
Traverse request meta headers to fetch tokens in ACL checker

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -144,7 +144,7 @@ func (b Service) Get(request *object.GetRequest, stream objectSvc.GetObjectStrea
 		return err
 	}
 
-	sTok := request.GetMetaHeader().GetSessionToken()
+	sTok := originalSessionToken(request.GetMetaHeader())
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
@@ -192,7 +192,7 @@ func (b Service) Head(
 		return nil, err
 	}
 
-	sTok := request.GetMetaHeader().GetSessionToken()
+	sTok := originalSessionToken(request.GetMetaHeader())
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
@@ -235,7 +235,7 @@ func (b Service) Search(request *object.SearchRequest, stream objectSvc.SearchSt
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
-		token:   request.GetMetaHeader().GetSessionToken(),
+		token:   originalSessionToken(request.GetMetaHeader()),
 		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
@@ -268,7 +268,7 @@ func (b Service) Delete(
 		return nil, err
 	}
 
-	sTok := request.GetMetaHeader().GetSessionToken()
+	sTok := originalSessionToken(request.GetMetaHeader())
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
@@ -300,7 +300,7 @@ func (b Service) GetRange(request *object.GetRangeRequest, stream objectSvc.GetO
 		return err
 	}
 
-	sTok := request.GetMetaHeader().GetSessionToken()
+	sTok := originalSessionToken(request.GetMetaHeader())
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
@@ -338,7 +338,7 @@ func (b Service) GetRangeHash(
 		return nil, err
 	}
 
-	sTok := request.GetMetaHeader().GetSessionToken()
+	sTok := originalSessionToken(request.GetMetaHeader())
 
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
@@ -780,4 +780,14 @@ func originalBearerToken(header *session.RequestMetaHeader) *bearer.BearerToken 
 	}
 
 	return header.GetBearerToken()
+}
+
+// originalSessionToken goes down to original request meta header and fetches
+// session token from there.
+func originalSessionToken(header *session.RequestMetaHeader) *session.SessionToken {
+	for header.GetOrigin() != nil {
+		header = header.GetOrigin()
+	}
+
+	return header.GetSessionToken()
 }

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -149,7 +149,7 @@ func (b Service) Get(request *object.GetRequest, stream objectSvc.GetObjectStrea
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   sTok,
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -197,7 +197,7 @@ func (b Service) Head(
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   sTok,
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -236,7 +236,7 @@ func (b Service) Search(request *object.SearchRequest, stream objectSvc.SearchSt
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   request.GetMetaHeader().GetSessionToken(),
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -273,7 +273,7 @@ func (b Service) Delete(
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   sTok,
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -305,7 +305,7 @@ func (b Service) GetRange(request *object.GetRangeRequest, stream objectSvc.GetO
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   sTok,
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -343,7 +343,7 @@ func (b Service) GetRangeHash(
 	req := metaWithToken{
 		vheader: request.GetVerificationHeader(),
 		token:   sTok,
-		bearer:  request.GetMetaHeader().GetBearerToken(),
+		bearer:  originalBearerToken(request.GetMetaHeader()),
 		src:     request,
 	}
 
@@ -387,7 +387,7 @@ func (p putStreamBasicChecker) Send(request *object.PutRequest) error {
 		req := metaWithToken{
 			vheader: request.GetVerificationHeader(),
 			token:   sTok,
-			bearer:  request.GetMetaHeader().GetBearerToken(),
+			bearer:  originalBearerToken(request.GetMetaHeader()),
 			src:     request,
 		}
 
@@ -770,4 +770,14 @@ func isOwnerFromKey(id *owner.ID, key *ecdsa.PublicKey) bool {
 	// we can compare .String() version of owners but don't think it is good idea
 	// binary comparison is better but MarshalBinary is more expensive
 	return bytes.Equal(id.ToV2().GetValue(), wallet.Bytes())
+}
+
+// originalBearerToken goes down to original request meta header and fetches
+// bearer token from there.
+func originalBearerToken(header *session.RequestMetaHeader) *bearer.BearerToken {
+	for header.GetOrigin() != nil {
+		header = header.GetOrigin()
+	}
+
+	return header.GetBearerToken()
 }

--- a/pkg/services/object/acl/acl_test.go
+++ b/pkg/services/object/acl/acl_test.go
@@ -1,0 +1,36 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/acl"
+	acltest "github.com/nspcc-dev/neofs-api-go/v2/acl/test"
+	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	sessiontest "github.com/nspcc-dev/neofs-api-go/v2/session/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOriginalTokens(t *testing.T) {
+	sToken := sessiontest.GenerateSessionToken(false)
+	bToken := acltest.GenerateBearerToken(false)
+
+	for i := 0; i < 10; i++ {
+		metaHeaders := testGenerateMetaHeader(uint32(i), bToken, sToken)
+		require.Equal(t, sToken, originalSessionToken(metaHeaders), i)
+		require.Equal(t, bToken, originalBearerToken(metaHeaders), i)
+	}
+}
+
+func testGenerateMetaHeader(depth uint32, b *acl.BearerToken, s *session.SessionToken) *session.RequestMetaHeader {
+	metaHeader := new(session.RequestMetaHeader)
+	metaHeader.SetBearerToken(b)
+	metaHeader.SetSessionToken(s)
+
+	for i := uint32(0); i < depth; i++ {
+		link := metaHeader
+		metaHeader = new(session.RequestMetaHeader)
+		metaHeader.SetOrigin(link)
+	}
+
+	return metaHeader
+}


### PR DESCRIPTION
Fixes #548 

When storage node re-sends requests, it creates new layer in request meta header chain. New layer does not contain tokens but container link to the original request meta header. ACL service should traverse to the original request meta header to fetch relevant session and bearer tokens.