### PR TITLE
Feat/Add auto negotiation of numbers of alphabet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Changelog for NeoFS Node
 
 ## [Unreleased]
 
+### Changed
+- Alphabet contract number is not mandatory (#880)
+
+### Upgrading from v0.26.1
+`NEOFS_IR_CONTRACTS_ALPHABET_AMOUNT` is not mandatory env anymore. If it
+is not set, Inner Ring would try to read maximum from config and NNS contract.
+However, that parameter still can be set in order to require the exact number
+of contracts.
+
 ## [0.26.1] - 2021-11-02
 
 ### Fixed

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -64,8 +64,6 @@ func defaultConfiguration(cfg *viper.Viper) {
 	cfg.SetDefault("contracts.proxy", "")
 	cfg.SetDefault("contracts.processing", "")
 	cfg.SetDefault("contracts.reputation", "")
-	// alphabet contracts
-	cfg.SetDefault("contracts.alphabet.amount", 7)
 
 	cfg.SetDefault("timers.epoch", "0")
 	cfg.SetDefault("timers.emit", "0")

--- a/pkg/morph/client/nns.go
+++ b/pkg/morph/client/nns.go
@@ -32,6 +32,13 @@ const (
 	NNSReputationContractName = "reputation.neofs"
 )
 
+var (
+	// ErrNNSRecordNotFound means that there is no such record in NNS contract.
+	ErrNNSRecordNotFound = errors.New("record has not been found in NNS contract")
+
+	errEmptyResultStack = errors.New("returned result stack is empty")
+)
+
 // NNSAlphabetContractName returns contract name of the alphabet contract in NNS
 // based on alphabet index.
 func NNSAlphabetContractName(index int) string {
@@ -40,6 +47,7 @@ func NNSAlphabetContractName(index int) string {
 
 // NNSContractAddress returns contract address script hash based on its name
 // in NNS contract.
+// If script hash has not been found, returns ErrNNSRecordNotFound.
 func (c *Client) NNSContractAddress(name string) (sh util.Uint160, err error) {
 	if c.multiClient != nil {
 		return sh, c.multiClient.iterateClients(func(c *Client) error {
@@ -61,6 +69,15 @@ func (c *Client) NNSContractAddress(name string) (sh util.Uint160, err error) {
 }
 
 func nnsResolve(c *client.Client, nnsHash util.Uint160, domain string) (util.Uint160, error) {
+	found, err := exists(c, nnsHash, domain)
+	if err != nil {
+		return util.Uint160{}, fmt.Errorf("could not check presence in NNS contract for %s: %w", domain, err)
+	}
+
+	if !found {
+		return util.Uint160{}, ErrNNSRecordNotFound
+	}
+
 	result, err := c.InvokeFunction(nnsHash, "resolve", []smartcontract.Parameter{
 		{
 			Type:  smartcontract.StringType,
@@ -78,7 +95,7 @@ func nnsResolve(c *client.Client, nnsHash util.Uint160, domain string) (util.Uin
 		return util.Uint160{}, fmt.Errorf("invocation failed: %s", result.FaultException)
 	}
 	if len(result.Stack) == 0 {
-		return util.Uint160{}, errors.New("result stack is empty")
+		return util.Uint160{}, errEmptyResultStack
 	}
 
 	// Parse the result of resolving NNS record.
@@ -96,4 +113,31 @@ func nnsResolve(c *client.Client, nnsHash util.Uint160, domain string) (util.Uin
 		return util.Uint160{}, fmt.Errorf("malformed response: %w", err)
 	}
 	return util.Uint160DecodeStringLE(string(bs))
+}
+
+func exists(c *client.Client, nnsHash util.Uint160, domain string) (bool, error) {
+	result, err := c.InvokeFunction(nnsHash, "isAvailable", []smartcontract.Parameter{
+		{
+			Type:  smartcontract.StringType,
+			Value: domain,
+		},
+	}, nil)
+	if err != nil {
+		return false, err
+	}
+
+	if len(result.Stack) == 0 {
+		return false, errEmptyResultStack
+	}
+
+	res := result.Stack[0]
+
+	available, err := res.TryBool()
+	if err != nil {
+		return false, fmt.Errorf("malformed response: %w", err)
+	}
+
+	// not available means that it is taken
+	// and, therefore, exists
+	return !available, nil
 }


### PR DESCRIPTION
First, I thought that if a record is not presented in NNS, [Resolve](https://github.com/nspcc-dev/neofs-contract/blob/v0.12.1/nns/nns_contract.go#L426) returns an empty string slice and that is enough to understand that there are no more contracts in the network. However, it panics instead: `at instruction 2580 (THROW): unhandled exception: "token not found"` (do not know is it expected or not).

So this PR adds NNS presence check for every record before its reading(via [IsAvailable](https://github.com/nspcc-dev/neofs-contract/blob/v0.12.1/nns/nns_contract.go#L253)) and closes #880. 