### PR TITLE
Make best effort traversing main chain list of keys

### DIFF
--- a/pkg/innerring/processors/governance/list.go
+++ b/pkg/innerring/processors/governance/list.go
@@ -44,19 +44,24 @@ func newAlphabetList(sidechain, mainnet keys.PublicKeys) (keys.PublicKeys, error
 	newNodes := 0
 	newNodeLimit := (ln - 1) / 3
 
-	for i := 0; i < ln; i++ {
-		if newNodes == newNodeLimit {
+	for _, node := range mainnet {
+		if len(result) == ln {
 			break
 		}
 
-		mainnetAddr := mainnet[i].Address()
+		limitReached := newNodes == newNodeLimit
+
+		mainnetAddr := node.Address()
 		if _, ok := hmap[mainnetAddr]; !ok {
+			if limitReached {
+				continue
+			}
 			newNodes++
 		} else {
 			hmap[mainnetAddr] = true
 		}
 
-		result = append(result, mainnet[i])
+		result = append(result, node)
 	}
 
 	if newNodes == 0 {

--- a/pkg/innerring/processors/governance/list_test.go
+++ b/pkg/innerring/processors/governance/list_test.go
@@ -68,6 +68,15 @@ func TestNewAlphabetList(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, equalPublicKeyLists(exp, got)) // expect {1, 2, 4, 5}, not {1, 2, 3, 5}
 	})
+
+	t.Run("new keys in the middle", func(t *testing.T) {
+		orig := keys.PublicKeys{k[0], k[1], k[2], k[6], k[7], k[8], k[9]}
+		// `exp` should contain maximum amount of new keys (2) in the middle
+		exp := keys.PublicKeys{k[0], k[3], k[4], k[6], k[7], k[8], k[9]}
+		got, err := newAlphabetList(orig, exp)
+		require.NoError(t, err)
+		require.True(t, equalPublicKeyLists(exp, got))
+	})
 }
 
 func TestUpdateInnerRing(t *testing.T) {


### PR DESCRIPTION
We should go through every key in main chain list to merget lists as fast as possible. Previously we drop main chain traversing as
soon as we have no more new keys to add. Instead we should try to go for old keys in the list and add it as more as we can.

In previous implementation test will produce `k[0], k[1], k[2], k[3], k[4], k[6], k[7]` which is sub optimal and it will take more iteration to converge. This PR fixes it and full main chain list traversal will produce expected result in one iteration. 