### PR TITLE
Do not use notary in audit client

### DIFF
--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -30,7 +30,7 @@ import (
 	balanceWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/balance/wrapper"
 	cntWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	neofsWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofs/wrapper"
-	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
+	neofsidWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
 	nmWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	repWrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -417,7 +417,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 		return nil, err
 	}
 
-	neofsIDClient, err := neofsid.NewFromMorph(server.morphClient, server.contracts.neofsID, fee)
+	neofsIDClient, err := neofsidWrapper.NewFromMorph(server.morphClient, server.contracts.neofsID, fee, neofsidWrapper.TryNotary())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -390,7 +390,9 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 
 	fee := server.feeConfig.SideChainFee()
 
-	server.auditClient, err = auditWrapper.NewFromMorph(server.morphClient, server.contracts.audit, fee, client.TryNotary())
+	// do not use TryNotary() in audit wrapper
+	// audit operations do not require multisignatures
+	server.auditClient, err = auditWrapper.NewFromMorph(server.morphClient, server.contracts.audit, fee)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -423,7 +423,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 	}
 
 	neofsClient, err := neofsWrapper.NewFromMorph(server.mainnetClient, server.contracts.neofs,
-		server.feeConfig.MainChainFee())
+		server.feeConfig.MainChainFee(), neofsWrapper.TryNotary())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/morph/client/neofs/wrapper/client.go
+++ b/pkg/morph/client/neofs/wrapper/client.go
@@ -16,9 +16,33 @@ import (
 // Working ClientWrapper must be created via NewFromMorph.
 type ClientWrapper neofscontract.Client
 
+// Option allows to set an optional
+// parameter of ClientWrapper.
+type Option func(*opts)
+
+type opts []client.StaticClientOption
+
+func defaultOpts() *opts {
+	return new(opts)
+}
+
+// TryNotary returns option to enable
+// notary invocation tries.
+func TryNotary() Option {
+	return func(o *opts) {
+		*o = append(*o, client.TryNotary())
+	}
+}
+
 // NewFromMorph wraps client to work with NeoFS contract.
-func NewFromMorph(cli *client.Client, contract util.Uint160, fee fixedn.Fixed8) (*ClientWrapper, error) {
-	sc, err := client.NewStatic(cli, contract, fee, client.TryNotary())
+func NewFromMorph(cli *client.Client, contract util.Uint160, fee fixedn.Fixed8, opts ...Option) (*ClientWrapper, error) {
+	o := defaultOpts()
+
+	for i := range opts {
+		opts[i](o)
+	}
+
+	sc, err := client.NewStatic(cli, contract, fee, ([]client.StaticClientOption)(*o)...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create client of NeoFS contract: %w", err)
 	}

--- a/pkg/morph/client/neofsid/wrapper/client.go
+++ b/pkg/morph/client/neofsid/wrapper/client.go
@@ -16,9 +16,33 @@ import (
 // Working ClientWrapper must be created via Wrap.
 type ClientWrapper neofsid.Client
 
+// Option allows to set an optional
+// parameter of ClientWrapper.
+type Option func(*opts)
+
+type opts []client.StaticClientOption
+
+func defaultOpts() *opts {
+	return new(opts)
+}
+
+// TryNotary returns option to enable
+// notary invocation tries.
+func TryNotary() Option {
+	return func(o *opts) {
+		*o = append(*o, client.TryNotary())
+	}
+}
+
 // NewFromMorph wraps client to work with NeoFS ID contract.
-func NewFromMorph(cli *client.Client, contract util.Uint160, fee fixedn.Fixed8) (*ClientWrapper, error) {
-	sc, err := client.NewStatic(cli, contract, fee, client.TryNotary())
+func NewFromMorph(cli *client.Client, contract util.Uint160, fee fixedn.Fixed8, opts ...Option) (*ClientWrapper, error) {
+	o := defaultOpts()
+
+	for i := range opts {
+		opts[i](o)
+	}
+
+	sc, err := client.NewStatic(cli, contract, fee, ([]client.StaticClientOption)(*o)...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create client of NeoFS ID contract: %w", err)
 	}


### PR DESCRIPTION
Audit client should sign all transaction by node's key and do not use multisignature.