### PR TITLE
[#835] neofs-adm: rename contract update method

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/update.go
+++ b/cmd/neofs-adm/internal/modules/morph/update.go
@@ -13,7 +13,7 @@ func updateContracts(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("initialization error: %w", err)
 	}
 
-	if err := wCtx.deployContracts("migrate"); err != nil {
+	if err := wCtx.deployContracts(updateMethodName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>

Fix #835 .  Checked init + update-contracts, no errors. NNS contract `_deploy` routine should be changed in the next release, for further updates to work.