### PR TITLE
Return endpoint flag to `control netmap-snapshot` command

### DIFF
--- a/cmd/neofs-cli/modules/control.go
+++ b/cmd/neofs-cli/modules/control.go
@@ -114,6 +114,7 @@ func initControlSnapshotCmd() {
 
 	flags := snapshotCmd.Flags()
 
+	flags.String(controlRPC, controlRPCDefault, controlRPCUsage)
 	flags.BoolVar(&netmapSnapshotJSON, "json", false,
 		"print netmap structure in JSON format")
 }


### PR DESCRIPTION
Fix #942 