### PR TITLE
Fallback to wallet section if storage node's key is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Do not require MainNet attributes in "Without MainNet" mode ([#663](https://github.com/nspcc-dev/neofs-node/issues/663)).
 - Stable alphabet list merge in Inner Ring governance ([#670](https://github.com/nspcc-dev/neofs-node/issues/670)).
+- User can specify only wallet section without node key ([#690](https://github.com/nspcc-dev/neofs-node/pull/690)).
 
 ### Removed
 - Debug output of public key in Inner Ring log ([#689](https://github.com/nspcc-dev/neofs-node/pull/689)).

--- a/cmd/neofs-node/config/node/config_test.go
+++ b/cmd/neofs-node/config/node/config_test.go
@@ -14,9 +14,8 @@ func TestNodeSection(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		empty := configtest.EmptyConfig()
 
-		require.PanicsWithError(
+		require.Panics(
 			t,
-			errKeyNotSet.Error(),
 			func() {
 				Key(empty)
 			},


### PR DESCRIPTION
Some users want to specify only wallet section in the SN. It is not possible if `Key` throws panic on empty value. Instead it should
fallback to wallet section. Panic is suitable if node's key is provided but invalid.