### PR TITLE
cmd/neofs-node: Don't lose local container size estimations

### DIFF
--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -228,16 +228,6 @@ func (*morphLoadWriter) Close() error {
 	return nil
 }
 
-type nopLoadWriter struct{}
-
-func (nopLoadWriter) Put(containerSDK.UsedSpaceAnnouncement) error {
-	return nil
-}
-
-func (nopLoadWriter) Close() error {
-	return nil
-}
-
 type remoteLoadAnnounceProvider struct {
 	key *ecdsa.PrivateKey
 
@@ -251,13 +241,8 @@ type remoteLoadAnnounceProvider struct {
 }
 
 func (r *remoteLoadAnnounceProvider) InitRemote(srv loadroute.ServerInfo) (loadcontroller.WriterProvider, error) {
-	if srv == nil {
+	if srv == nil || r.netmapKeys.IsLocalKey(srv.PublicKey()) {
 		return r.deadEndProvider, nil
-	}
-
-	if r.netmapKeys.IsLocalKey(srv.PublicKey()) {
-		// if local => return no-op writer
-		return loadcontroller.SimpleWriterProvider(new(nopLoadWriter)), nil
 	}
 
 	var info client.NodeInfo

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -228,6 +228,16 @@ func (*morphLoadWriter) Close() error {
 	return nil
 }
 
+type nopLoadWriter struct{}
+
+func (nopLoadWriter) Put(containerSDK.UsedSpaceAnnouncement) error {
+	return nil
+}
+
+func (nopLoadWriter) Close() error {
+	return nil
+}
+
 type remoteLoadAnnounceProvider struct {
 	key *ecdsa.PrivateKey
 
@@ -241,8 +251,13 @@ type remoteLoadAnnounceProvider struct {
 }
 
 func (r *remoteLoadAnnounceProvider) InitRemote(srv loadroute.ServerInfo) (loadcontroller.WriterProvider, error) {
-	if srv == nil || r.netmapKeys.IsLocalKey(srv.PublicKey()) {
+	if srv == nil {
 		return r.deadEndProvider, nil
+	}
+
+	if r.netmapKeys.IsLocalKey(srv.PublicKey()) {
+		// if local => return no-op writer
+		return loadcontroller.SimpleWriterProvider(new(nopLoadWriter)), nil
 	}
 
 	var info client.NodeInfo

--- a/pkg/services/container/announcement/load/route/placement/calls.go
+++ b/pkg/services/container/announcement/load/route/placement/calls.go
@@ -1,6 +1,7 @@
 package placementrouter
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
@@ -30,7 +31,15 @@ func (b *Builder) NextStage(a container.UsedSpaceAnnouncement, passed []loadrout
 			continue
 		}
 
-		res = append(res, placement[i][0])
+		target := placement[i][0]
+
+		if len(passed) == 1 && bytes.Equal(passed[0].PublicKey(), target.PublicKey()) {
+			// add nil element so the announcement will be saved in local memory
+			res = append(res, nil)
+		} else {
+			// add element with remote node to send announcement to
+			res = append(res, target)
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
Containers with one storage node do not produce size estimations. The reason is that load controller uses `nopLoadWriter` which loses the data. It does not accumulated in storage and therefore does not announced to the container contract, which is incorrect.