### PR TITLE
config/testnet: Fix configuration after testnet redeploy

### DIFF
--- a/config/testnet/README.md
+++ b/config/testnet/README.md
@@ -14,7 +14,7 @@ However, if you need to rebuild it for some reason, run
 $ make image-storage-testnet
 ...
 Successfully built ab0557117b02
-Successfully tagged nspccdev/neofs-storage-testnet:0.24.0
+Successfully tagged nspccdev/neofs-storage-testnet:0.25.1
 ```
 
 ## Deploy node
@@ -34,15 +34,15 @@ Then make a deposit by transferring GAS to NeoFS contract in N3 Testnet.
 You can provide scripthash in the `data` argument of transfer tx to make a
 deposit to specified account. Otherwise, deposit is made to tx sender.
 
-NeoFS contract scripthash in NEO Testnet is `51cf687eb6625eb1a2b98b0fb4e9d52bdf95f3a6`, 
-so the address is `Nb8jADHaYuH2e46koNEfTSrKj7iEPEEY7p`
+NeoFS contract scripthash in N3 Testnet is `b65d8243ac63983206d17e5221af0653a7266fa1`, 
+so the address is `NadZ8YfvkddivcFFkztZgfwxZyKf1acpRF`.
 
 See a deposit example with `neo-go`.
 
 ```
-neo-go wallet nep17 transfer -w wallet.json -r https://rpc1.n3.nspcc.ru:20331 \
+neo-go wallet nep17 transfer -w wallet.json -r https://rpc01.testnet.n3.nspcc.ru:21331 \
 --from NXxRAFPqPstaPByndKMHuC8iGcaHgtRY3m \
---to Nb8jADHaYuH2e46koNEfTSrKj7iEPEEY7p \
+--to NadZ8YfvkddivcFFkztZgfwxZyKf1acpRF \
 --token GAS \
 --amount 1
 ```

--- a/config/testnet/config.yml
+++ b/config/testnet/config.yml
@@ -21,10 +21,10 @@ morph:
   dial_timeout: 20s
 
 contracts:
-  balance: 4f5b98a079e61cfb33cf2b9da8fd2dcaedb71d82
-  container: 8c555fa20e13bed708fe635492647c595d35e430
-  netmap: 86f589459b0b0ae47d31f3b9b340d6d431358954
-  reputation: 8d9ddd707af12c0d41f5da8f3d56386b39d871e0
+  balance: e0420c216003747626670d1424569c17c79015bf
+  container: 9dbd2b5e67568ed285c3d6f96bac4edf5e1efba0
+  netmap: d4b331639799e2958d4bc5b711b469d79de94e01
+  reputation: 376c23a2ae1fad088c82046abb59984e3c4519d9
 
 node:
   key: /node.key


### PR DESCRIPTION
Contracts section can be omitted in neofs-node v0.25.x. But upcoming changes in NNS contract are going to be incompatible with v0.25.x, so it is better to stick with smart contract addresses in config file.

Related to #912 