### PR TITLE
Feature/Improve release process

### DIFF
--- a/.docker/Dockerfile.adm
+++ b/.docker/Dockerfile.adm
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as basebuilder
+FROM golang:1.16 as basebuilder
 RUN apk add --update make bash
 
 FROM basebuilder as builder

--- a/.docker/Dockerfile.adm
+++ b/.docker/Dockerfile.adm
@@ -1,7 +1,4 @@
-FROM golang:1.16 as basebuilder
-RUN apk add --update make bash
-
-FROM basebuilder as builder
+FROM golang:1.16 as builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as basebuilder
+FROM golang:1.16 as basebuilder
 RUN apk add --update make bash
 
 FROM basebuilder as builder

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,7 +1,4 @@
-FROM golang:1.16 as basebuilder
-RUN apk add --update make bash
-
-FROM basebuilder as builder
+FROM golang:1.16 as builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.ir
+++ b/.docker/Dockerfile.ir
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as basebuilder
+FROM golang:1.16 as basebuilder
 RUN apk add --update make bash
 
 FROM basebuilder as builder

--- a/.docker/Dockerfile.ir
+++ b/.docker/Dockerfile.ir
@@ -1,7 +1,4 @@
-FROM golang:1.16 as basebuilder
-RUN apk add --update make bash
-
-FROM basebuilder as builder
+FROM golang:1.16 as builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.storage
+++ b/.docker/Dockerfile.storage
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as basebuilder
+FROM golang:1.16 as basebuilder
 RUN apk add --update make bash
 
 FROM basebuilder as builder

--- a/.docker/Dockerfile.storage
+++ b/.docker/Dockerfile.storage
@@ -1,7 +1,4 @@
-FROM golang:1.16 as basebuilder
-RUN apk add --update make bash
-
-FROM basebuilder as builder
+FROM golang:1.16 as builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.storage-testnet
+++ b/.docker/Dockerfile.storage-testnet
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as basebuilder
+FROM golang:1.16 as basebuilder
 RUN apk add --update make bash
 
 FROM basebuilder as builder

--- a/.docker/Dockerfile.storage-testnet
+++ b/.docker/Dockerfile.storage-testnet
@@ -1,7 +1,4 @@
-FROM golang:1.16 as basebuilder
-RUN apk add --update make bash
-
-FROM basebuilder as builder
+FROM golang:1.16 as builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 bin
+release
 temp
 cmd/test
 /plugins/

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,16 @@ images: image-storage image-ir image-cli image-adm
 # Build dirty local Docker images
 dirty-images: image-dirty-storage image-dirty-ir image-dirty-cli image-dirty-adm
 
+# Run `make %` in Golang container
+docker/%:
+	docker run --rm -it \
+	-v `pwd`:/src \
+	-w /src \
+	-u "$$(id -u):$$(id -g)" \
+	--env HOME=/src \
+	golang:$(GO_VERSION) make $*
+
+
 # Run all code formatters
 fmts: fmt imports
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ image-%:
 		-t $(HUB_IMAGE)-$*:$(HUB_TAG) .
 
 # Build all Docker images
-images: image-storage image-ir image-cli image-adm
+images: image-storage image-ir image-cli image-adm image-storage-testnet
 
 # Build dirty local Docker images
 dirty-images: image-dirty-storage image-dirty-ir image-dirty-cli image-dirty-adm

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,11 @@ HUB_IMAGE ?= nspccdev/neofs
 HUB_TAG ?= "$(shell echo ${VERSION} | sed 's/^v//')"
 
 GO_VERSION ?= 1.16
+ARCH = amd64
 
 BIN = bin
-DIRS = $(BIN)
-
 RELEASE = release
