### PR TITLE
Update inner ring config

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -70,11 +70,11 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("timers.main_notary", "1000")
 	cfg.SetDefault("timers.side_notary", "1000")
 	cfg.SetDefault("timers.stop_estimation.mul", 1)
-	cfg.SetDefault("timers.stop_estimation.div", 1)
+	cfg.SetDefault("timers.stop_estimation.div", 4)
 	cfg.SetDefault("timers.collect_basic_income.mul", 1)
-	cfg.SetDefault("timers.collect_basic_income.div", 1)
-	cfg.SetDefault("timers.distribute_basic_income.mul", 1)
-	cfg.SetDefault("timers.distribute_basic_income.div", 1)
+	cfg.SetDefault("timers.collect_basic_income.div", 2)
+	cfg.SetDefault("timers.distribute_basic_income.mul", 3)
+	cfg.SetDefault("timers.distribute_basic_income.div", 4)
 
 	cfg.SetDefault("notary.side.deposit_amount", 1_0000_0000) // 1.0 Fixed8
 	cfg.SetDefault("notary.main.deposit_amount", 2000_0000)   // 0.2 Fixed8
@@ -86,7 +86,7 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("workers.alphabet", "10")
 	cfg.SetDefault("workers.reputation", "10")
 
-	cfg.SetDefault("netmap_cleaner.enabled", false)
+	cfg.SetDefault("netmap_cleaner.enabled", true)
 	cfg.SetDefault("netmap_cleaner.threshold", 3)
 
 	cfg.SetDefault("emit.storage.amount", 0)

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -4,17 +4,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nspcc-dev/neofs-node/misc"
 	"github.com/spf13/viper"
 )
 
 func newConfig(path string) (*viper.Viper, error) {
+	const innerRingPrefix = "neofs_ir"
+
 	var (
 		err error
 		v   = viper.New()
 	)
 
-	v.SetEnvPrefix(misc.InnerRingPrefix)
+	v.SetEnvPrefix(innerRingPrefix)
 	v.AutomaticEnv()
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 

--- a/cmd/neofs-ir/main.go
+++ b/cmd/neofs-ir/main.go
@@ -40,7 +40,8 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Println("version:", misc.Version)
+		fmt.Println("neofs-ir", misc.Version)
+		fmt.Println("debug:", misc.Debug)
 		os.Exit(SuccessReturnCode)
 	}
 

--- a/misc/build.go
+++ b/misc/build.go
@@ -1,13 +1,5 @@
 package misc
 
-const (
-	// Prefix is a neofs node application prefix.
-	Prefix = "neofs"
-
-	// InnerRingPrefix is an inner ring application prefix.
-	InnerRingPrefix = "neofs_ir"
-)
-
 // These variables are changed in compile time.
 var (
 	// Build is an application build time.

--- a/pkg/innerring/config/config.go
+++ b/pkg/innerring/config/config.go
@@ -13,6 +13,7 @@ Implemented as a part of https://github.com/nspcc-dev/neofs-node/issues/363
 */
 
 import (
+	"github.com/nspcc-dev/neofs-node/misc"
 	netmapClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/spf13/viper"
 )
@@ -30,27 +31,33 @@ func NewGlobalConfigReader(cfg *viper.Viper, nm *netmapClient.Wrapper) *GlobalCo
 }
 
 func (c *GlobalConfig) BasicIncomeRate() (uint64, error) {
-	value := c.cfg.GetUint64("settlement.basic_income_rate")
-	if value != 0 {
-		return value, nil
+	if isDebug() {
+		value := c.cfg.GetUint64("settlement.basic_income_rate")
+		if value != 0 {
+			return value, nil
+		}
 	}
 
 	return c.nm.BasicIncomeRate()
 }
 
 func (c *GlobalConfig) AuditFee() (uint64, error) {
-	value := c.cfg.GetUint64("settlement.audit_fee")
-	if value != 0 {
-		return value, nil
+	if isDebug() {
+		value := c.cfg.GetUint64("settlement.audit_fee")
+		if value != 0 {
+			return value, nil
+		}
 	}
 
 	return c.nm.AuditFee()
 }
 
 func (c *GlobalConfig) EpochDuration() (uint32, error) {
-	value := c.cfg.GetUint32("timers.epoch")
-	if value != 0 {
-		return value, nil
+	if isDebug() {
+		value := c.cfg.GetUint32("timers.epoch")
+		if value != 0 {
+			return value, nil
+		}
 	}
 
 	epochDuration, err := c.nm.EpochDuration()
@@ -59,4 +66,8 @@ func (c *GlobalConfig) EpochDuration() (uint32, error) {
 	}
 
 	return uint32(epochDuration), nil
+}
+
+func isDebug() bool {
+	return misc.Debug == "true"
 }


### PR DESCRIPTION
Closes #363 

This PR finishes transition to global config in inner ring node. All global config values have corresponding local config values, but they are active **only in debug build**. To make debug build try:
```
$ DEBUG=true make bin/neofs-ir
```

There are couple more changes there as well. First we came up with values for out timers in testnet and neofs-dev-env so it makes sense to make them default. Also we changed storage node config and it can't turn off or specify length of bootstrap healthchecks, so it also reflected in inner ring config.