### PR TITLE
Backport v0.21.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 Changelog for NeoFS Node
 
+## [0.21.1] - 2021-06-10
+
+### Fixed
+- Session token lifetime check (#589).
+- Payload size check on the relayed objects (#580).
+
+### Added
+- VMagent to collect metrics from testnet storage image
+
+### Changed
+- Updated neofs-api-go to v1.27.1 release.
+
 ## [0.21.0] - 2021-06-03 - Seongmodo (석모도, 席毛島)
 
 Session token support in container service, refactored config in storage node,
@@ -394,6 +406,7 @@ NeoFS-API v2.0 support and updated brand-new storage node application.
 
 First public review release.
 
+[0.21.1]: https://github.com/nspcc-dev/neofs-node/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/nspcc-dev/neofs-node/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/nspcc-dev/neofs-node/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/nspcc-dev/neofs-node/compare/v0.18.0...v0.19.0

--- a/config/testnet/docker-compose.yml
+++ b/config/testnet/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "2.4"
 services:
   storage01:
-    image: nspccdev/neofs-storage-testnet:0.21.0
+    image: nspccdev/neofs-storage-testnet:0.21.1
     container_name: neofs-testnet
     network_mode: host
     restart: always

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.95.1
-	github.com/nspcc-dev/neofs-api-go v1.27.1-0.20210607102659-cc1163fd5797
+	github.com/nspcc-dev/neofs-api-go v1.27.1
 	github.com/nspcc-dev/neofs-crypto v0.3.0
 	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20210520210714-9dee13f0d556
 	github.com/nspcc-dev/tzhash v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/nspcc-dev/neo-go v0.95.1 h1:5fgLFOul1Ax/maFkgLkD5rDUwY/nB/xX/Jpcd8hLH
 github.com/nspcc-dev/neo-go v0.95.1/go.mod h1:bW07ge1WFXsBgqrcPpLUr6OcyQxHqM26MZNesWMdH0c=
 github.com/nspcc-dev/neofs-api-go v1.24.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-api-go v1.26.1/go.mod h1:SHuH1Ba3U/h3j+8HHbb3Cns1LfMlEb88guWog9Qi68Y=
-github.com/nspcc-dev/neofs-api-go v1.27.1-0.20210607102659-cc1163fd5797 h1:pUFVPj21BaKdeSyuqBXJUFTPgx7H0cO167+2SJ472jU=
-github.com/nspcc-dev/neofs-api-go v1.27.1-0.20210607102659-cc1163fd5797/go.mod h1:i0Cwgvcu9A4M4e58pydbXFisUhSxpfljmuWFPIp2btE=
+github.com/nspcc-dev/neofs-api-go v1.27.1 h1:ONdKOnm0/hK6m38VTUliCHY6RTxg+IpAzY4G+BeOZG4=
+github.com/nspcc-dev/neofs-api-go v1.27.1/go.mod h1:i0Cwgvcu9A4M4e58pydbXFisUhSxpfljmuWFPIp2btE=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
Master branch is broken now but we have to release public node with VMagent. 