### PR TITLE
Smart contract script hash auto negotiation

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -139,6 +139,8 @@ type cfgMorph struct {
 
 	blockTimers     []*timer.BlockTimer // all combined timers
 	eigenTrustTimer *timer.BlockTimer   // timer for EigenTrust iterations
+
+	proxyScriptHash neogoutil.Uint160
 }
 
 type cfgAccounting struct {
@@ -277,6 +279,9 @@ func initCfg(path string) *cfg {
 		cfgGRPC: cfgGRPC{
 			maxChunkSize:  maxChunkSize,
 			maxAddrAmount: maxAddrAmount,
+		},
+		cfgMorph: cfgMorph{
+			proxyScriptHash: contractsconfig.Proxy(appCfg),
 		},
 		localAddr: netAddr,
 		respSvc: response.NewService(

--- a/cmd/neofs-node/config/contracts/config.go
+++ b/cmd/neofs-node/config/contracts/config.go
@@ -14,6 +14,7 @@ const (
 // Netmap returns value of "netmap" config parameter
 // from "contracts" section.
 //
+// Returns zero filled script hash if value is not set.
 // Throws panic if value is not a 20-byte LE hex-encoded string.
 func Netmap(c *config.Config) util.Uint160 {
 	return contractAddress(c, "netmap")
@@ -22,6 +23,7 @@ func Netmap(c *config.Config) util.Uint160 {
 // Balance returns value of "balance" config parameter
 // from "contracts" section.
 //
+// Returns zero filled script hash if value is not set.
 // Throws panic if value is not a 20-byte LE hex-encoded string.
 func Balance(c *config.Config) util.Uint160 {
 	return contractAddress(c, "balance")
@@ -30,6 +32,7 @@ func Balance(c *config.Config) util.Uint160 {
 // Container returns value of "container" config parameter
 // from "contracts" section.
 //
+// Returns zero filled script hash if value is not set.
 // Throws panic if value is not a 20-byte LE hex-encoded string.
 func Container(c *config.Config) util.Uint160 {
 	return contractAddress(c, "container")
@@ -38,6 +41,7 @@ func Container(c *config.Config) util.Uint160 {
 // Reputation returns value of "reputation" config parameter
 // from "contracts" section.
 //
+// Returns zero filled script hash if value is not set.
 // Throws panic if value is not a 20-byte LE hex-encoded string.
 func Reputation(c *config.Config) util.Uint160 {
 	return contractAddress(c, "reputation")
@@ -46,6 +50,7 @@ func Reputation(c *config.Config) util.Uint160 {
 // Proxy returns value of "proxy" config parameter
 // from "contracts" section.
 //
+// Returns zero filled script hash if value is not set.
 // Throws panic if value is not a 20-byte LE hex-encoded string.
 func Proxy(c *config.Config) util.Uint160 {
 	return contractAddress(c, "proxy")
@@ -54,11 +59,7 @@ func Proxy(c *config.Config) util.Uint160 {
 func contractAddress(c *config.Config, name string) util.Uint160 {
 	v := config.String(c.Sub(subsection), name)
 	if v == "" {
-		panic(fmt.Errorf(
-			"empty %s contract address, see `contracts.%s` section",
-			name,
-			name,
-		))
+		return util.Uint160{} // if address is not set, then NNS resolver should be used
 	}
 
 	addr, err := util.Uint160DecodeStringLE(v)

--- a/cmd/neofs-node/config/contracts/config_test.go
+++ b/cmd/neofs-node/config/contracts/config_test.go
@@ -13,11 +13,13 @@ import (
 func TestContractsSection(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		empty := configtest.EmptyConfig()
+		emptyHash := util.Uint160{}
 
-		require.Panics(t, func() { contractsconfig.Balance(empty) })
-		require.Panics(t, func() { contractsconfig.Container(empty) })
-		require.Panics(t, func() { contractsconfig.Netmap(empty) })
-		require.Panics(t, func() { contractsconfig.Reputation(empty) })
+		require.Equal(t, emptyHash, contractsconfig.Balance(empty))
+		require.Equal(t, emptyHash, contractsconfig.Container(empty))
+		require.Equal(t, emptyHash, contractsconfig.Netmap(empty))
+		require.Equal(t, emptyHash, contractsconfig.Reputation(empty))
+		require.Equal(t, emptyHash, contractsconfig.Proxy(empty))
 	})
 
 	const path = "../../../../config/example/node"

--- a/pkg/innerring/contracts.go
+++ b/pkg/innerring/contracts.go
@@ -1,0 +1,112 @@
+package innerring
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/spf13/viper"
+)
+
+type contracts struct {
+	neofs      util.Uint160 // in mainnet
+	netmap     util.Uint160 // in morph
+	balance    util.Uint160 // in morph
+	container  util.Uint160 // in morph
+	audit      util.Uint160 // in morph
+	proxy      util.Uint160 // in morph
+	processing util.Uint160 // in mainnet
+	reputation util.Uint160 // in morph
+	neofsID    util.Uint160 // in morph
+
+	alphabet alphabetContracts // in morph
+}
+
+func parseContracts(cfg *viper.Viper, morph *client.Client, withoutMainNet, withoutMainNotary, withoutSideNotary bool) (*contracts, error) {
+	var (
+		result = new(contracts)
+		err    error
+	)
+
+	if !withoutMainNet {
+		result.neofs, err = util.Uint160DecodeStringLE(cfg.GetString("contracts.neofs"))
+		if err != nil {
+			return nil, fmt.Errorf("can't get neofs script hash: %w", err)
+		}
+
+		if !withoutMainNotary {
+			result.processing, err = util.Uint160DecodeStringLE(cfg.GetString("contracts.processing"))
+			if err != nil {
+				return nil, fmt.Errorf("can't get processing script hash: %w", err)
+			}
+		}
+	}
+
+	if !withoutSideNotary {
+		result.proxy, err = parseContract(cfg, morph, "contracts.proxy", client.NNSProxyContractName)
+		if err != nil {
+			return nil, fmt.Errorf("can't get proxy script hash: %w", err)
+		}
+	}
+
+	targets := [...]struct {
+		cfgName string
+		nnsName string
+		dest    *util.Uint160
+	}{
+		{"contracts.netmap", client.NNSNetmapContractName, &result.netmap},
+		{"contracts.balance", client.NNSBalanceContractName, &result.balance},
+		{"contracts.container", client.NNSContainerContractName, &result.container},
+		{"contracts.audit", client.NNSAuditContractName, &result.audit},
+		{"contracts.reputation", client.NNSReputationContractName, &result.reputation},
+		{"contracts.neofsid", client.NNSNeoFSIDContractName, &result.neofsID},
+	}
+
+	for _, t := range targets {
+		*t.dest, err = parseContract(cfg, morph, t.cfgName, t.nnsName)
+		if err != nil {
+			name := strings.TrimPrefix(t.cfgName, "contracts.")
+			return nil, fmt.Errorf("can't get %s script hash: %w", name, err)
+		}
+	}
+
+	result.alphabet, err = parseAlphabetContracts(cfg, morph)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func parseAlphabetContracts(cfg *viper.Viper, morph *client.Client) (alphabetContracts, error) {
+	num := GlagoliticLetter(cfg.GetUint("contracts.alphabet.amount"))
+	alpha := newAlphabetContracts()
+
+	if num > lastLetterNum {
+		return nil, fmt.Errorf("amount of alphabet contracts overflows glagolitsa %d > %d", num, lastLetterNum)
+	}
+
+	for letter := az; letter < num; letter++ {
+		contractHash, err := parseContract(cfg, morph,
+			"contracts.alphabet."+letter.String(),
+			client.NNSAlphabetContractName(int(letter)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("invalid alphabet %s contract: %w", letter, err)
+		}
+
+		alpha.set(letter, contractHash)
+	}
+
+	return alpha, nil
+}
+
+func parseContract(cfg *viper.Viper, morph *client.Client, cfgName, nnsName string) (res util.Uint160, err error) {
+	contractStr := cfg.GetString(cfgName)
+	if len(contractStr) == 0 {
+		return morph.NNSContractAddress(nnsName)
+	}
+
+	return util.Uint160DecodeStringLE(contractStr)
+}

--- a/pkg/morph/client/nns.go
+++ b/pkg/morph/client/nns.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"fmt"
+	"strconv"
+
+	nns "github.com/nspcc-dev/neo-go/examples/nft-nd-nns"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+const (
+	nnsContractID = 1 // NNS contract must be deployed first in side chain
+
+	// NNSAuditContractName is a name of the audit contract in NNS.
+	NNSAuditContractName = "audit.neofs"
+	// NNSBalanceContractName is a name of the balance contract in NNS.
+	NNSBalanceContractName = "balance.neofs"
+	// NNSContainerContractName is a name of the container contract in NNS.
+	NNSContainerContractName = "container.neofs"
+	// NNSNeoFSIDContractName is a name of the neofsid contract in NNS.
+	NNSNeoFSIDContractName = "neofsid.neofs"
+	// NNSNetmapContractName is a name of the netmap contract in NNS.
+	NNSNetmapContractName = "netmap.neofs"
+	// NNSProxyContractName is a name of the proxy contract in NNS.
+	NNSProxyContractName = "proxy.neofs"
+	// NNSReputationContractName is a name of the reputation contract in NNS.
+	NNSReputationContractName = "reputation.neofs"
+)
+
+// NNSAlphabetContractName returns contract name of the alphabet contract in NNS
+// based on alphabet index.
+func NNSAlphabetContractName(index int) string {
+	return "alphabet" + strconv.Itoa(index) + ".neofs"
+}
+
+// NNSContractAddress returns contract address script hash based on its name
+// in NNS contract.
+func (c *Client) NNSContractAddress(name string) (sh util.Uint160, err error) {
+	if c.multiClient != nil {
+		return sh, c.multiClient.iterateClients(func(c *Client) error {
+			sh, err = c.NNSContractAddress(name)
+			return err
+		})
+	}
+
+	cs, err := c.client.GetContractStateByID(nnsContractID) // cache it?
+	if err != nil {
+		return sh, fmt.Errorf("NNS contract state: %w", err)
+	}
+
+	s, err := c.client.NNSResolve(cs.Hash, name, nns.TXT)
+	if err != nil {
+		return sh, fmt.Errorf("NNS.resolve: %w", err)
+	}
+
+	sh, err = util.Uint160DecodeStringLE(s)
+	if err != nil {
+		return sh, fmt.Errorf("NNS u160 decode: %w", err)
+	}
+
+	return sh, nil
+}


### PR DESCRIPTION
Closes #736

This PR contains:
- new `client.NNSContractAddress()` from `morph/client` that resolves `TXT` record of NNS contract from the contract with ID:1
- bunch of `client.NNS*ContractName` constants and `client.NNSAlphabetContractName()`,
- the usage of `client.NNSContractAddress()` in Storage and Inner Ring node applications.

NNS contract only used when applications miss some configuration record of contract script hash. Local config values override NNS values.