### PR TITLE
Cache the results of Container read operations

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	"github.com/nspcc-dev/neofs-node/pkg/metrics"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
-	cntwrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	nmwrapper "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmap2 "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
@@ -39,6 +38,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl"
 	trustcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
 	truststorage "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/storage"
 	tokenStorage "github.com/nspcc-dev/neofs-node/pkg/services/session/storage"
@@ -171,7 +171,7 @@ type cfgObject struct {
 
 	cnrSource container.Source
 
-	cnrClient *cntwrapper.Wrapper
+	eaclSource eacl.Source
 
 	pool cfgObjectRoutines
 

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -364,20 +364,6 @@ func initObjectService(c *cfg) {
 		respSvc,
 	)
 
-	var (
-		eACLSource  eacl.Source
-		eACLFetcher = &morphEACLFetcher{
-			w: c.cfgObject.cnrClient,
-		}
-	)
-
-	if c.cfgMorph.disableCache {
-		eACLSource = eACLFetcher
-	} else {
-		// use RPC node as source of eACL (with caching)
-		eACLSource = newCachedEACLStorage(eACLFetcher)
-	}
-
 	aclSvc := acl.New(
 		acl.WithSenderClassifier(
 			acl.NewSenderClassifier(
@@ -392,7 +378,7 @@ func initObjectService(c *cfg) {
 		acl.WithNextService(signSvc),
 		acl.WithLocalStorage(ls),
 		acl.WithEACLValidatorOptions(
-			eacl.WithEACLSource(eACLSource),
+			eacl.WithEACLSource(c.cfgObject.eaclSource),
 			eacl.WithLogger(c.log),
 		),
 		acl.WithNetmapState(c.cfgNetmap.state),


### PR DESCRIPTION
Closes #676.

In previous implementation Container service handlers didn't cache the
results of `Get` / `GetEACL` / `List` operations. As a consequence of this,
high load on the service caused neo-go client's connection errors. To avoid
this there is a need to use cache. Object service already uses `Get` and
`GetEACL` caches.

Implement cache of `List` results. Share already implemented cache of Object
service with the Container one. Provide new instance of read-only container
storage (defined as an interface)to morph executor's constructor on which
container service is based. Write operations remained unchanged.