### PR TITLE
morph/client: Check return state in invoke

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -100,6 +100,10 @@ func (c *Client) Invoke(contract util.Uint160, fee fixedn.Fixed8, method string,
 		return err
 	}
 
+	if resp.State != HaltState {
+		return &NotHaltStateError{state: resp.State, exception: resp.FaultException}
+	}
+
 	if len(resp.Script) == 0 {
 		return errEmptyInvocationScript
 	}

--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -51,11 +51,11 @@ var ErrNilClient = errors.New("client is nil")
 // HaltState returned if TestInvoke function processed without panic.
 const HaltState = "HALT"
 
-type NotHaltStateError struct {
+type notHaltStateError struct {
 	state, exception string
 }
 
-func (e *NotHaltStateError) Error() string {
+func (e *notHaltStateError) Error() string {
 	return fmt.Sprintf(
 		"chain/client: contract execution finished with state %s; exception: %s",
 		e.state,
@@ -101,7 +101,7 @@ func (c *Client) Invoke(contract util.Uint160, fee fixedn.Fixed8, method string,
 	}
 
 	if resp.State != HaltState {
-		return &NotHaltStateError{state: resp.State, exception: resp.FaultException}
+		return &notHaltStateError{state: resp.State, exception: resp.FaultException}
 	}
 
 	if len(resp.Script) == 0 {
@@ -151,7 +151,7 @@ func (c *Client) TestInvoke(contract util.Uint160, method string, args ...interf
 	}
 
 	if val.State != HaltState {
-		return nil, &NotHaltStateError{state: val.State, exception: val.FaultException}
+		return nil, &notHaltStateError{state: val.State, exception: val.FaultException}
 	}
 
 	return val.Stack, nil

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -244,7 +244,7 @@ func (c *Client) notaryInvoke(committee bool, contract util.Uint160, method stri
 
 	// check invocation state
 	if test.State != HaltState {
-		return &NotHaltStateError{state: test.State, exception: test.FaultException}
+		return &notHaltStateError{state: test.State, exception: test.FaultException}
 	}
 
 	// if test invocation failed, then return error


### PR DESCRIPTION
Test invocations are used in `Invoke` method to calculate consumed gas. We can check return code and return error if panic happened in contract. 

This is already done the same way in `TestInvoke` method.