### PR TITLE
Fix/Do not require MainNet attributes in `WITHOUT_MAINNET` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog for NeoFS Node
 
 ## [Unreleased]
 
+### Fixed
+- Do not require MainNet attributes in "Without MainNet" mode ([#663](https://github.com/nspcc-dev/neofs-node/issues/663)).
+
 ## [0.22.2] - 2021-07-07
 
 Updated broken version of NeoFS API Go.

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -23,7 +23,8 @@ changes between releases.
 ## Tag the release
 
 Use `vX.Y.Z` tag for releases and `vX.Y.Z-rc.N` for release candidates
-following the [semantic versioning](https://semver.org/) standard.
+following the [semantic versioning](https://semver.org/) standard. Tag must be
+created from the latest commit of the master branch.
 
 ## Push changes and release tag to github
 


### PR DESCRIPTION
If `WITHOUT_MAINNET` environmental variable is
`true`:
- Do not read `NeoFS` and `processing`
script-hashes from envs;
- Do not init Governance processor;
- Do not init NeoFS processor.

Clarify tag section in release instruction.

Closes #663.