### PR TITLE
acl: Use session token from request at object.Put

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -381,7 +381,7 @@ func (p putStreamBasicChecker) Send(request *object.PutRequest) error {
 			return err
 		}
 
-		sTok := part.GetHeader().GetSessionToken()
+		sTok := request.GetMetaHeader().GetSessionToken()
 
 		req := metaWithToken{
 			vheader: request.GetVerificationHeader(),


### PR DESCRIPTION
Session token can be present in both object header and request meta header. They are the same during initial object placement.

At the object replication, storage node puts object without any session tokens attached to the request. If container's eACL denies object.Put for USER role (use bearer to upload), then replication might fail on objects with session tokens of the signed by container owner. It is incorrect, so use session token directly from request meta header.

---

I run ACL suit of neofs integration tests with this patch and it seems to work just fine.
Closes #881 