### PR TITLE
config/testnet: Fix ports

### DIFF
--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -3,21 +3,21 @@ logger:
 
 morph:
   rpc_endpoint:
-    - https://rpc01.morph.testnet.fs.neo.org:50331
-    - https://rpc02.morph.testnet.fs.neo.org:50331
-    - https://rpc03.morph.testnet.fs.neo.org:50331
-    - https://rpc04.morph.testnet.fs.neo.org:50331
-    - https://rpc05.morph.testnet.fs.neo.org:50331
-    - https://rpc06.morph.testnet.fs.neo.org:50331
-    - https://rpc07.morph.testnet.fs.neo.org:50331
+    - https://rpc01.morph.testnet.fs.neo.org:51331
+    - https://rpc02.morph.testnet.fs.neo.org:51331
+    - https://rpc03.morph.testnet.fs.neo.org:51331
+    - https://rpc04.morph.testnet.fs.neo.org:51331
+    - https://rpc05.morph.testnet.fs.neo.org:51331
+    - https://rpc06.morph.testnet.fs.neo.org:51331
+    - https://rpc07.morph.testnet.fs.neo.org:51331
   notification_endpoint:
-    - wss://rpc01.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc02.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc03.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc04.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc05.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc06.morph.testnet.fs.neo.org:50331/ws
-    - wss://rpc07.morph.testnet.fs.neo.org:50331/ws
+    - wss://rpc01.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc02.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc03.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc04.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc05.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc06.morph.testnet.fs.neo.org:51331/ws
+    - wss://rpc07.morph.testnet.fs.neo.org:51331/ws
   dial_timeout: 20s
 
 contracts:


### PR DESCRIPTION
[neofs-storage-testnet:0.23.0](https://hub.docker.com/layers/nspccdev/neofs-storage-testnet/0.23.0/images/sha256-a5374e19fe7bf0bf8d947a464c21a20d4df5c9a8b2a08c71a9c2523978ab5f3c?context=repo) image has been reupload with these changes.