### PR TITLE
Fix/Cut `PACK` opcodes in notaryPreparator

### DIFF
--- a/pkg/morph/event/container/delete_notary.go
+++ b/pkg/morph/event/container/delete_notary.go
@@ -57,8 +57,6 @@ func ParseDeleteNotary(ne event.NotaryEvent) (event.Event, error) {
 
 			deleteFieldSetters[fieldNum](&ev, op.Param())
 			fieldNum++
-		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
-			// array packing opcodes. do nothing with it
 		default:
 			return nil, event.UnexpectedOpcode(DeleteNotaryEvent, op.Code())
 		}

--- a/pkg/morph/event/container/eacl_notary.go
+++ b/pkg/morph/event/container/eacl_notary.go
@@ -64,8 +64,6 @@ func ParseSetEACLNotary(ne event.NotaryEvent) (event.Event, error) {
 
 			setEACLFieldSetters[fieldNum](&ev, op.Param())
 			fieldNum++
-		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
-			// array packing opcodes. do nothing with it
 		default:
 			return nil, event.UnexpectedOpcode(SetEACLNotaryEvent, op.Code())
 		}

--- a/pkg/morph/event/container/put_notary.go
+++ b/pkg/morph/event/container/put_notary.go
@@ -64,8 +64,6 @@ func ParsePutNotary(ne event.NotaryEvent) (event.Event, error) {
 
 			putFieldSetters[fieldNum](&ev, op.Param())
 			fieldNum++
-		case opcode.PUSH0 <= currentOp && currentOp <= opcode.PUSH16 || currentOp == opcode.PACK:
-			// array packing opcodes. do nothing with it
 		default:
 			return nil, event.UnexpectedOpcode(PutNotaryEvent, op.Code())
 		}

--- a/pkg/morph/event/notary_preparator_test.go
+++ b/pkg/morph/event/notary_preparator_test.go
@@ -1,0 +1,157 @@
+package event
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/interop/interopnames"
+	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/hash"
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/network/payload"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	alphaKeys keys.PublicKeys
+
+	dummyInvocationScript = append([]byte{byte(opcode.PUSHDATA1), 64}, make([]byte, 64)...)
+	contractSysCall       = make([]byte, 4)
+
+	scriptHash util.Uint160
+)
+
+func init() {
+	privat, _ := keys.NewPrivateKey()
+	pub := privat.PublicKey()
+
+	alphaKeys = keys.PublicKeys{pub}
+
+	binary.LittleEndian.PutUint32(contractSysCall, interopnames.ToID([]byte(interopnames.SystemContractCall)))
+
+	scriptHash, _ = util.Uint160DecodeStringLE("21fce15191428e9c2f0e8d0329ff6d3dd14882de")
+}
+
+type blockCounter struct {
+	epoch uint32
+	err   error
+}
+
+func (b blockCounter) BlockCount() (res uint32, err error) {
+	return b.epoch, b.err
+}
+
+func TestPrepare_CorrectNR(t *testing.T) {
+	tests := []struct {
+		hash   util.Uint160
+		method string
+		args   []interface{}
+	}{
+		{
+			scriptHash,
+			"test1",
+			nil,
+		},
+		{
+			scriptHash,
+			"test2",
+			[]interface{}{
+				int64(4),
+				"test",
+				[]interface{}{
+					int64(4),
+					false,
+					true,
+				},
+			},
+		},
+	}
+
+	preparator := notaryPreparator(
+		PreparatorPrm{
+			alphaKeysSource(),
+			blockCounter{100, nil},
+		},
+	)
+
+	for _, test := range tests {
+		nr := correctNR(script(test.hash, test.method, test.args...))
+
+		event, err := preparator.Prepare(nr)
+
+		require.NoError(t, err)
+		require.Equal(t, test.method, event.Type().String())
+		require.Equal(t, test.hash.StringLE(), event.ScriptHash().StringLE())
+	}
+}
+
+func alphaKeysSource() client.AlphabetKeys {
+	return func() (keys.PublicKeys, error) {
+		return alphaKeys, nil
+	}
+}
+
+func script(hash util.Uint160, method string, args ...interface{}) []byte {
+	bw := io.NewBufBinWriter()
+
+	if len(args) > 0 {
+		emit.AppCall(bw.BinWriter, hash, method, callflag.All, args)
+	} else {
+		emit.AppCallNoArgs(bw.BinWriter, hash, method, callflag.All)
+	}
+
+	return bw.Bytes()
+}
+
+func correctNR(script []byte) *payload.P2PNotaryRequest {
+	alphaVerificationScript, _ := smartcontract.CreateMultiSigRedeemScript(len(alphaKeys)*2/3+1, alphaKeys)
+
+	return &payload.P2PNotaryRequest{
+		MainTransaction: &transaction.Transaction{
+			Signers: []transaction.Signer{
+				{},
+				{
+					Account: hash.Hash160(alphaVerificationScript),
+				},
+				{},
+			},
+			Scripts: []transaction.Witness{
+				{},
+				{
+					InvocationScript:   dummyInvocationScript,
+					VerificationScript: alphaVerificationScript,
+				},
+				{
+					InvocationScript: dummyInvocationScript,
+				},
+			},
+			Attributes: []transaction.Attribute{
+				{
+					Value: &transaction.NotaryAssisted{
+						NKeys: uint8(len(alphaKeys)),
+					},
+				},
+			},
+			Script: script,
+		},
+		FallbackTransaction: &transaction.Transaction{
+			Attributes: []transaction.Attribute{
+				{},
+				{
+					Type: transaction.NotValidBeforeT,
+					Value: &transaction.NotValidBefore{
+						Height: 1000,
+					},
+				},
+				{},
+			},
+		},
+	}
+}

