### PR TITLE
More network configuration parameters in neofs-adm

### DIFF
--- a/cmd/neofs-adm/internal/modules/config/config_test.go
+++ b/cmd/neofs-adm/internal/modules/config/config_test.go
@@ -28,6 +28,11 @@ func TestGenerateConfigExample(t *testing.T) {
 	require.Equal(t, path.Join(appDir, "alphabet-wallets"), v.GetString("alphabet-wallets"))
 	require.Equal(t, 67108864, v.GetInt("network.max_object_size"))
 	require.Equal(t, 240, v.GetInt("network.epoch_duration"))
+	require.Equal(t, 100000000, v.GetInt("network.basic_income_rate"))
+	require.Equal(t, 10000, v.GetInt("network.fee.audit"))
+	require.Equal(t, 10000000000, v.GetInt("network.fee.candidate"))
+	require.Equal(t, 1000, v.GetInt("network.fee.container"))
+	require.Equal(t, 100000000, v.GetInt("network.fee.withdraw"))
 
 	var i innerring.GlagoliticLetter
 	for i = 0; i < innerring.GlagoliticLetter(n); i++ {

--- a/cmd/neofs-adm/internal/modules/morph/dump.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump.go
@@ -133,10 +133,8 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid response from NNS contract: %w", err)
 	}
 
-	res, err = wCtx.Client.InvokeFunction(nmHash, "listConfig", []smartcontract.Parameter{}, []transaction.Signer{{
-		Account: wCtx.CommitteeAcc.Contract.ScriptHash(),
-		Scopes:  transaction.Global,
-	}})
+	res, err = wCtx.Client.InvokeFunction(nmHash, "listConfig",
+		[]smartcontract.Parameter{}, []transaction.Signer{{}})
 	if err != nil || res.State != vm.HaltState.String() || len(res.Stack) == 0 {
 		return errors.New("can't fetch list of network config keys from the netmap contract")
 	}
@@ -166,13 +164,15 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 		}
 
 		switch string(k) {
-		case "AuditFee", "BasicIncomeRate", "ContainerFee", "EigenTrustIterations",
-			"EpochDuration", "InnerRingCandidateFee", "MaxObjectSize", "WithdrawFee":
+		case netmapAuditFeeKey, netmapBasicIncomeRateKey,
+			netmapContainerFeeKey, netmapEigenTrustIterationsKey,
+			netmapEpochKey, netmapInnerRingCandidateFeeKey,
+			netmapMaxObjectSizeKey, netmapWithdrawFeeKey:
 			nbuf := make([]byte, 8)
 			copy(nbuf[:], v)
 			n := binary.LittleEndian.Uint64(nbuf)
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%d (int)\n", k, n)))
-		case "EigenTrustAlpha":
+		case netmapEigenTrustAlphaKey:
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (str)\n", k, v)))
 		default:
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (hex)\n", k, hex.EncodeToString(v))))

--- a/cmd/neofs-adm/internal/modules/morph/dump.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump.go
@@ -2,14 +2,21 @@ package morph
 
 import (
 	"bytes"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"text/tabwriter"
 
 	nns "github.com/nspcc-dev/neo-go/examples/nft-nd-nns"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -87,6 +94,89 @@ func dumpContractHashes(cmd *cobra.Command, _ []string) error {
 		}
 
 		_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s\n", contractList[i], ctrHash)))
+	}
+
+	_ = tw.Flush()
+	cmd.Print(buf.String())
+
+	return nil
+}
+
+func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
+	wCtx, err := newInitializeContext(cmd, viper.GetViper())
+	if err != nil {
+		return fmt.Errorf("can't to initialize context: %w", err)
+	}
+
+	cs, err := wCtx.Client.GetContractStateByID(1)
+	if err != nil {
+		return fmt.Errorf("can't get NNS contract info: %w", err)
+	}
+
+	res, err := wCtx.Client.InvokeFunction(cs.Hash, "resolve", []smartcontract.Parameter{
+		{Type: smartcontract.StringType, Value: netmapContract + ".neofs"},
+		{Type: smartcontract.IntegerType, Value: int64(nns.TXT)},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("can't get netmap contract hash: %w", err)
+	}
+	if len(res.Stack) == 0 {
+		return errors.New("empty response from NNS")
+	}
+
+	var nmHash util.Uint160
+	bs, err := res.Stack[0].TryBytes()
+	if err == nil {
+		nmHash, err = util.Uint160DecodeStringLE(string(bs))
+	}
+	if err != nil {
+		return fmt.Errorf("invalid response from NNS contract: %w", err)
+	}
+
+	res, err = wCtx.Client.InvokeFunction(nmHash, "listConfig", []smartcontract.Parameter{}, []transaction.Signer{{
+		Account: wCtx.CommitteeAcc.Contract.ScriptHash(),
+		Scopes:  transaction.Global,
+	}})
+	if err != nil || res.State != vm.HaltState.String() || len(res.Stack) == 0 {
+		return errors.New("can't fetch list of network config keys from the netmap contract")
+	}
+
+	arr, ok := res.Stack[0].Value().([]stackitem.Item)
+	if !ok {
+		return errors.New("invalid ListConfig response from netmap contract")
+	}
+
+	buf := bytes.NewBuffer(nil)
+	tw := tabwriter.NewWriter(buf, 0, 2, 2, ' ', 0)
+
+	for _, param := range arr {
+		tuple, ok := param.Value().([]stackitem.Item)
+		if !ok || len(tuple) != 2 {
+			return errors.New("invalid ListConfig response from netmap contract")
+		}
+
+		k, err := tuple[0].TryBytes()
+		if err != nil {
+			return errors.New("invalid config key from netmap contract")
+		}
+
+		v, err := tuple[1].TryBytes()
+		if err != nil {
+			return errors.New("invalid config value from netmap contract")
+		}
+
+		switch string(k) {
+		case "AuditFee", "BasicIncomeRate", "ContainerFee", "EigenTrustIterations",
+			"EpochDuration", "InnerRingCandidateFee", "MaxObjectSize", "WithdrawFee":
+			nbuf := make([]byte, 8)
+			copy(nbuf[:], v)
+			n := binary.LittleEndian.Uint64(nbuf)
+			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%d (int)\n", k, n)))
+		case "EigenTrustAlpha":
+			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (str)\n", k, v)))
+		default:
+			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (hex)\n", k, hex.EncodeToString(v))))
+		}
 	}
 
 	_ = tw.Flush()

--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -43,13 +43,8 @@ const (
 	netmapInnerRingCandidateFeeKey = "InnerRingCandidateFee"
 	netmapWithdrawFeeKey           = "WithdrawFee"
 
-	defaultAuditFee              = 10000
-	defaultContainerFee          = 1000
-	defaultEigenTrustIterations  = 4
-	defaultEigenTrustAlpha       = "0.1"
-	defaultBasicIncomeRate       = 100000000
-	defaultInnerRingCandidateFee = 10000000000
-	defaultWithdrawFee           = 100000000
+	defaultEigenTrustIterations = 4
+	defaultEigenTrustAlpha      = "0.1"
 )
 
 var contractList = []string{
@@ -272,19 +267,19 @@ func (c *initializeContext) getContractDeployData(ctrName string, keysParam []sm
 			{Type: smartcontract.StringType, Value: netmapMaxObjectSizeKey},
 			{Type: smartcontract.IntegerType, Value: viper.GetInt64(maxObjectSizeInitFlag)},
 			{Type: smartcontract.StringType, Value: netmapAuditFeeKey},
-			{Type: smartcontract.IntegerType, Value: int64(defaultAuditFee)},
+			{Type: smartcontract.IntegerType, Value: viper.GetInt64(auditFeeInitFlag)},
 			{Type: smartcontract.StringType, Value: netmapContainerFeeKey},
-			{Type: smartcontract.IntegerType, Value: int64(defaultContainerFee)},
+			{Type: smartcontract.IntegerType, Value: viper.GetInt64(containerFeeInitFlag)},
 			{Type: smartcontract.StringType, Value: netmapEigenTrustIterationsKey},
 			{Type: smartcontract.IntegerType, Value: int64(defaultEigenTrustIterations)},
 			{Type: smartcontract.StringType, Value: netmapEigenTrustAlphaKey},
 			{Type: smartcontract.StringType, Value: defaultEigenTrustAlpha},
 			{Type: smartcontract.StringType, Value: netmapBasicIncomeRateKey},
-			{Type: smartcontract.IntegerType, Value: int64(defaultBasicIncomeRate)},
+			{Type: smartcontract.IntegerType, Value: viper.GetInt64(incomeRateInitFlag)},
 			{Type: smartcontract.StringType, Value: netmapInnerRingCandidateFeeKey},
-			{Type: smartcontract.IntegerType, Value: int64(defaultInnerRingCandidateFee)},
+			{Type: smartcontract.IntegerType, Value: viper.GetInt64(candidateFeeInitFlag)},
 			{Type: smartcontract.StringType, Value: netmapWithdrawFeeKey},
-			{Type: smartcontract.IntegerType, Value: int64(defaultWithdrawFee)},
+			{Type: smartcontract.IntegerType, Value: viper.GetInt64(withdrawFeeInitFlag)},
 		}
 		items = append(items,
 			newContractParameter(smartcontract.Hash160Type, c.Contracts[balanceContract].Hash),

--- a/cmd/neofs-adm/internal/modules/morph/root.go
+++ b/cmd/neofs-adm/internal/modules/morph/root.go
@@ -17,6 +17,16 @@ const (
 	maxObjectSizeCLIFlag  = "max-object-size"
 	epochDurationInitFlag = "network.epoch_duration"
 	epochDurationCLIFlag  = "epoch-duration"
+	incomeRateInitFlag    = "network.basic_income_rate"
+	incomeRateCLIFlag     = "basic-income-rate"
+	auditFeeInitFlag      = "network.fee.audit"
+	auditFeeCLIFlag       = "audit-fee"
+	containerFeeInitFlag  = "network.fee.container"
+	containerFeeCLIFlag   = "container-fee"
+	candidateFeeInitFlag  = "network.fee.candidate"
+	candidateFeeCLIFlag   = "candidate-fee"
+	withdrawFeeInitFlag   = "network.fee.withdraw"
+	withdrawFeeCLIFlag    = "withdraw-fee"
 )
 
 var (
@@ -44,6 +54,11 @@ var (
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
 			_ = viper.BindPFlag(epochDurationInitFlag, cmd.Flags().Lookup(epochDurationCLIFlag))
 			_ = viper.BindPFlag(maxObjectSizeInitFlag, cmd.Flags().Lookup(maxObjectSizeCLIFlag))
+			_ = viper.BindPFlag(incomeRateInitFlag, cmd.Flags().Lookup(incomeRateCLIFlag))
+			_ = viper.BindPFlag(auditFeeInitFlag, cmd.Flags().Lookup(auditFeeCLIFlag))
+			_ = viper.BindPFlag(candidateFeeInitFlag, cmd.Flags().Lookup(candidateFeeCLIFlag))
+			_ = viper.BindPFlag(containerFeeInitFlag, cmd.Flags().Lookup(containerFeeCLIFlag))
+			_ = viper.BindPFlag(withdrawFeeInitFlag, cmd.Flags().Lookup(withdrawFeeCLIFlag))
 		},
 		RunE: initializeSideChainCmd,
 	}
@@ -77,6 +92,15 @@ var (
 		},
 		RunE: dumpContractHashes,
 	}
+
+	dumpNetworkConfigCmd = &cobra.Command{
+		Use:   "dump-config",
+		Short: "Dump NeoFS network config.",
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
+		},
+		RunE: dumpNetworkConfig,
+	}
 )
 
 func init() {
@@ -103,4 +127,7 @@ func init() {
 
 	RootCmd.AddCommand(dumpContractHashesCmd)
 	dumpContractHashesCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
+
+	RootCmd.AddCommand(dumpNetworkConfigCmd)
+	dumpNetworkConfigCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.96.1
 	github.com/nspcc-dev/neofs-api-go v1.28.3
+	github.com/nspcc-dev/neofs-contract v0.10.1
 	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20210520210714-9dee13f0d556
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,7 @@ github.com/nspcc-dev/neo-go v0.91.0/go.mod h1:G6HdOWvzQ6tlvFdvFSN/PgCzLPN/X/X4d5
 github.com/nspcc-dev/neo-go v0.95.0/go.mod h1:bW07ge1WFXsBgqrcPpLUr6OcyQxHqM26MZNesWMdH0c=
 github.com/nspcc-dev/neo-go v0.95.1/go.mod h1:bW07ge1WFXsBgqrcPpLUr6OcyQxHqM26MZNesWMdH0c=
 github.com/nspcc-dev/neo-go v0.95.3/go.mod h1:t15xRFDVhz5o/pstptdoW9N9JJBNn1hZ6APMNiC6MrY=
+github.com/nspcc-dev/neo-go v0.96.0/go.mod h1:Mj6P7K9+1FDquUGXZ9LKGqS9vFKesvkV+Ad4zI84of8=
 github.com/nspcc-dev/neo-go v0.96.1 h1:JaKWvM/vvQ48bq2ADNj7zH/6Ek38Iqxo22hdu2lhxmY=
 github.com/nspcc-dev/neo-go v0.96.1/go.mod h1:yguwQBpWMTHx07INKoElJT8Gga1LUdTSi0gT75ywJ68=
 github.com/nspcc-dev/neofs-api-go v1.24.0/go.mod h1:G7dqincfdjBrAbL5nxVp82emF05fSVEqe59ICsoRDI8=
@@ -393,6 +394,8 @@ github.com/nspcc-dev/neofs-api-go v1.26.1/go.mod h1:SHuH1Ba3U/h3j+8HHbb3Cns1LfMl
 github.com/nspcc-dev/neofs-api-go v1.27.1/go.mod h1:i0Cwgvcu9A4M4e58pydbXFisUhSxpfljmuWFPIp2btE=
 github.com/nspcc-dev/neofs-api-go v1.28.3 h1:53Ec3hv3LtI3uuG1H8Yp2OKOIdsAqQVfUOyClhnhc9g=
 github.com/nspcc-dev/neofs-api-go v1.28.3/go.mod h1:YRIzUqBj/lGbmFm8mmCh54ZOzcJKkEIhv2s7ZvSLv3M=
+github.com/nspcc-dev/neofs-contract v0.10.1 h1:PWNiolmOuksWB4/4hgZlfnQxSyT4Vb9fxa8JKJWvOfE=
+github.com/nspcc-dev/neofs-contract v0.10.1/go.mod h1:vjq00npZi7Bqp8GSDvappbHJ/OQH6U6JWs1CajVq4YA=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=


### PR DESCRIPTION
Config example:
```
$ cat neofs-adm.yml 
rpc-endpoint: http://morph_chain.neofs.devenv:30333
alphabet-wallets: /home/alexvanin/Project/NeoFS/neofs-node/bin/alphabets
network:
  max_object_size: 67108864
  epoch_duration: 50
  basic_income_rate: 5000
  fee:
    audit: 333333
    candidate: 4444444
    container: 555555
    withdraw: 666666
credentials:
  az: onetwo
```

Command output example:
```
./neofs-adm -c neofs-adm.yml morph dump-config
AuditFee:               333333 (int)
BasicIncomeRate:        5000 (int)
ContainerFee:           555555 (int)
EigenTrustAlpha:        0.1 (str)
EigenTrustIterations:   4 (int)
EpochDuration:          50 (int)
InnerRingCandidateFee:  4444444 (int)
MaxObjectSize:          67108864 (int)
WithdrawFee:            666666 (int)
```