### PR TITLE
Release/v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog for NeoFS Node
 
 ## [Unreleased]
 
-## [0.21.1] - 2021-07-07
+## [0.22.1] - 2021-07-07
 
 ### Added
 - `GetCandidates` method to morph client wrapper ([#647](https://github.com/nspcc-dev/neofs-node/pull/647)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog for NeoFS Node
 
 ## [Unreleased]
 
+## [0.22.2] - 2021-07-07
+
+Updated broken version of NeoFS API Go.
+
+### Updated
+- NeoFS API Go: [v1.28.3](https://github.com/nspcc-dev/neofs-api-go/releases/tag/v1.28.3).
+
 ## [0.22.1] - 2021-07-07
 
 ### Added
@@ -470,7 +477,8 @@ NeoFS-API v2.0 support and updated brand-new storage node application.
 
 First public review release.
 
-[Unreleased]: https://github.com/nspcc-dev/neofs-node/compare/v0.22.1...master
+[Unreleased]: https://github.com/nspcc-dev/neofs-node/compare/v0.22.2...master
+[0.22.2]: https://github.com/nspcc-dev/neofs-node/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/nspcc-dev/neofs-node/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/nspcc-dev/neofs-node/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/nspcc-dev/neofs-node/compare/v0.21.0...v0.21.1

--- a/config/testnet/README.md
+++ b/config/testnet/README.md
@@ -14,7 +14,7 @@ However, if you need to rebuild it for some reason, run
 $ make image-storage-testnet
 ...
 Successfully built ab0557117b02
-Successfully tagged nspccdev/neofs-storage-testnet:0.21.1
+Successfully tagged nspccdev/neofs-storage-testnet:0.22.2
 ```
 
 ## Deploy node

--- a/config/testnet/docker-compose.yml
+++ b/config/testnet/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "2.4"
 services:
   storage01:
-    image: nspccdev/neofs-storage-testnet:0.21.1
+    image: nspccdev/neofs-storage-testnet:0.22.2
     container_name: neofs-testnet
     env_file: node_config.env
     network_mode: host

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.2
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.95.3
-	github.com/nspcc-dev/neofs-api-go v1.28.2
+	github.com/nspcc-dev/neofs-api-go v1.28.3
 	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20210520210714-9dee13f0d556
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/nspcc-dev/neo-go v0.95.3/go.mod h1:t15xRFDVhz5o/pstptdoW9N9JJBNn1hZ6A
 github.com/nspcc-dev/neofs-api-go v1.24.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
 github.com/nspcc-dev/neofs-api-go v1.26.1/go.mod h1:SHuH1Ba3U/h3j+8HHbb3Cns1LfMlEb88guWog9Qi68Y=
 github.com/nspcc-dev/neofs-api-go v1.27.1/go.mod h1:i0Cwgvcu9A4M4e58pydbXFisUhSxpfljmuWFPIp2btE=
-github.com/nspcc-dev/neofs-api-go v1.28.2 h1:T74HsOcDANc8LXbhNHI+k3KksSA/dK6VHKtYDmDE6PM=
-github.com/nspcc-dev/neofs-api-go v1.28.2/go.mod h1:YRIzUqBj/lGbmFm8mmCh54ZOzcJKkEIhv2s7ZvSLv3M=
+github.com/nspcc-dev/neofs-api-go v1.28.3 h1:53Ec3hv3LtI3uuG1H8Yp2OKOIdsAqQVfUOyClhnhc9g=
+github.com/nspcc-dev/neofs-api-go v1.28.3/go.mod h1:YRIzUqBj/lGbmFm8mmCh54ZOzcJKkEIhv2s7ZvSLv3M=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
`neofs-api-go` `v1.28.2` => `v1.28.3` 
Fix link in changelog for `v0.22.1` release and add changes for `v0.22.2`.