### PR TITLE
services/policer: Select pseudo-random list of objects to check

### DIFF
--- a/pkg/services/policer/queue.go
+++ b/pkg/services/policer/queue.go
@@ -3,6 +3,7 @@ package policer
 import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
+	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
 )
 
 type jobQueue struct {
@@ -18,6 +19,10 @@ func (q *jobQueue) Select(limit int) ([]*object.Address, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	rand.New().Shuffle(len(res), func(i, j int) {
+		res[i], res[j] = res[j], res[i]
+	})
 
 	if len(res) < limit {
 		return res, nil


### PR DESCRIPTION
Closes #715.

In previous implementation of Policer's job queue the same list of objects for
processing was selected at each iteration. This was caused by consistent
return of `engine.List` function.

Use `rand.Shuffle` function to compose pseudo-random list of all objects in
order to approximately evenly distribute objects to work.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>