### PR TITLE
Unify storage engine logs

### DIFF
--- a/pkg/local_object_storage/blobstor/delete_big.go
+++ b/pkg/local_object_storage/blobstor/delete_big.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
+	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 )
 
 // DeleteBigPrm groups the parameters of DeleteBig operation.
@@ -25,6 +26,10 @@ func (b *BlobStor) DeleteBig(prm *DeleteBigPrm) (*DeleteBigRes, error) {
 	err := b.fsTree.Delete(prm.addr)
 	if errors.Is(err, fstree.ErrFileNotFound) {
 		err = object.ErrNotFound
+	}
+
+	if err == nil {
+		storagelog.Write(b.log, storagelog.AddressField(prm.addr), storagelog.OpField("fstree DELETE"))
 	}
 
 	return nil, err

--- a/pkg/local_object_storage/blobstor/put.go
+++ b/pkg/local_object_storage/blobstor/put.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 )
 
 // PutPrm groups the parameters of Put operation.
@@ -43,7 +44,14 @@ func (b *BlobStor) PutRaw(addr *objectSDK.Address, data []byte) (*PutRes, error)
 
 	if big {
 		// save object in shallow dir
-		return new(PutRes), b.fsTree.Put(addr, data)
+		err := b.fsTree.Put(addr, data)
+		if err != nil {
+			return nil, err
+		}
+
+		storagelog.Write(b.log, storagelog.AddressField(addr), storagelog.OpField("fstree PUT"))
+
+		return new(PutRes), nil
 	}
 
 	// save object in blobovnicza

--- a/pkg/local_object_storage/internal/log/log.go
+++ b/pkg/local_object_storage/internal/log/log.go
@@ -1,0 +1,26 @@
+package storagelog
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	"go.uber.org/zap"
+)
+
+// a distinctive part of all messages
+const headMsg = "local object storage operation"
+
+// Write writes message about storage engine's operation to logger.
+func Write(logger *logger.Logger, fields ...zap.Field) {
+	logger.Info(headMsg, fields...)
+}
+
+// AddressField returns logger's field for object address.
+//
+// Address should be type of *object.Address or string.
+func AddressField(addr interface{}) zap.Field {
+	return zap.Any("address", addr)
+}
+
+// AddressField returns logger's field for operation type.
+func OpField(op string) zap.Field {
+	return zap.String("op", op)
+}

--- a/pkg/local_object_storage/writecache/options.go
+++ b/pkg/local_object_storage/writecache/options.go
@@ -31,7 +31,7 @@ type options struct {
 // WithLogger sets logger.
 func WithLogger(log *zap.Logger) Option {
 	return func(o *options) {
-		o.log = log
+		o.log = log.With(zap.String("component", "WriteCache"))
 	}
 }
 

--- a/pkg/local_object_storage/writecache/put.go
+++ b/pkg/local_object_storage/writecache/put.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 )
 
 // ErrBigObject is returned when object is too big to be placed in cache.
@@ -34,6 +35,9 @@ func (c *cache) Put(o *object.Object) error {
 		c.mem = append(c.mem, oi)
 
 		c.mtx.Unlock()
+
+		storagelog.Write(c.log, storagelog.AddressField(oi.addr), storagelog.OpField("in-mem PUT"))
+
 		return nil
 	}
 

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -10,6 +10,7 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
+	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
@@ -109,6 +110,7 @@ func (c *cache) deleteFromDB(keys [][]byte) error {
 				return err
 			}
 			sz += uint64(len(has))
+			storagelog.Write(c.log, storagelog.AddressField(string(keys[i])), storagelog.OpField("db DELETE"))
 		}
 		return nil
 	})
@@ -135,6 +137,8 @@ func (c *cache) deleteFromDisk(keys [][]byte) error {
 			lastErr = err
 			c.log.Error("can't remove object from write-cache", zap.Error(err))
 			continue
+		} else if err == nil {
+			storagelog.Write(c.log, storagelog.AddressField(string(keys[i])), storagelog.OpField("fstree DELETE"))
 		}
 	}
 


### PR DESCRIPTION
Closes #790.

Unified message head is hard-coded to `local object storage operation`. Log level is hard-coded to `Info`.