### PR TITLE
Fix attribute parser issues

### DIFF
--- a/pkg/util/attributes/parser.go
+++ b/pkg/util/attributes/parser.go
@@ -28,6 +28,7 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.NodeAttribute, 
 	}
 
 	cache := make(map[string]*netmap.NodeAttribute, len(attrs))
+	result := make([]*netmap.NodeAttribute, 0, len(attrs))
 
 	for i := range attrs {
 		line := strings.Trim(attrs[i], pairSeparator)
@@ -67,6 +68,7 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.NodeAttribute, 
 				attribute.SetValue(value)
 
 				cache[key] = attribute
+				result = append(result, attribute)
 			}
 
 			if parentKey != "" {
@@ -78,11 +80,6 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.NodeAttribute, 
 
 			parentKey = key
 		}
-	}
-
-	result := make([]*netmap.NodeAttribute, 0, len(cache))
-	for _, v := range cache {
-		result = append(result, v)
 	}
 
 	return result, nil

--- a/pkg/util/attributes/parser.go
+++ b/pkg/util/attributes/parser.go
@@ -59,16 +59,16 @@ func ParseV2Attributes(attrs []string, excl []string) ([]*netmap.NodeAttribute, 
 			}
 
 			if !present {
+				attribute = netmap.NewNodeAttribute()
+				cache[key] = attribute
+				result = append(result, attribute)
+
 				// replace non-printable symbols with escaped symbols without escape character
 				key = replaceEscaping(key, true)
 				value = replaceEscaping(value, true)
 
-				attribute = netmap.NewNodeAttribute()
 				attribute.SetKey(key)
 				attribute.SetValue(value)
-
-				cache[key] = attribute
-				result = append(result, attribute)
 			}
 
 			if parentKey != "" {

--- a/pkg/util/attributes/parser_test.go
+++ b/pkg/util/attributes/parser_test.go
@@ -63,10 +63,10 @@ func TestParseV2Attributes(t *testing.T) {
 		}
 		attrs, err := attributes.ParseV2Attributes(from, nil)
 		require.NoError(t, err)
-		require.Equal(t, attrs[0].Key(), `K:ey1`)
-		require.Equal(t, attrs[0].Value(), `V/alue\`)
-		require.Equal(t, attrs[1].Key(), `Ke/y2`)
-		require.Equal(t, attrs[1].Value(), `Va:lue`)
+		require.Equal(t, `K:ey1`, attrs[0].Key())
+		require.Equal(t, `V/alue\`, attrs[0].Value())
+		require.Equal(t, `Ke/y2`, attrs[1].Key())
+		require.Equal(t, `Va:lue`, attrs[1].Value())
 	})
 
 	t.Run("same attributes", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestParseV2Attributes(t *testing.T) {
 		for _, attr := range attrs {
 			if attr.Key() == "child" {
 				flag = true
-				require.Equal(t, attr.ParentKeys(), []string{"parent1", "parent2"})
+				require.Equal(t, []string{"parent1", "parent2"}, attr.ParentKeys())
 			}
 		}
 		require.True(t, flag)
@@ -102,12 +102,12 @@ func TestParseV2Attributes(t *testing.T) {
 			attrs, err := attributes.ParseV2Attributes(from, nil)
 			require.NoError(t, err)
 
-			require.Equal(t, attrs[0].Key(), "a")
-			require.Equal(t, attrs[0].Value(), "1")
-			require.Equal(t, attrs[1].Key(), "b")
-			require.Equal(t, attrs[1].Value(), "2")
-			require.Equal(t, attrs[2].Key(), "c")
-			require.Equal(t, attrs[2].Value(), "3")
+			require.Equal(t, "a", attrs[0].Key())
+			require.Equal(t, "1", attrs[0].Value())
+			require.Equal(t, "b", attrs[1].Key())
+			require.Equal(t, "2", attrs[1].Value())
+			require.Equal(t, "c", attrs[2].Key())
+			require.Equal(t, "3", attrs[2].Value())
 		}
 	})
 }

--- a/pkg/util/attributes/parser_test.go
+++ b/pkg/util/attributes/parser_test.go
@@ -25,7 +25,6 @@ func TestParseV2Attributes(t *testing.T) {
 		bad := append(good, "StorageType:SSD/Cell:QLC")
 		_, err = attributes.ParseV2Attributes(bad, nil)
 		require.Error(t, err)
-
 	})
 
 	t.Run("malformed", func(t *testing.T) {
@@ -68,5 +67,31 @@ func TestParseV2Attributes(t *testing.T) {
 		require.Equal(t, attrs[0].Value(), `V/alue\`)
 		require.Equal(t, attrs[1].Key(), `Ke/y2`)
 		require.Equal(t, attrs[1].Value(), `Va:lue`)
+	})
+
+	t.Run("same attributes", func(t *testing.T) {
+		from := []string{"/a:b", "/a:b"}
+		attrs, err := attributes.ParseV2Attributes(from, nil)
+		require.NoError(t, err)
+		require.Len(t, attrs, 1)
+	})
+
+	t.Run("multiple parents", func(t *testing.T) {
+		from := []string{
+			"/parent1:x/child:x",
+			"/parent2:x/child:x",
+			"/parent2:x/child:x/subchild:x",
+		}
+		attrs, err := attributes.ParseV2Attributes(from, nil)
+		require.NoError(t, err)
+
+		var flag bool
+		for _, attr := range attrs {
+			if attr.Key() == "child" {
+				flag = true
+				require.Equal(t, attr.ParentKeys(), []string{"parent1", "parent2"})
+			}
+		}
+		require.True(t, flag)
 	})
 }

--- a/pkg/util/attributes/parser_test.go
+++ b/pkg/util/attributes/parser_test.go
@@ -94,4 +94,20 @@ func TestParseV2Attributes(t *testing.T) {
 		}
 		require.True(t, flag)
 	})
+
+	t.Run("consistent order in chain", func(t *testing.T) {
+		from := []string{"/a:1/b:2/c:3"}
+
+		for i := 0; i < 10000; i++ {
+			attrs, err := attributes.ParseV2Attributes(from, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, attrs[0].Key(), "a")
+			require.Equal(t, attrs[0].Value(), "1")
+			require.Equal(t, attrs[1].Key(), "b")
+			require.Equal(t, attrs[1].Value(), "2")
+			require.Equal(t, attrs[2].Key(), "c")
+			require.Equal(t, attrs[2].Value(), "3")
+		}
+	})
 }

--- a/pkg/util/attributes/parser_test.go
+++ b/pkg/util/attributes/parser_test.go
@@ -74,6 +74,13 @@ func TestParseV2Attributes(t *testing.T) {
 		attrs, err := attributes.ParseV2Attributes(from, nil)
 		require.NoError(t, err)
 		require.Len(t, attrs, 1)
+
+		t.Run("with escape characters", func(t *testing.T) {
+			from = []string{`/a\::b\/`, `/a\::b\/`}
+			attrs, err := attributes.ParseV2Attributes(from, nil)
+			require.NoError(t, err)
+			require.Len(t, attrs, 1)
+		})
 	})
 
 	t.Run("multiple parents", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes:
1. inconsistent order of the returned attributes,
2. multiple attribute parent support.

As for (1), attributes does not require any special order, because they are linked together with `Parents` field. However for the tests it would be better to have consistent parsing function, so we won't see any 
```
             	Error Trace:	parser_test.go:67
            	Error:      	Not equal: 
            	            	expected: "Ke/y2"
            	            	actual  : "K:ey1"
```
errors.

As for (2), previously we didn't reuse existing attributes so the `Parents` list will have at most one record. 

It is better to review per commit than whole PR.
