### PR TITLE
util/attributes: Support escaped symbols

### DIFF
--- a/pkg/util/attributes/parser_test.go
+++ b/pkg/util/attributes/parser_test.go
@@ -57,4 +57,16 @@ func TestParseV2Attributes(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, attrs, 5)
 	})
+
+	t.Run("escape characters", func(t *testing.T) {
+		from := []string{
+			`/K\:ey1:V\/alue\\/Ke\/y2:Va\:lue`,
+		}
+		attrs, err := attributes.ParseV2Attributes(from, nil)
+		require.NoError(t, err)
+		require.Equal(t, attrs[0].Key(), `K:ey1`)
+		require.Equal(t, attrs[0].Value(), `V/alue\`)
+		require.Equal(t, attrs[1].Key(), `Ke/y2`)
+		require.Equal(t, attrs[1].Value(), `Va:lue`)
+	})
 }


### PR DESCRIPTION
Closes #700 

To encode attributes with semicolon or slash, use backslash as escaped character.

Example: `NEOFS_NODE_ATTRIBUTE_2=User-Agent:NeoFS\/0.23`

```
$ ./bin/neofs-cli -c control-devenv.yml control netmap-snapshot
Epoch: 1
Node 1: eQEUoc2DRn4oNnNUxs8iviWJYrYS4mTBsgQqjJ44aFyJ ONLINE [/dns4/s01.neofs.devenv/tcp/8080]
        Capacity: 0
        Continent: Europe
        Country: Russia
        CountryCode: RU
        Location: Moskva
        Price: 22
        SubDiv: Moskva
        SubDivCode: MOW
        UN-LOCODE: RU MOW
        User-Agent: NeoFS/0.23
Node 2: o5H2uGUa7cwBvb1GSx62SUL8Mkpp4PbgB1oUstPgnfo8 ONLINE [/dns4/s03.neofs.devenv/tcp/8080]
        Capacity: 0
        Continent: Europe
        Country: Sweden
        CountryCode: SE
        Location: Stockholm
        Price: 11
        SubDiv: Stockholms l�n
        SubDivCode: AB
        UN-LOCODE: SE STO
        User-Agent: NeoFS/0.23
Node 3: 249VqsrQDNv8X7bYHTUH86ZqRJKogJnAeovMmCqMqM3u6 ONLINE [/dns4/s04.neofs.devenv/tcp/8082/tls /dns4/s04.neofs.devenv/tcp/8080]
        Capacity: 0
        Continent: Europe
        Country: Finland
        CountryCode: FI
        Location: Helsinki (Helsingfors)
        Price: 44
        SubDiv: Uusimaa
        SubDivCode: 18
        UN-LOCODE: FI HEL
        User-Agent: NeoFS/0.23
Node 4: 2Bsv2nitVMDi9S77fuYNqDeYtRHcxAmp1J6Q7Hx79Wwem ONLINE [/dns4/s02.neofs.devenv/tcp/8080]
        Capacity: 0
        Continent: Europe
        Country: Russia
        CountryCode: RU
        Location: Saint Petersburg (ex Leningrad)
        Price: 33
        SubDiv: Sankt-Peterburg
        SubDivCode: SPE
        UN-LOCODE: RU LED
        User-Agent: NeoFS/0.23

```