### PR TITLE
Fix/Add options to netmap wrapper constructor

### DIFF
--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -434,7 +434,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper) (*Server, error
 		return nil, err
 	}
 
-	server.netmapClient, err = nmWrapper.NewFromMorph(server.morphClient, server.contracts.netmap, fee, client.TryNotary(), client.AsAlphabet())
+	server.netmapClient, err = nmWrapper.NewFromMorph(server.morphClient, server.contracts.netmap, fee, nmWrapper.TryNotary(), nmWrapper.AsAlphabet())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/innerring/notary.go
+++ b/pkg/innerring/notary.go
@@ -67,7 +67,7 @@ func awaitNotaryDepositInClient(ctx context.Context, cli *client.Client, txHash 
 			return errDepositFail
 		}
 
-		cli.Wait(ctx, 1)
+		_ = cli.Wait(ctx, 1)
 	}
 
 	return errDepositTimeout

--- a/pkg/morph/client/balance/wrapper/wrapper.go
+++ b/pkg/morph/client/balance/wrapper/wrapper.go
@@ -23,7 +23,7 @@ type Wrapper struct {
 }
 
 // Option allows to set an optional
-// parameter of ClientWrapper.
+// parameter of Wrapper.
 type Option func(*opts)
 
 type opts []client.StaticClientOption

--- a/pkg/morph/client/container/wrapper/wrapper.go
+++ b/pkg/morph/client/container/wrapper/wrapper.go
@@ -22,7 +22,7 @@ type Wrapper struct {
 }
 
 // Option allows to set an optional
-// parameter of ClientWrapper.
+// parameter of Wrapper.
 type Option func(*opts)
 
 type opts []client.StaticClientOption


### PR DESCRIPTION
Closes #793.

Also fixes `errcheck` linter warning and adds `AsAlphabet` option.