### PR TITLE
service/object: Do not use request forwarding when assembling object

### DIFF
--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -12,7 +12,11 @@ func (exec *execCtx) assemble() {
 		return
 	}
 
-	exec.assembling = true
+	// do not use forwarding during assembly stage
+	// assembly flag is not inherited in produced
+	// `execCtx`, however `commonPrm` does, so it
+	// makes sense to nil it there
+	exec.prm.SetRequestForwarder(nil)
 
 	exec.log.Debug("trying to assemble the object...")
 

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -12,11 +12,10 @@ func (exec *execCtx) assemble() {
 		return
 	}
 
-	// do not use forwarding during assembly stage
-	// assembly flag is not inherited in produced
-	// `execCtx`, however `commonPrm` does, so it
-	// makes sense to nil it there
-	exec.prm.SetRequestForwarder(nil)
+	// Do not use forwarding during assembly stage.
+	// Request forwarding closure inherited in produced
+	// `execCtx` so it should be disabled there.
+	exec.disableForwarding()
 
 	exec.log.Debug("trying to assemble the object...")
 

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -41,12 +41,6 @@ type execCtx struct {
 	head bool
 
 	curProcEpoch uint64
-
-	// true when the processing of the initial request
-	// is turned to assembling stage. When false,
-	// initial request can be forwarded during network
-	// communication.
-	assembling bool
 }
 
 type execOption func(*execCtx)

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -347,3 +347,15 @@ func (exec *execCtx) writeCollectedObject() {
 		exec.writeObjectPayload(exec.collectedObject)
 	}
 }
+
+// isForwardingEnabled returns true if common execution
+// parameters has request forwarding closure set.
+func (exec execCtx) isForwardingEnabled() bool {
+	return exec.prm.forwarder != nil
+}
+
+// disableForwarding removes request forwarding closure from common
+// parameters, so it won't be inherited in new execution contexts.
+func (exec *execCtx) disableForwarding() {
+	exec.prm.SetRequestForwarder(nil)
+}

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -82,7 +82,7 @@ func (c *clientCacheWrapper) get(addr network.AddressGroup) (getClient, error) {
 }
 
 func (c *clientWrapper) getObject(exec *execCtx, addr network.AddressGroup) (*objectSDK.Object, error) {
-	if exec.prm.forwarder != nil {
+	if exec.isForwardingEnabled() {
 		return exec.prm.forwarder(addr, c.client)
 	}
 

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -82,7 +82,7 @@ func (c *clientCacheWrapper) get(addr network.AddressGroup) (getClient, error) {
 }
 
 func (c *clientWrapper) getObject(exec *execCtx, addr network.AddressGroup) (*objectSDK.Object, error) {
-	if !exec.assembling && exec.prm.forwarder != nil {
+	if exec.prm.forwarder != nil {
 		return exec.prm.forwarder(addr, c.client)
 	}
 


### PR DESCRIPTION
Forwarding mechanism resends original request. During split object chain traversal, storage node performs multiple object.Head requests on each child. If request forwarding happens, then object.Head returns object ID of the original request. This produces infinite assembly loop.

---

This reproduced when storage node has only most right child. It tries to build the chain by using `headChild` function for all children in the chain. The problem is with `err := exec.svc.Head(exec.context(), prm)` function there. This function creates new execution context which has unset assembly flag by default. However forwarder is not nil, thanks to common parameters there. 

The fun part if you go deeper and try to add panic in `processNode`:
```go
func (exec *execCtx) processNode(ctx context.Context, addr network.AddressGroup) bool {
	obj, err := client.getObject(exec, addr)

	switch {
	case err == nil:
		exec.status = statusOK
		exec.err = nil
		exec.collectedObject = object.NewFromSDK(obj)
		if exec.address().ObjectID().String() != obj.ID().String() { // <- this
			s := fmt.Sprintf(">> @processNode from %s expected %s, got %s", network.StringifyGroup(addr), exec.address(), obj.ID())
			panic(s)
		}
	}
}
```

Almost all request for split objects will produce panic without the fix.