### PR TITLE
neofs-adm: dump deployed contract hashes from NNS

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/dump.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const lastGlagoliticLetter = 41
+
 func dumpContractHashes(cmd *cobra.Command, _ []string) error {
 	c, err := getN3Client(viper.GetViper())
 	if err != nil {
@@ -40,8 +42,43 @@ func dumpContractHashes(cmd *cobra.Command, _ []string) error {
 		return errors.New("invalid response from NNS contract: length mismatch")
 	}
 
+	irSize := 0
+	for ; irSize < lastGlagoliticLetter; irSize++ {
+		ok, err := c.NNSIsAvailable(cs.Hash, getAlphabetNNSDomain(irSize))
+		if err != nil {
+			return err
+		} else if ok {
+			break
+		}
+	}
+
 	buf := bytes.NewBuffer(nil)
 	tw := tabwriter.NewWriter(buf, 0, 2, 2, ' ', 0)
+
+	if irSize != 0 {
+		bw.Reset()
+		for i := 0; i < irSize; i++ {
+			emit.AppCall(bw.BinWriter, cs.Hash, "resolve", callflag.ReadOnly,
+				getAlphabetNNSDomain(i),
+				int64(nns.TXT))
+		}
+
+		alphaRes, err := c.InvokeScript(bw.Bytes(), nil)
+		if err != nil {
+			return fmt.Errorf("can't fetch info from NNS: %w", err)
+		}
+
+		for i := 0; i < irSize; i++ {
+			ctrHash := "hash is invalid"
+			bs, err := alphaRes.Stack[i].TryBytes()
+			if err == nil {
+				ctrHash = string(bs) // hashes are stored as hex-encoded LE string
+			}
+
+			_, _ = tw.Write([]byte(fmt.Sprintf("alphabet %d:\t%s\n", i, ctrHash)))
+		}
+	}
+
 	for i := range contractList {
 		ctrHash := "hash is invalid"
 		bs, err := res.Stack[i].TryBytes()

--- a/cmd/neofs-adm/internal/modules/morph/dump.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump.go
@@ -1,0 +1,59 @@
+package morph
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"text/tabwriter"
+
+	nns "github.com/nspcc-dev/neo-go/examples/nft-nd-nns"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func dumpContractHashes(cmd *cobra.Command, _ []string) error {
+	c, err := getN3Client(viper.GetViper())
+	if err != nil {
+		return fmt.Errorf("can't create N3 client: %w", err)
+	}
+
+	cs, err := c.GetContractStateByID(1)
+	if err != nil {
+		return err
+	}
+
+	bw := io.NewBufBinWriter()
+	for _, ctrName := range contractList {
+		emit.AppCall(bw.BinWriter, cs.Hash, "resolve", callflag.ReadOnly,
+			ctrName+".neofs", int64(nns.TXT))
+	}
+
+	res, err := c.InvokeScript(bw.Bytes(), nil)
+	if err != nil {
+		return fmt.Errorf("can't fetch info from NNS: %w", err)
+	}
+
+	if len(res.Stack) != len(contractList) {
+		return errors.New("invalid response from NNS contract: length mismatch")
+	}
+
+	buf := bytes.NewBuffer(nil)
+	tw := tabwriter.NewWriter(buf, 0, 2, 2, ' ', 0)
+	for i := range contractList {
+		ctrHash := "hash is invalid"
+		bs, err := res.Stack[i].TryBytes()
+		if err == nil {
+			ctrHash = string(bs) // hashes are stored as hex-encoded LE string
+		}
+
+		_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s\n", contractList[i], ctrHash)))
+	}
+
+	_ = tw.Flush()
+	cmd.Print(buf.String())
+
+	return nil
+}

--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -32,7 +32,6 @@ const (
 )
 
 var contractList = []string{
-	alphabetContract,
 	auditContract,
 	balanceContract,
 	containerContract,
@@ -118,7 +117,11 @@ func (c *initializeContext) deployContracts() error {
 			return err
 		}
 
-		cs := c.Contracts[alphabetContract]
+		cs, err := c.readContract(ctrPath, alphabetContract)
+		if err != nil {
+			return err
+		}
+
 		ctrHash := state.CreateContractHash(acc.Contract.ScriptHash(), cs.NEF.Checksum, cs.Manifest.Name)
 		if _, err := c.Client.GetContractStateByHash(ctrHash); err == nil {
 			c.Command.Printf("Stage 4: alphabet contract #%d is already deployed.\n", i)
@@ -152,10 +155,6 @@ func (c *initializeContext) deployContracts() error {
 	}
 
 	for _, ctrName := range contractList {
-		if ctrName == alphabetContract {
-			continue
-		}
-
 		cs := c.Contracts[ctrName]
 		if _, err := c.Client.GetContractStateByHash(cs.Hash); err == nil {
 			c.Command.Printf("Stage 4: %s contract is already deployed.\n", ctrName)

--- a/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
@@ -59,7 +59,7 @@ func (c *initializeContext) setNNS() error {
 		alphaCs.Hash = state.CreateContractHash(acc.Contract.ScriptHash(), alphaCs.NEF.Checksum, alphaCs.Manifest.Name)
 
 		domain := getAlphabetNNSDomain(i)
-		if ok, err := c.nnsDomainAvailable(h, domain); err != nil {
+		if ok, err := c.Client.NNSIsAvailable(h, domain); err != nil {
 			return err
 		} else if !ok {
 			continue
@@ -86,7 +86,7 @@ func (c *initializeContext) setNNS() error {
 		cs.Hash = state.CreateContractHash(c.CommitteeAcc.Contract.ScriptHash(), cs.NEF.Checksum, cs.Manifest.Name)
 
 		domain := ctrName + ".neofs"
-		if ok, err := c.nnsDomainAvailable(h, domain); err != nil {
+		if ok, err := c.Client.NNSIsAvailable(h, domain); err != nil {
 			return err
 		} else if !ok {
 			continue
@@ -115,21 +115,6 @@ func (c *initializeContext) nnsRootRegistered(nnsHash util.Uint160) (bool, error
 		return false, err
 	}
 	return res.State == vm.HaltState.String(), nil
-}
-
-func (c *initializeContext) nnsDomainAvailable(nnsHash util.Uint160, domain string) (bool, error) {
-	params := []smartcontract.Parameter{{Type: smartcontract.StringType, Value: domain}}
-	res, err := c.Client.InvokeFunction(nnsHash, "isAvailable", params, nil)
-	if err != nil {
-		return false, err
-	}
-	if len(res.Stack) == 0 {
-		return true, nil
-	}
-	if ok, err := res.Stack[0].TryBool(); err == nil {
-		return ok, nil
-	}
-	return true, nil
 }
 
 func getAlphabetNNSDomain(i int) string {

--- a/cmd/neofs-adm/internal/modules/morph/root.go
+++ b/cmd/neofs-adm/internal/modules/morph/root.go
@@ -65,6 +65,15 @@ var (
 		},
 		RunE: forceNewEpochCmd,
 	}
+
+	dumpContractHashesCmd = &cobra.Command{
+		Use:   "dump-hashes",
+		Short: "Dump deployed contract hashes.",
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
+		},
+		RunE: dumpContractHashes,
+	}
 )
 
 func init() {
@@ -87,4 +96,7 @@ func init() {
 	RootCmd.AddCommand(forceNewEpoch)
 	forceNewEpoch.Flags().String(alphabetWalletsFlag, "", "path to alphabet wallets dir")
 	forceNewEpoch.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
+
+	RootCmd.AddCommand(dumpContractHashesCmd)
+	dumpContractHashesCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
 }


### PR DESCRIPTION
Also set hashes of all alphabet contracts.
```
alphabet 0:  58e305a68eea2c5f1e8d6b94f61ce79db4036e5c
alphabet 1:  a1e03470cdaac3d093c1774d681357f7f6e72127
alphabet 2:  8be6184611cf9b264c39dde763486b96870840f4
alphabet 3:  e8e714a7d278ec93c3c0242458fb449a4c06e8f3
audit:       bc086562cd491ec86e15a808a43bba571ae378cd
balance:     22a5d1a3b456b45fdb5ec37aca35dcc92bad96f7
container:   45c30c8af952541aadabdcef8c9edc651dd6ddd2
neofsid:     ae6e6056e4e2e911b1e7a3b59ed1913675ad4bf5
netmap:      b5b3144938f745e5743c4130d3a1e912a2331d1b
proxy:       febf124409abb1aad6f32e2fba70e867cefd161b
reputation:  51ef954a1e34c6b5d59750c3ed9cf720c04433ea
```