--- a/pkg/morph/event/opcodes.go
+++ b/pkg/morph/event/opcodes.go
@@ -1,6 +1,11 @@
 package event
 
-import "github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+import (
+	"fmt"
+
+	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
+	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
+)
 
 // Op is wrapper over Neo VM's opcode
 // and its parameter.
@@ -18,4 +23,28 @@ func (o Op) Code() opcode.Opcode {
 // Neo VM opcode.
 func (o Op) Param() []byte {
 	return o.param
+}
+
+// BytesFromOpcode tries to retrieve bytes from Op.
+func BytesFromOpcode(op Op) ([]byte, error) {
+	switch code := op.Code(); code {
+	case opcode.PUSHDATA1, opcode.PUSHDATA2, opcode.PUSHDATA4:
+		return op.Param(), nil
+	default:
+		return nil, fmt.Errorf("unexpected ByteArray opcode %s", code)
+	}
+}
+
+// IntFromOpcode tries to retrieve bytes from Op.
+func IntFromOpcode(op Op) (int64, error) {
+	switch code := op.Code(); {
+	case code == opcode.PUSHM1:
+		return -1, nil
+	case code >= opcode.PUSH0 && code <= opcode.PUSH16:
+		return int64(code - opcode.PUSH0), nil
+	case code <= opcode.PUSHINT256:
+		return bigint.FromBytes(op.Param()).Int64(), nil
+	default:
+		return 0, fmt.Errorf("unexpected INT opcode %s", code)
+	}
 }

--- a/pkg/morph/event/opcodes_test.go
+++ b/pkg/morph/event/opcodes_test.go
@@ -1,0 +1,82 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesFromOpcode(t *testing.T) {
+	tests := [...][]byte{
+		[]byte("test"),
+		[]byte("test test"),
+		[]byte(""),
+		[]byte("1"),
+	}
+
+	bw := io.NewBufBinWriter()
+
+	for _, test := range tests {
+		emit.Bytes(bw.BinWriter, test)
+	}
+
+	var (
+		ctx = vm.NewContext(bw.Bytes())
+
+		op Op
+
+		gotBytes []byte
+		err      error
+	)
+
+	for _, test := range tests {
+		op = getNextOp(ctx)
+
+		gotBytes, err = BytesFromOpcode(op)
+
+		require.NoError(t, err)
+		require.Equal(t, test, gotBytes)
+	}
+}
+
+func TestIntFromOpcode(t *testing.T) {
+	tests := [...]int64{
+		-1,
+		-5,
+		15,
+		16,
+		1_000_000,
+	}
+
+	bw := io.NewBufBinWriter()
+
+	for _, test := range tests {
+		emit.Int(bw.BinWriter, test)
+	}
+
+	var (
+		ctx = vm.NewContext(bw.Bytes())
+
+		op Op
+
+		gotInt int64
+		err    error
+	)
+
+	for _, test := range tests {
+		op = getNextOp(ctx)
+
+		gotInt, err = IntFromOpcode(op)
+
+		require.NoError(t, err)
+		require.Equal(t, test, gotInt)
+	}
+}
+
+func getNextOp(ctx *vm.Context) (op Op) {
+	op.code, op.param, _ = ctx.Next()
+	return
+}


### PR DESCRIPTION
Do not pass high-level `PACK` opcode to notary parsers. Also add unit test for correct NR preparing by `NotaryPreparator`