### PR TITLE
Sync first epoch duration at application startup

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -315,3 +315,9 @@ func toStackParameter(value interface{}) (sc.Parameter, error) {
 func (c *Client) MagicNumber() uint64 {
 	return uint64(c.client.GetNetwork())
 }
+
+// BlockCount returns block count of the network
+// to which the underlying RPC node client is connected.
+func (c *Client) BlockCount() (uint32, error) {
+	return c.client.GetBlockCount()
+}

--- a/pkg/morph/client/netmap/client.go
+++ b/pkg/morph/client/netmap/client.go
@@ -40,6 +40,7 @@ type cfg struct {
 	epochSnapshotMethod, // get network map snapshot by epoch method name
 	updateStateMethod, // update state method name for invocation
 	epochMethod, // get epoch number method name
+	epochBlockMethod, // get epoch number method name
 	updateInnerRing, // update innerring method name
 	setConfigMethod, // set config method name
 	configMethod string // get config value method name
@@ -49,6 +50,7 @@ const (
 	defaultAddPeerMethod         = "addPeer"          // default add peer method name
 	defaultConfigMethod          = "config"           // default get config value method name
 	defaultEpochMethod           = "epoch"            // default get epoch number method name
+	defaultEpochBlockMethod      = "epochBlock"       // default get epoch block number method name
 	defaultInnerRingListMethod   = "innerRingList"    // default get innerring list method name
 	defaultNetMapCandidateMethod = "netmapCandidates" // default get network candidates method name
 	defaultNetMapMethod          = "netmap"           // default get network map method name
@@ -66,6 +68,7 @@ func defaultConfig() *cfg {
 		addPeerMethod:          defaultAddPeerMethod,
 		configMethod:           defaultConfigMethod,
 		epochMethod:            defaultEpochMethod,
+		epochBlockMethod:       defaultEpochBlockMethod,
 		innerRingList:          defaultInnerRingListMethod,
 		netMapCandidatesMethod: defaultNetMapCandidateMethod,
 		netMapMethod:           defaultNetMapMethod,

--- a/pkg/morph/client/netmap/epoch.go
+++ b/pkg/morph/client/netmap/epoch.go
@@ -22,6 +22,22 @@ func (e EpochValues) Number() int64 {
 	return e.num
 }
 
+// EpochBlockArgs groups the arguments of
+// get epoch block number test invoke call.
+type EpochBlockArgs struct {
+}
+
+// EpochBlockValues groups the stack parameters
+// returned by get epoch block number test invoke.
+type EpochBlockValues struct {
+	block int64
+}
+
+// Block return the block number of NeoFS epoch.
+func (e EpochBlockValues) Block() int64 {
+	return e.block
+}
+
 // Epoch performs the test invoke of get epoch number
 // method of NeoFS Netmap contract.
 func (c *Client) Epoch(_ EpochArgs) (*EpochValues, error) {
@@ -45,5 +61,30 @@ func (c *Client) Epoch(_ EpochArgs) (*EpochValues, error) {
 
 	return &EpochValues{
 		num: num,
+	}, nil
+}
+
+// LastEpochBlock performs the test invoke of get epoch block number
+// method of NeoFS Netmap contract.
+func (c *Client) LastEpochBlock(_ EpochBlockArgs) (*EpochBlockValues, error) {
+	items, err := c.client.TestInvoke(c.epochBlockMethod)
+	if err != nil {
+		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
+			c.epochBlockMethod, err)
+	}
+
+	if ln := len(items); ln != 1 {
+		return nil, fmt.Errorf("unexpected stack item count (%s): %d",
+			c.epochBlockMethod, ln)
+	}
+
+	block, err := client.IntFromStackItem(items[0])
+	if err != nil {
+		return nil, fmt.Errorf("could not get number from stack item (%s): %w",
+			c.epochBlockMethod, err)
+	}
+
+	return &EpochBlockValues{
+		block: block,
 	}, nil
 }

--- a/pkg/morph/client/netmap/wrapper/epoch.go
+++ b/pkg/morph/client/netmap/wrapper/epoch.go
@@ -18,3 +18,16 @@ func (w *Wrapper) Epoch() (uint64, error) {
 
 	return uint64(vals.Number()), nil
 }
+
+// LastEpochBlock receives block number of current NeoFS epoch
+// through the Netmap contract call.
+func (w *Wrapper) LastEpochBlock() (uint32, error) {
+	args := netmap.EpochBlockArgs{}
+
+	vals, err := w.client.LastEpochBlock(args)
+	if err != nil {
+		return 0, fmt.Errorf("(%T) could not get epoch block number: %w", w, err)
+	}
+
+	return uint32(vals.Block()), nil
+}


### PR DESCRIPTION
Closes #679 

At the startup, Inner Ring application calculates block duration before next epoch tick and processes new epoch event at this block.