### PR TITLE
Fix/Support reading paths with `~` for Alphabet wallets in neofs-adm

### DIFF
--- a/cmd/neofs-adm/internal/modules/config/util.go
+++ b/cmd/neofs-adm/internal/modules/config/util.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveHomePath replaces leading `~`
+// with home directory.
+//
+// Does nothing if path does not start
+// with contain `~`.
+func ResolveHomePath(path string) string {
+	homeDir, _ := os.UserHomeDir()
+
+	if path == "~" {
+		path = homeDir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(homeDir, path[2:])
+	}
+
+	return path
+}

--- a/cmd/neofs-adm/internal/modules/morph/generate.go
+++ b/cmd/neofs-adm/internal/modules/morph/generate.go
@@ -36,7 +36,7 @@ func generateAlphabetCreds(cmd *cobra.Command, args []string) error {
 		return errors.New("size must be > 0")
 	}
 
-	walletDir := viper.GetString(alphabetWalletsFlag)
+	walletDir := config.ResolveHomePath(viper.GetString(alphabetWalletsFlag))
 	pwds, err := initializeWallets(walletDir, int(size))
 	if err != nil {
 		return err

--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -90,7 +90,7 @@ func initializeSideChainCmd(cmd *cobra.Command, args []string) error {
 }
 
 func newInitializeContext(cmd *cobra.Command, v *viper.Viper) (*initializeContext, error) {
-	walletDir := v.GetString(alphabetWalletsFlag)
+	walletDir := config.ResolveHomePath(viper.GetString(alphabetWalletsFlag))
 	wallets, err := openAlphabetWallets(walletDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #739.