-ARCH = amd64
+DIRS = $(BIN) $(RELEASE)
 
 # List of binaries to build.
 CMDS = $(notdir $(basename $(wildcard cmd/*)))
@@ -42,16 +41,13 @@ $(DIRS):
 	@echo "⇒ Ensure dir: $@"
 	@mkdir -p $@
 
-# Directory for release files
-$(RELEASE):
-	@echo "⇒ Ensure dir: $@"
-	@mkdir -p $@
-
 # Prepare binaries and archives for release
-prepare-release: $(RELEASE) docker/all
-	@for file in $$(find $(BIN) -name 'neofs-*' -printf "%f\n"); do \
-  		cp $(BIN)/$$file $(RELEASE)/$$file-$(ARCH) && \
-  		tar -czf $(RELEASE)/$$file-$(ARCH).tar.gz $(RELEASE)/$$file-$(ARCH) ; \
+.ONESHELL:
+prepare-release: docker/all
+	@for file in `ls -1 $(BIN)/neofs-*`; do
+		cp $$file $(RELEASE)/`basename $$file`-$(ARCH)
+		strip $(RELEASE)/`basename $$file`-$(ARCH)
+		tar -czf $(RELEASE)/`basename $$file`-$(ARCH).tar.gz $(RELEASE)/`basename $$file`-$(ARCH)
 	done
 
 # Pull go dependencies

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -42,7 +42,7 @@ Create images for `neofs-storage`, `neofs-ir` and `neofs-cli`, `neofs-adm` appli
 and push them into Docker Hub (so that releasing requires privileges in nspccdev
 organization in Docker Hub)
 
-    $ make images && make image-storage-testnet
+    $ make images
     $ docker push nspccdev/neofs-storage:0.24.0
     $ docker push nspccdev/neofs-storage-testnet:0.24.0
     $ docker push nspccdev/neofs-ir:0.24.0

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -3,10 +3,12 @@
 ## Pre-release checks
 
 These should run successfully:
- * build,
- * unit-tests,
- * integration tests in 
- [neofs-devenv](https://github.com/nspcc-dev/neofs-devenv).
+ * `make all`;
+ * `make test`;
+ * `make lint` (should not change any files);
+ * `make fmts` (should not change any files);
+ * `go mod tidy` (should not change any files);
+ * integration tests in [neofs-devenv](https://github.com/nspcc-dev/neofs-devenv).
 
 ## Writing changelog
 
@@ -14,7 +16,7 @@ Add an entry to the `CHANGELOG.md` following the style established there. Add an
 optional codename, version and release date in the heading. Write a paragraph
 describing the most significant changes done in this release. Add
 `Fixed`, `Added`, `Removed` and `Updated` sections with fixed bug descriptions
-and changes. Describe each change in detail with a reference to github issues if
+and changes. Describe each change in detail with a reference to GitHub issues if
 possible. 
 
 Update supported version of neofs-contract in `README.md` if there were 
@@ -26,7 +28,7 @@ Use `vX.Y.Z` tag for releases and `vX.Y.Z-rc.N` for release candidates
 following the [semantic versioning](https://semver.org/) standard. Tag must be
 created from the latest commit of the master branch.
 
-## Push changes and release tag to github
+## Push changes and release tag to GitHub
 
 This step should bypass the default PR mechanism to get a correct result (so
 that releasing requires admin privileges for the project), both the `master`
@@ -34,25 +36,28 @@ branch update and tag must be pushed simultaneously like this:
 
     $ git push origin master v0.12.0
 
-## Prepare and push images to a dockerhub
+## Prepare and push images to a Docker Hub
 
-Create images for `neofs-storage`, `neofs-ir` and `neofs-cli` applications
-and push them into dockerhub (so that releasing requires privileges in nspccdev
-organization in dockerhub)
+Create images for `neofs-storage`, `neofs-ir` and `neofs-cli`, `neofs-adm` applications
+and push them into Docker Hub (so that releasing requires privileges in nspccdev
+organization in Docker Hub)
 
-    $ make images
-    $ docker push nspccdev/neofs-storage:0.12.0
-    $ docker push nspccdev/neofs-ir:0.12.0
-    $ docker push nspccdev/neofs-cli:0.12.0
+    $ make images && make image-storage-testnet
+    $ docker push nspccdev/neofs-storage:0.24.0
+    $ docker push nspccdev/neofs-storage-testnet:0.24.0
+    $ docker push nspccdev/neofs-ir:0.24.0
+    $ docker push nspccdev/neofs-cli:0.24.0
+    $ docker push nspccdev/neofs-adm:0.24.0
 
-## Make a proper github release
+## Make a proper GitHub release
 
-Edit an automatically-created release on github, copy things from changelog. 
-Make a release.
+Edit an automatically-created release on GitHub, copy things from changelog.
+Build and tar release binaries with `make prepare-release`, attach them to
+the release. Publish the release.
 
-## Close github milestone
+## Close GitHub milestone
 
-Close corresponding vX.Y.Z github milestone.
+Close corresponding vX.Y.Z GitHub milestone.
 
 ## Post-release
 

--- a/docs/update-go-instruction.md
+++ b/docs/update-go-instruction.md
@@ -1,0 +1,35 @@
+# Updating Golang version
+
+## Update go.mod
+
+`go mod edit -go=X.Y`
+
+## Update CI
+
+Change Golang versions for unit test in CI.
+There is `go` section in `.github/workflows/go.yaml` file:
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: [ 'X.Y.x', 'X.Y.x' ]
+```
+
+That section should contain two latest Golang minor versions
+that are currently supported by Golang authors.
+
+## Update docker images
+
+Update all docker files that contain `golang` image in `./docker`
+directory.
+
+## Update Makefile
+
+Update `GO_VERSION` variable in `./Makefile`.
+
+## Apply language changes
+
+Open PR that fixes/updates repository's code according to 
+language improvements.


### PR DESCRIPTION
Release binaries are not built in the clean reproducible environment. It would be safer to build binaries in container, the same way we do for docker images.