### PR TITLE
Feature/Add `WithSingleClient` client constructor option

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -54,6 +54,16 @@ type singleClient struct {
 	notary *notary
 }
 
+func blankSingleClient(cli *client.Client, w *wallet.Account, cfg *cfg) *singleClient {
+	return &singleClient{
+		logger:       cfg.logger,
+		client:       cli,
+		acc:          w,
+		waitInterval: cfg.waitInterval,
+		signer:       cfg.signer,
+	}
+}
+
 // ErrNilClient is returned by functions that expect
 // a non-nil Client pointer, but received nil.
 var ErrNilClient = errors.New("client is nil")

--- a/pkg/morph/client/multi.go
+++ b/pkg/morph/client/multi.go
@@ -36,15 +36,11 @@ func (x *multiClient) createForAddress(addr string) (*Client, error) {
 		return nil, err
 	}
 
+	sCli := blankSingleClient(cli, x.account, &x.cfg)
+	sCli.notary = x.sharedNotary
+
 	c := &Client{
-		singleClient: &singleClient{
-			logger:       x.cfg.logger,
-			client:       cli,
-			acc:          x.account,
-			waitInterval: x.cfg.waitInterval,
-			signer:       x.cfg.signer,
-			notary:       x.sharedNotary,
-		},
+		singleClient: sCli,
 	}
 
 	x.clients[addr] = c


### PR DESCRIPTION
`WithSingleClient` allows Morph client creation with existing raw neo-go client.

Can be used for applications that use more than one `Morph` client and do not want to create multiple neo-go clients.