### PR TITLE
Use public key comparison as a locality criterion

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -240,7 +240,7 @@ func initObjectService(c *cfg) {
 		policer.WithRemoteHeader(
 			headsvc.NewRemoteHeader(keyStorage, clientConstructor),
 		),
-		policer.WithLocalAddressSource(c),
+		policer.WithNetmapKeys(c),
 		policer.WithHeadTimeout(
 			policerconfig.HeadTimeout(c.appCfg),
 		),
@@ -276,7 +276,7 @@ func initObjectService(c *cfg) {
 		putsvc.WithLocalStorage(ls),
 		putsvc.WithContainerSource(c.cfgObject.cnrSource),
 		putsvc.WithNetworkMapSource(c.cfgObject.netMapSource),
-		putsvc.WithLocalAddressSource(c),
+		putsvc.WithNetmapKeys(c),
 		putsvc.WithFormatValidatorOpts(
 			objectCore.WithDeleteHandler(objInhumer),
 		),

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -87,7 +87,7 @@ func initReputationService(c *cfg) {
 
 	remoteLocalTrustProvider := common.NewRemoteTrustProvider(
 		common.RemoteProviderPrm{
-			LocalAddrSrc:    c,
+			NetmapKeys:      c,
 			DeadEndProvider: daughterStorageWriterProvider,
 			ClientCache:     c.clientCache,
 			WriterProvider: localreputation.NewRemoteProvider(
@@ -100,7 +100,7 @@ func initReputationService(c *cfg) {
 
 	remoteIntermediateTrustProvider := common.NewRemoteTrustProvider(
 		common.RemoteProviderPrm{
-			LocalAddrSrc:    c,
+			NetmapKeys:      c,
 			DeadEndProvider: consumerStorageWriterProvider,
 			ClientCache:     c.clientCache,
 			WriterProvider: intermediatereputation.NewRemoteProvider(

--- a/pkg/core/netmap/keys.go
+++ b/pkg/core/netmap/keys.go
@@ -1,0 +1,7 @@
+package netmap
+
+// AnnouncedKeys is an interface of utility for working with announced public keys of the storage nodes.
+type AnnouncedKeys interface {
+	// Checks if key was announced by local node.
+	IsLocalKey(key []byte) bool
+}

--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -23,12 +23,6 @@ type Address struct {
 	ma multiaddr.Multiaddr
 }
 
-// LocalAddressSource is an interface of local
-// network address container with read access.
-type LocalAddressSource interface {
-	LocalAddress() AddressGroup
-}
-
 // String returns multiaddr string.
 func (a Address) String() string {
 	return a.ma.String()
@@ -134,10 +128,4 @@ func multiaddrStringFromHostAddr(host string) (string, error) {
 	const l4Protocol = "tcp"
 
 	return strings.Join([]string{prefix, addr, l4Protocol, port}, "/"), nil
-}
-
-// IsLocalAddress returns true if network endpoints from local address group
-// source intersects with network endpoints of passed address group.
-func IsLocalAddress(src LocalAddressSource, addr AddressGroup) bool {
-	return src.LocalAddress().Intersects(addr)
 }

--- a/pkg/services/object/get/container.go
+++ b/pkg/services/object/get/container.go
@@ -78,7 +78,7 @@ func (exec *execCtx) processCurrentEpoch() bool {
 			// TODO: consider parallel execution
 			// TODO: consider optimization: if status == SPLIT we can continue until
 			//  we reach the best result - split info with linking object ID.
-			if exec.processNode(ctx, addrs[i]) {
+			if exec.processNode(ctx, addrs[i].Addresses()) {
 				exec.log.Debug("completing the operation")
 				return true
 			}

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	"github.com/nspcc-dev/neofs-node/pkg/network"
 	svcutil "github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/transformer"
@@ -23,7 +22,7 @@ type distributedTarget struct {
 
 	chunks [][]byte
 
-	nodeTargetInitializer func(network.AddressGroup) transformer.ObjectTarget
+	nodeTargetInitializer func(placement.Node) transformer.ObjectTarget
 
 	relay func(placement.Node) error
 
@@ -76,7 +75,7 @@ func (t *distributedTarget) sendObject(node placement.Node) error {
 		}
 	}
 
-	target := t.nodeTargetInitializer(node.Addresses())
+	target := t.nodeTargetInitializer(node)
 
 	if err := target.WriteHeader(t.obj); err != nil {
 		return fmt.Errorf("could not write header: %w", err)

--- a/pkg/services/object/put/service.go
+++ b/pkg/services/object/put/service.go
@@ -46,7 +46,7 @@ type cfg struct {
 
 	workerPool util.WorkerPool
 
-	localAddrSrc network.LocalAddressSource
+	netmapKeys netmap.AnnouncedKeys
 
 	fmtValidator *object.FormatValidator
 
@@ -123,9 +123,9 @@ func WithWorkerPool(v util.WorkerPool) Option {
 	}
 }
 
-func WithLocalAddressSource(v network.LocalAddressSource) Option {
+func WithNetmapKeys(v netmap.AnnouncedKeys) Option {
 	return func(c *cfg) {
-		c.localAddrSrc = v
+		c.netmapKeys = v
 	}
 }
 

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -147,9 +147,11 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 var errLocalAddress = errors.New("can't relay to local address")
 
 func (p *Streamer) newCommonTarget(prm *PutInitPrm) transformer.ObjectTarget {
-	var relay func(network.AddressGroup) error
+	var relay func(placement.Node) error
 	if p.relay != nil {
-		relay = func(addr network.AddressGroup) error {
+		relay = func(node placement.Node) error {
+			addr := node.Addresses()
+
 			if network.IsLocalAddress(p.localAddrSrc, addr) {
 				return errLocalAddress
 			}

--- a/pkg/services/object/search/container.go
+++ b/pkg/services/object/search/container.go
@@ -76,7 +76,7 @@ func (exec *execCtx) processCurrentEpoch() bool {
 			}
 
 			// TODO: consider parallel execution
-			exec.processNode(ctx, addrs[i])
+			exec.processNode(ctx, addrs[i].Addresses())
 		}
 	}
 

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -122,11 +122,18 @@ func flatNodes(ns []netmap.Nodes) []netmap.Nodes {
 // Node is a descriptor of storage node with information required for intra-container communication.
 type Node struct {
 	addresses network.AddressGroup
+
+	key []byte
 }
 
 // Addresses returns group of network addresses.
 func (x Node) Addresses() network.AddressGroup {
 	return x.addresses
+}
+
+// Key returns public key in a binary format. Should not be mutated.
+func (x Node) Key() []byte {
+	return x.key
 }
 
 // Next returns next unprocessed address of the object placement.
@@ -157,6 +164,8 @@ func (t *Traverser) Next() []Node {
 			// TODO: log error
 			return nil
 		}
+
+		nodes[i].key = t.vectors[0][i].PublicKey()
 	}
 
 	t.vectors[0] = t.vectors[0][count:]

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -119,10 +119,20 @@ func flatNodes(ns []netmap.Nodes) []netmap.Nodes {
 	return []netmap.Nodes{flat}
 }
 
+// Node is a descriptor of storage node with information required for intra-container communication.
+type Node struct {
+	addresses network.AddressGroup
+}
+
+// Addresses returns group of network addresses.
+func (x Node) Addresses() network.AddressGroup {
+	return x.addresses
+}
+
 // Next returns next unprocessed address of the object placement.
 //
 // Returns nil if no nodes left or traversal operation succeeded.
-func (t *Traverser) Next() []network.AddressGroup {
+func (t *Traverser) Next() []Node {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 
@@ -139,10 +149,10 @@ func (t *Traverser) Next() []network.AddressGroup {
 		count = len(t.vectors[0])
 	}
 
-	addrs := make([]network.AddressGroup, count)
+	nodes := make([]Node, count)
 
 	for i := 0; i < count; i++ {
-		err := addrs[i].FromIterator(t.vectors[0][i])
+		err := nodes[i].addresses.FromIterator(t.vectors[0][i])
 		if err != nil {
 			// TODO: log error
 			return nil
@@ -151,7 +161,7 @@ func (t *Traverser) Next() []network.AddressGroup {
 
 	t.vectors[0] = t.vectors[0][count:]
 
-	return addrs
+	return nodes
 }
 
 func (t *Traverser) skipEmptyVectors() {

--- a/pkg/services/object_manager/placement/traverser_test.go
+++ b/pkg/services/object_manager/placement/traverser_test.go
@@ -95,7 +95,7 @@ func TestTraverserObjectScenarios(t *testing.T) {
 			require.Len(t, addrs, len(nodes[i]))
 
 			for j, n := range nodes[i] {
-				assertSameAddress(t, n.NodeInfo, addrs[j])
+				assertSameAddress(t, n.NodeInfo, addrs[j].Addresses())
 			}
 		}
 
@@ -129,7 +129,7 @@ func TestTraverserObjectScenarios(t *testing.T) {
 		err = n.FromIterator(nodes[1][0])
 		require.NoError(t, err)
 
-		require.Equal(t, []network.AddressGroup{n}, tr.Next())
+		require.Equal(t, []Node{{addresses: n}}, tr.Next())
 	})
 
 	t.Run("put scenario", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestTraverserObjectScenarios(t *testing.T) {
 				require.Len(t, addrs, replicas[curVector])
 
 				for j := range addrs {
-					assertSameAddress(t, nodes[curVector][i+j].NodeInfo, addrs[j])
+					assertSameAddress(t, nodes[curVector][i+j].NodeInfo, addrs[j].Addresses())
 				}
 			}
 

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -68,7 +68,7 @@ func (p *Policer) processNodes(ctx context.Context, addr *object.Address, nodes 
 			continue
 		}
 
-		if network.IsLocalAddress(p.localAddrSrc, node) {
+		if p.netmapKeys.IsLocalKey(nodes[i].PublicKey()) {
 			if shortage == 0 {
 				// we can call the redundant copy callback
 				// here to slightly improve the performance

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
+	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	"github.com/nspcc-dev/neofs-node/pkg/network"
 	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/services/replicator"
@@ -47,7 +47,7 @@ type cfg struct {
 
 	remoteHeader *headsvc.RemoteHeader
 
-	localAddrSrc network.LocalAddressSource
+	netmapKeys netmap.AnnouncedKeys
 
 	replicator *replicator.Replicator
 
@@ -142,10 +142,10 @@ func WithRemoteHeader(v *headsvc.RemoteHeader) Option {
 	}
 }
 
-// WithLocalAddressSource returns option to set local address source of Policer.
-func WithLocalAddressSource(v network.LocalAddressSource) Option {
+// WithNetmapKeys returns option to set tool to work with announced public keys.
+func WithNetmapKeys(v netmap.AnnouncedKeys) Option {
 	return func(c *cfg) {
-		c.localAddrSrc = v
+		c.netmapKeys = v
 	}
 }
 


### PR DESCRIPTION
Related #645.

In current neofs-api-go and SDK state 5 and 6 points of issue are hard to implement , so I didn't touched them.