### PR TITLE
Add command to sign session tokens

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -161,7 +161,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 			return err
 		}
 
-		tok, err := containerSessionToken()
+		tok, err := getSessionToken(sessionTokenPath)
 		if err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ Only owner of the container has a permission to remove container.`,
 			return err
 		}
 
-		tok, err := containerSessionToken()
+		tok, err := getSessionToken(sessionTokenPath)
 		if err != nil {
 			return err
 		}
@@ -477,7 +477,7 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 			return err
 		}
 
-		tok, err := containerSessionToken()
+		tok, err := getSessionToken(sessionTokenPath)
 		if err != nil {
 			return err
 		}
@@ -595,12 +595,13 @@ func init() {
 	}
 }
 
-func containerSessionToken() (*session.Token, error) {
+// getSessionToken reads `<path>` as JSON file with session token and parses it.
+func getSessionToken(path string) (*session.Token, error) {
 	// try to read session token from file
 	var tok *session.Token
 
-	if sessionTokenPath != "" {
-		data, err := ioutil.ReadFile(sessionTokenPath)
+	if path != "" {
+		data, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Use case:

```
$ neofs-cli util sign session-token -k issuer.key --from token.json --to stoken.json
signed session token saved in stoken.json

$ neofs-cli -r s01.neofs.devenv:8080 -k sender.key container create -p rule.ql --session stoken.json --await
container ID: 9EN4iiLHpCRkbqseKDEDCeQMUHzh4Wno796vcjADNRuV
awaiting...
container has been persisted on sidechain
```

Token example:
```json
{
  "body": {
    "id": "KNiz/TYNTkib7TvBHcFevQ==",
    "ownerID": {
      "value": "NU+8+vi5RqUFhQmDHeJQf4IIzl1i6BAmXQ=="
    },
    "lifetime": {
      "exp": "100500",
      "nbf": "1",
      "iat": "1"
    },
    "sessionKey": "Axpsb7vfAso1F0X6hrm6WpRS14WsT3/Ct1SMoqRsT89K",
    "container": {
      "verb": "PUT",
      "wildcard": true
    }
  }
}
```