### PR TITLE
change vmagent port to 443

### DIFF
--- a/config/testnet/docker-compose.yml
+++ b/config/testnet/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     env_file: node_config.env
     command:
       - '-promscrape.config=/configs/prometheus.yml'
-      - '-remoteWrite.url=https://collector.fs.neo.org:8429/api/v1/write'
+      - '-remoteWrite.url=https://collector.fs.neo.org/api/v1/write'
     network_mode: host
     restart: always
     volumes:


### PR DESCRIPTION
Update vmagent to an actual collectors configuration, that use default https port now.

Signed-off-by: Sergio Nemirowski <sergio@nspcc.ru>