### PR TITLE
Feat/Add notary notification for container contract

### DIFF
--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -41,7 +41,14 @@ const (
 )
 
 func initContainerService(c *cfg) {
+	// container wrapper that tries to invoke notary
+	// requests if chain is configured so
 	wrap, err := wrapper.NewFromMorph(c.cfgMorph.client, c.cfgContainer.scriptHash, 0, wrapper.TryNotary())
+	fatalOnErr(err)
+
+	// container wrapper that always sends non-notary
+	// requests
+	wrapperNoNotary, err := wrapper.NewFromMorph(c.cfgMorph.client, c.cfgContainer.scriptHash, 0)
 	fatalOnErr(err)
 
 	cnrSrc := wrapper.AsContainerSource(wrap)
@@ -76,7 +83,7 @@ func initContainerService(c *cfg) {
 
 	resultWriter := &morphLoadWriter{
 		log:            c.log,
-		cnrMorphClient: wrap,
+		cnrMorphClient: wrapperNoNotary,
 		key:            pubKey,
 	}
 

--- a/pkg/innerring/bindings.go
+++ b/pkg/innerring/bindings.go
@@ -10,41 +10,31 @@ type (
 	ContractProcessor interface {
 		ListenerNotificationParsers() []event.NotificationParserInfo
 		ListenerNotificationHandlers() []event.NotificationHandlerInfo
-		TimersHandlers() []event.NotificationHandlerInfo
-	}
-
-	// NotaryContractProcessor interface defines function for binding notary event
-	// producers such as event.Listener with contract processor.
-	//
-	// This interface is optional for contract processor. If contract processor
-	// supports notary event handling, it should implement both ContractProcessor
-	// and NotaryContractProcessor interfaces.
-	NotaryContractProcessor interface {
 		ListenerNotaryParsers() []event.NotaryParserInfo
 		ListenerNotaryHandlers() []event.NotaryHandlerInfo
+		TimersHandlers() []event.NotificationHandlerInfo
 	}
 )
 
 func connectListenerWithProcessor(l event.Listener, p ContractProcessor) {
-	// register parsers
+	// register notification parsers
 	for _, parser := range p.ListenerNotificationParsers() {
 		l.SetNotificationParser(parser)
 	}
 
-	// register handlers
+	// register notification handlers
 	for _, handler := range p.ListenerNotificationHandlers() {
 		l.RegisterNotificationHandler(handler)
 	}
 
-	// add notary handlers if processor supports it
-	if notaryProcessor, ok := p.(NotaryContractProcessor); ok {
-		for _, notaryParser := range notaryProcessor.ListenerNotaryParsers() {
-			l.SetNotaryParser(notaryParser)
-		}
+	// register notary parsers
+	for _, notaryParser := range p.ListenerNotaryParsers() {
+		l.SetNotaryParser(notaryParser)
+	}
 
-		for _, notaryHandler := range notaryProcessor.ListenerNotaryHandlers() {
-			l.RegisterNotaryHandler(notaryHandler)
-		}
+	// register notary handlers
+	for _, notaryHandler := range p.ListenerNotaryHandlers() {
+		l.RegisterNotaryHandler(notaryHandler)
 	}
 }
 

--- a/pkg/innerring/processors/alphabet/handlers.go
+++ b/pkg/innerring/processors/alphabet/handlers.go
@@ -6,16 +6,16 @@ import (
 	"go.uber.org/zap"
 )
 
-func (np *Processor) HandleGasEmission(ev event.Event) {
+func (ap *Processor) HandleGasEmission(ev event.Event) {
 	_ = ev.(timers.NewAlphabetEmitTick)
-	np.log.Info("tick", zap.String("type", "alphabet gas emit"))
+	ap.log.Info("tick", zap.String("type", "alphabet gas emit"))
 
 	// send event to the worker pool
 
-	err := np.pool.Submit(func() { np.processEmit() })
+	err := ap.pool.Submit(func() { ap.processEmit() })
 	if err != nil {
 		// there system can be moved into controlled degradation stage
-		np.log.Warn("alphabet processor worker pool drained",
-			zap.Int("capacity", np.pool.Cap()))
+		ap.log.Warn("alphabet processor worker pool drained",
+			zap.Int("capacity", ap.pool.Cap()))
 	}
 }

--- a/pkg/innerring/processors/alphabet/process_emit.go
+++ b/pkg/innerring/processors/alphabet/process_emit.go
@@ -10,39 +10,39 @@ import (
 
 const emitMethod = "emit"
 
-func (np *Processor) processEmit() {
-	index := np.irList.AlphabetIndex()
+func (ap *Processor) processEmit() {
+	index := ap.irList.AlphabetIndex()
 	if index < 0 {
-		np.log.Info("non alphabet mode, ignore gas emission event")
+		ap.log.Info("non alphabet mode, ignore gas emission event")
 
 		return
 	}
 
-	contract, ok := np.alphabetContracts.GetByIndex(index)
+	contract, ok := ap.alphabetContracts.GetByIndex(index)
 	if !ok {
-		np.log.Debug("node is out of alphabet range, ignore gas emission event",
+		ap.log.Debug("node is out of alphabet range, ignore gas emission event",
 			zap.Int("index", index))
 
 		return
 	}
 
 	// there is no signature collecting, so we don't need extra fee
-	err := np.morphClient.Invoke(contract, 0, emitMethod)
+	err := ap.morphClient.Invoke(contract, 0, emitMethod)
 	if err != nil {
-		np.log.Warn("can't invoke alphabet emit method")
+		ap.log.Warn("can't invoke alphabet emit method")
 
 		return
 	}
 
-	if np.storageEmission == 0 {
-		np.log.Info("storage node emission is off")
+	if ap.storageEmission == 0 {
+		ap.log.Info("storage node emission is off")
 
 		return
 	}
 
-	networkMap, err := np.netmapClient.Snapshot()
+	networkMap, err := ap.netmapClient.Snapshot()
 	if err != nil {
-		np.log.Warn("can't get netmap snapshot to emit gas to storage nodes",
+		ap.log.Warn("can't get netmap snapshot to emit gas to storage nodes",
 			zap.String("error", err.Error()))
 
 		return
@@ -50,27 +50,27 @@ func (np *Processor) processEmit() {
 
 	ln := len(networkMap.Nodes)
 	if ln == 0 {
-		np.log.Debug("empty network map, do not emit gas")
+		ap.log.Debug("empty network map, do not emit gas")
 
 		return
 	}
 
-	gasPerNode := fixedn.Fixed8(np.storageEmission / uint64(ln))
+	gasPerNode := fixedn.Fixed8(ap.storageEmission / uint64(ln))
 
 	for i := range networkMap.Nodes {
 		keyBytes := networkMap.Nodes[i].PublicKey()
 
 		key, err := keys.NewPublicKeyFromBytes(keyBytes, elliptic.P256())
 		if err != nil {
-			np.log.Warn("can't convert node public key to address",
+			ap.log.Warn("can't convert node public key to address",
 				zap.String("error", err.Error()))
 
 			continue
 		}
 
-		err = np.morphClient.TransferGas(key.GetScriptHash(), gasPerNode)
+		err = ap.morphClient.TransferGas(key.GetScriptHash(), gasPerNode)
 		if err != nil {
-			np.log.Warn("can't transfer gas",
+			ap.log.Warn("can't transfer gas",
 				zap.String("receiver", key.Address()),
 				zap.Int64("amount", int64(gasPerNode)),
 				zap.String("error", err.Error()),

--- a/pkg/innerring/processors/alphabet/processor.go
+++ b/pkg/innerring/processors/alphabet/processor.go
@@ -83,16 +83,26 @@ func New(p *Params) (*Processor, error) {
 }
 
 // ListenerNotificationParsers for the 'event.Listener' event producer.
-func (np *Processor) ListenerNotificationParsers() []event.NotificationParserInfo {
+func (ap *Processor) ListenerNotificationParsers() []event.NotificationParserInfo {
 	return nil
 }
 
 // ListenerNotificationHandlers for the 'event.Listener' event producer.
-func (np *Processor) ListenerNotificationHandlers() []event.NotificationHandlerInfo {
+func (ap *Processor) ListenerNotificationHandlers() []event.NotificationHandlerInfo {
+	return nil
+}
+
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (ap *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (ap *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
 	return nil
 }
 
 // TimersHandlers for the 'Timers' event producer.
-func (np *Processor) TimersHandlers() []event.NotificationHandlerInfo {
+func (ap *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil
 }

--- a/pkg/innerring/processors/balance/processor.go
+++ b/pkg/innerring/processors/balance/processor.go
@@ -104,6 +104,16 @@ func (bp *Processor) ListenerNotificationHandlers() []event.NotificationHandlerI
 	return handlers
 }
 
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (bp *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (bp *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
+	return nil
+}
+
 // TimersHandlers for the 'Timers' event producer.
 func (bp *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil

--- a/pkg/innerring/processors/container/processor.go
+++ b/pkg/innerring/processors/container/processor.go
@@ -181,6 +181,11 @@ func (cp *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
 	p.SetParser(containerEvent.ParseDeleteNotary)
 	pp = append(pp, p)
 
+	// set EACL
+	p.SetRequestType(containerEvent.SetEACLNotaryEvent)
+	p.SetParser(containerEvent.ParseSetEACLNotary)
+	pp = append(pp, p)
+
 	return pp
 }
 
@@ -203,6 +208,11 @@ func (cp *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
 	// container delete
 	h.SetRequestType(containerEvent.DeleteNotaryEvent)
 	h.SetHandler(cp.handleDelete)
+	hh = append(hh, h)
+
+	// set eACL
+	h.SetRequestType(containerEvent.SetEACLNotaryEvent)
+	h.SetHandler(cp.handleSetEACL)
 	hh = append(hh, h)
 
 	return hh

--- a/pkg/innerring/processors/governance/processor.go
+++ b/pkg/innerring/processors/governance/processor.go
@@ -146,6 +146,16 @@ func (gp *Processor) ListenerNotificationHandlers() []event.NotificationHandlerI
 	return []event.NotificationHandlerInfo{hi}
 }
 
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (gp *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (gp *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
+	return nil
+}
+
 // TimersHandlers for the 'Timers' event producer.
 func (gp *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil

--- a/pkg/innerring/processors/neofs/processor.go
+++ b/pkg/innerring/processors/neofs/processor.go
@@ -215,6 +215,16 @@ func (np *Processor) ListenerNotificationHandlers() []event.NotificationHandlerI
 	return handlers
 }
 
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (np *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (np *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
+	return nil
+}
+
 // TimersHandlers for the 'Timers' event producer.
 func (np *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -202,6 +202,16 @@ func (np *Processor) ListenerNotificationHandlers() []event.NotificationHandlerI
 	return handlers
 }
 
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (np *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (np *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
+	return nil
+}
+
 // TimersHandlers for the 'Timers' event producer.
 func (np *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil

--- a/pkg/innerring/processors/reputation/processor.go
+++ b/pkg/innerring/processors/reputation/processor.go
@@ -116,6 +116,16 @@ func (rp *Processor) ListenerNotificationHandlers() []event.NotificationHandlerI
 	return handlers
 }
 
+// ListenerNotaryParsers for the 'event.Listener' event producer.
+func (rp *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
+	return nil
+}
+
+// ListenerNotaryHandlers for the 'event.Listener' event producer.
+func (rp *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
+	return nil
+}
+
 // TimersHandlers for the 'Timers' event producer.
 func (rp *Processor) TimersHandlers() []event.NotificationHandlerInfo {
 	return nil

--- a/pkg/morph/event/container/delete_notary.go
+++ b/pkg/morph/event/container/delete_notary.go
@@ -1,0 +1,70 @@
+package container
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+)
+
+func (d *Delete) setContainerID(v []byte) {
+	if v != nil {
+		d.containerID = v
+	}
+}
+
+func (d *Delete) setSignature(v []byte) {
+	if v != nil {
+		d.signature = v
+	}
+}
+
+func (d *Delete) setToken(v []byte) {
+	if v != nil {
+		d.token = v
+	}
+}
+
+var deleteFieldSetters = []func(*Delete, []byte){
+	// order on stack is reversed
+	(*Delete).setToken,
+	(*Delete).setSignature,
+	(*Delete).setContainerID,
+}
+
+const (
+	// DeleteNotaryEvent is method name for container delete operations
+	// in `Container` contract. Is used as identificator for notary
+	// delete container requests.
+	DeleteNotaryEvent = "delete"
+)
+
+// ParseDeleteNotary from NotaryEvent into container event structure.
+func ParseDeleteNotary(ne event.NotaryEvent) (event.Event, error) {
+	var (
+		ev        Delete
+		currentOp opcode.Opcode
+	)
+
+	fieldNum := 0
+
+	for _, op := range ne.Params() {
+		currentOp = op.Code()
+
+		switch {
+		case opcode.PUSHDATA1 <= currentOp && currentOp <= opcode.PUSHDATA4:
+			if fieldNum == expectedItemNumDelete {
+				return nil, event.UnexpectedArgNumErr(DeleteNotaryEvent)
+			}
+
+			deleteFieldSetters[fieldNum](&ev, op.Param())
+			fieldNum++
+		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
+			// array packing opcodes. do nothing with it
+		default:
+			return nil, event.UnexpectedOpcode(DeleteNotaryEvent, op.Code())
+		}
+	}
+
+	ev.notaryRequest = ne.Raw()
+
+	return ev, nil
+}

--- a/pkg/morph/event/container/eacl_notary.go
+++ b/pkg/morph/event/container/eacl_notary.go
@@ -1,0 +1,77 @@
+package container
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+)
+
+func (x *SetEACL) setTable(v []byte) {
+	if v != nil {
+		x.table = v
+	}
+}
+
+func (x *SetEACL) setSignature(v []byte) {
+	if v != nil {
+		x.signature = v
+	}
+}
+
+func (x *SetEACL) setPublicKey(v []byte) {
+	if v != nil {
+		x.publicKey = v
+	}
+}
+
+func (x *SetEACL) setToken(v []byte) {
+	if v != nil {
+		x.token = v
+	}
+}
+
+var setEACLFieldSetters = []func(*SetEACL, []byte){
+	// order on stack is reversed
+	(*SetEACL).setToken,
+	(*SetEACL).setPublicKey,
+	(*SetEACL).setSignature,
+	(*SetEACL).setTable,
+}
+
+const (
+	// SetEACLNotaryEvent is method name for container EACL operations
+	// in `Container` contract. Is used as identificator for notary
+	// EACL changing requests.
+	SetEACLNotaryEvent = "setEACL"
+)
+
+// ParseSetEACLNotary from NotaryEvent into container event structure.
+func ParseSetEACLNotary(ne event.NotaryEvent) (event.Event, error) {
+	var (
+		ev        SetEACL
+		currentOp opcode.Opcode
+	)
+
+	fieldNum := 0
+
+	for _, op := range ne.Params() {
+		currentOp = op.Code()
+
+		switch {
+		case opcode.PUSHDATA1 <= currentOp && currentOp <= opcode.PUSHDATA4:
+			if fieldNum == expectedItemNumEACL {
+				return nil, event.UnexpectedArgNumErr(SetEACLNotaryEvent)
+			}
+
+			setEACLFieldSetters[fieldNum](&ev, op.Param())
+			fieldNum++
+		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
+			// array packing opcodes. do nothing with it
+		default:
+			return nil, event.UnexpectedOpcode(SetEACLNotaryEvent, op.Code())
+		}
+	}
+
+	ev.notaryRequest = ne.Raw()
+
+	return ev, nil
+}

--- a/pkg/morph/event/container/put_notary.go
+++ b/pkg/morph/event/container/put_notary.go
@@ -1,8 +1,6 @@
 package container
 
 import (
-	"fmt"
-
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -31,7 +29,7 @@ func (p *Put) setToken(v []byte) {
 	}
 }
 
-var fieldSetters = []func(*Put, []byte){
+var putFieldSetters = []func(*Put, []byte){
 	// order on stack is reversed
 	(*Put).setToken,
 	(*Put).setPublicKey,
@@ -45,8 +43,6 @@ const (
 	// put container requests.
 	PutNotaryEvent = "put"
 )
-
-var errUnexpectedArgumentAmount = fmt.Errorf("unexpected arguments amount in %s call", PutNotaryEvent)
 
 // ParsePutNotary from NotaryEvent into container event structure.
 func ParsePutNotary(ne event.NotaryEvent) (event.Event, error) {
@@ -63,10 +59,10 @@ func ParsePutNotary(ne event.NotaryEvent) (event.Event, error) {
 		switch {
 		case opcode.PUSHDATA1 <= currentOp && currentOp <= opcode.PUSHDATA4:
 			if fieldNum == expectedItemNumPut {
-				return nil, errUnexpectedArgumentAmount
+				return nil, event.UnexpectedArgNumErr(PutNotaryEvent)
 			}
 
-			fieldSetters[fieldNum](&ev, op.Param())
+			putFieldSetters[fieldNum](&ev, op.Param())
 			fieldNum++
 		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
 			// array packing opcodes. do nothing with it

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -368,6 +368,11 @@ func (l listener) parseAndHandleNotary(nr *response.NotaryRequestEvent) {
 		return
 	}
 
+	log := l.log.With(
+		zap.String("contract", notaryEvent.ScriptHash().StringLE()),
+		zap.Stringer("method", notaryEvent.Type()),
+	)
+
 	notaryKey := notaryRequestTypes{}
 	notaryKey.SetMempoolType(nr.Type)
 	notaryKey.SetRequestType(notaryEvent.Type())
@@ -379,7 +384,7 @@ func (l listener) parseAndHandleNotary(nr *response.NotaryRequestEvent) {
 	l.mtx.RUnlock()
 
 	if !ok {
-		l.log.Debug("notary parser not set")
+		log.Debug("notary parser not set")
 
 		return
 	}
@@ -387,7 +392,7 @@ func (l listener) parseAndHandleNotary(nr *response.NotaryRequestEvent) {
 	// parse the notary event
 	event, err := parser(notaryEvent)
 	if err != nil {
-		l.log.Warn("could not parse notary event",
+		log.Warn("could not parse notary event",
 			zap.String("error", err.Error()),
 		)
 
@@ -400,7 +405,7 @@ func (l listener) parseAndHandleNotary(nr *response.NotaryRequestEvent) {
 	l.mtx.RUnlock()
 
 	if !ok {
-		l.log.Info("notary handlers for parsed notification event were not registered",
+		log.Info("notary handlers for parsed notification event were not registered",
 			zap.Any("event", event),
 		)
 
@@ -416,8 +421,8 @@ func (l listener) parseAndHandleNotary(nr *response.NotaryRequestEvent) {
 // Ignores the parser if listener is started.
 func (l listener) SetNotificationParser(pi NotificationParserInfo) {
 	log := l.log.With(
-		zap.String("script hash LE", pi.ScriptHash().StringLE()),
-		zap.Stringer("event type", pi.getType()),
+		zap.String("contract", pi.ScriptHash().StringLE()),
+		zap.Stringer("event_type", pi.getType()),
 	)
 
 	parser := pi.parser()
@@ -449,8 +454,8 @@ func (l listener) SetNotificationParser(pi NotificationParserInfo) {
 // Ignores handlers of event without parser.
 func (l listener) RegisterNotificationHandler(hi NotificationHandlerInfo) {
 	log := l.log.With(
-		zap.String("script hash LE", hi.ScriptHash().StringLE()),
-		zap.Stringer("event type", hi.GetType()),
+		zap.String("contract", hi.ScriptHash().StringLE()),
+		zap.Stringer("event_type", hi.GetType()),
 	)
 
 	handler := hi.Handler()
@@ -512,7 +517,7 @@ func (l listener) SetNotaryParser(pi NotaryParserInfo) {
 
 	log := l.log.With(
 		zap.Stringer("mempool_type", pi.GetMempoolType()),
-		zap.Stringer("script_hash", pi.ScriptHash()),
+		zap.String("contract", pi.ScriptHash().StringLE()),
 		zap.Stringer("notary_type", pi.RequestType()),
 	)
 
@@ -549,8 +554,8 @@ func (l listener) RegisterNotaryHandler(hi NotaryHandlerInfo) {
 	}
 
 	log := l.log.With(
-		zap.Stringer("mempool type", hi.GetMempoolType()),
-		zap.Stringer("script_hash", hi.ScriptHash()),
+		zap.Stringer("mempool_type", hi.GetMempoolType()),
+		zap.String("contract", hi.ScriptHash().StringLE()),
 		zap.Stringer("notary type", hi.RequestType()),
 	)
 

--- a/pkg/morph/event/notary.go
+++ b/pkg/morph/event/notary.go
@@ -43,6 +43,12 @@ func NotaryTypeFromString(str string) NotaryType {
 	return NotaryType(str)
 }
 
+// UnexpectedArgNumErr returns error when notary parsers
+// get unexpected amount of argument in contract call.
+func UnexpectedArgNumErr(method string) error {
+	return fmt.Errorf("unexpected arguments amount in %s call", method)
+}
+
 // UnexpectedOpcode returns error when notary parsers
 // get unexpected opcode in contract call.
 func UnexpectedOpcode(method string, op opcode.Opcode) error {

--- a/pkg/morph/event/notary.go
+++ b/pkg/morph/event/notary.go
@@ -1,8 +1,11 @@
 package event
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
 )
 
 // NotaryType is a notary event enumeration type.
@@ -38,4 +41,10 @@ func NotaryTypeFromBytes(data []byte) NotaryType {
 // NotaryTypeFromString converts string to NotaryType.
 func NotaryTypeFromString(str string) NotaryType {
 	return NotaryType(str)
+}
+
+// UnexpectedOpcode returns error when notary parsers
+// get unexpected opcode in contract call.
+func UnexpectedOpcode(method string, op opcode.Opcode) error {
+	return fmt.Errorf("unexpected opcode in %s call: %s", method, op)
 }


### PR DESCRIPTION
Closes #731.

Also: 
- merges `ContractProcessor` and `NotaryContractProcessor` interfaces;
- adds notary notification support for `delete` container operation;
- improves logging in notary listener;
- refactors binding processors and parsers/handlers.

Merge after #814.