### PR TITLE
Reduce amount of open connections in storage node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - Stable alphabet list merge in Inner Ring governance ([#670](https://github.com/nspcc-dev/neofs-node/issues/670)).
 - User can specify only wallet section without node key ([#690](https://github.com/nspcc-dev/neofs-node/pull/690)).
 - Log keys in hex format in reputation errors ([#693](https://github.com/nspcc-dev/neofs-node/pull/693)).
+- Connections leak and reduced amount of connection overall ([#692](https://github.com/nspcc-dev/neofs-node/issues/692)).
 
 ### Removed
 - Debug output of public key in Inner Ring log ([#689](https://github.com/nspcc-dev/neofs-node/pull/689)).

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -21,7 +21,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
-	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	containerTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/container/grpc"
 	containerService "github.com/nspcc-dev/neofs-node/pkg/services/container"
 	loadcontroller "github.com/nspcc-dev/neofs-node/pkg/services/container/announcement/load/controller"
@@ -72,23 +71,19 @@ func initContainerService(c *cfg) {
 		PlacementBuilder: loadPlacementBuilder,
 	})
 
-	clientCache := cache.NewSDKClientCache() // FIXME: use shared cache
-
 	loadRouter := loadroute.New(
 		loadroute.Prm{
 			LocalServerInfo: c,
 			RemoteWriterProvider: &remoteLoadAnnounceProvider{
 				key:             &c.key.PrivateKey,
 				loadAddrSrc:     c,
-				clientCache:     clientCache,
+				clientCache:     c.clientCache,
 				deadEndProvider: loadcontroller.SimpleWriterProvider(loadAccumulator),
 			},
 			Builder: routeBuilder,
 		},
 		loadroute.WithLogger(c.log),
 	)
-
-	c.onShutdown(clientCache.CloseAll)
 
 	ctrl := loadcontroller.New(
 		loadcontroller.Prm{

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/util/signature"
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	objectGRPC "github.com/nspcc-dev/neofs-api-go/v2/object/grpc"
-	apiclientconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/apiclient"
 	policerconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/policer"
 	replicatorconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/replicator"
 	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
@@ -25,7 +24,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
-	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	objectTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/object/grpc"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl"
@@ -168,17 +166,12 @@ func initObjectService(c *cfg) {
 
 	nodeOwner.SetNeo3Wallet(neo3Wallet)
 
-	clientCache := cache.NewSDKClientCache(
-		client.WithDialTimeout(apiclientconfig.DialTimeout(c.appCfg)))
-
-	c.onShutdown(clientCache.CloseAll)
-
 	clientConstructor := &reputationClientConstructor{
 		log:              c.log,
 		nmSrc:            c.cfgObject.netMapStorage,
 		netState:         c.cfgNetmap.state,
 		trustStorage:     c.cfgReputation.localTrustStorage,
-		basicConstructor: clientCache,
+		basicConstructor: c.clientCache,
 	}
 
 	coreConstructor := (*coreClientConstructor)(clientConstructor)

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -14,7 +14,6 @@ import (
 	rtpwrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/reputation/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
-	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	grpcreputation "github.com/nspcc-dev/neofs-node/pkg/network/transport/reputation/grpc"
 	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
@@ -87,15 +86,11 @@ func initReputationService(c *cfg) {
 		},
 	)
 
-	apiClientCache := cache.NewSDKClientCache()
-
-	c.onShutdown(apiClientCache.CloseAll)
-
 	remoteLocalTrustProvider := common.NewRemoteTrustProvider(
 		common.RemoteProviderPrm{
 			LocalAddrSrc:    c,
 			DeadEndProvider: daughterStorageWriterProvider,
-			ClientCache:     apiClientCache,
+			ClientCache:     c.clientCache,
 			WriterProvider: localreputation.NewRemoteProvider(
 				localreputation.RemoteProviderPrm{
 					Key: &c.key.PrivateKey,
@@ -108,7 +103,7 @@ func initReputationService(c *cfg) {
 		common.RemoteProviderPrm{
 			LocalAddrSrc:    c,
 			DeadEndProvider: consumerStorageWriterProvider,
-			ClientCache:     apiClientCache,
+			ClientCache:     c.clientCache,
 			WriterProvider: intermediatereputation.NewRemoteProvider(
 				intermediatereputation.RemoteProviderPrm{
 					Key: &c.key.PrivateKey,

--- a/pkg/network/cache/multi.go
+++ b/pkg/network/cache/multi.go
@@ -324,9 +324,14 @@ func (x *multiClient) Close() error {
 func (x *multiClient) RawForAddress(addr network.Address) *rawclient.Client {
 	x.mtx.Lock()
 
-	c := x.createForAddress(addr).Raw()
+	strAddr := addr.String()
+
+	c, cached := x.clients[strAddr]
+	if !cached {
+		c = x.createForAddress(addr)
+	}
 
 	x.mtx.Unlock()
 
-	return c
+	return c.Raw()
 }

--- a/pkg/network/cache/multi.go
+++ b/pkg/network/cache/multi.go
@@ -61,18 +61,9 @@ func (x *multiClient) iterateClients(f func(client.Client) error) error {
 	var firstErr error
 
 	x.addr.IterateAddresses(func(addr network.Address) bool {
-		x.mtx.Lock()
-
-		strAddr := addr.String()
-
 		var err error
 
-		c, cached := x.clients[strAddr]
-		if !cached {
-			c = x.createForAddress(addr)
-		}
-
-		x.mtx.Unlock()
+		c := x.client(addr)
 
 		err = f(c)
 
@@ -322,6 +313,10 @@ func (x *multiClient) Close() error {
 }
 
 func (x *multiClient) RawForAddress(addr network.Address) *rawclient.Client {
+	return x.client(addr).Raw()
+}
+
+func (x *multiClient) client(addr network.Address) client.Client {
 	x.mtx.Lock()
 
 	strAddr := addr.String()
@@ -333,5 +328,5 @@ func (x *multiClient) RawForAddress(addr network.Address) *rawclient.Client {
 
 	x.mtx.Unlock()
 
-	return c.Raw()
+	return c
 }


### PR DESCRIPTION
Closes #692 

First commit fixes issue with connection leak.
Second commit reduces amount of total connections by reusing the same client cache in all storage node components.