### PR TITLE
Storage engine `ListWithCursor` implementation

### DIFF
--- a/pkg/core/object/errors.go
+++ b/pkg/core/object/errors.go
@@ -12,8 +12,3 @@ var ErrRangeOutOfBounds = errors.New("payload range is out of bounds")
 
 // ErrAlreadyRemoved returned when object has tombstone in graveyard.
 var ErrAlreadyRemoved = errors.New("object already removed")
-
-// ErrEndOfListing is returned from object listing with cursor
-// when storage can't return any more objects after provided
-// cursor. Use nil cursor object to start listing again.
-var ErrEndOfListing = errors.New("end of object listing")

--- a/pkg/core/object/errors.go
+++ b/pkg/core/object/errors.go
@@ -12,3 +12,8 @@ var ErrRangeOutOfBounds = errors.New("payload range is out of bounds")
 
 // ErrAlreadyRemoved returned when object has tombstone in graveyard.
 var ErrAlreadyRemoved = errors.New("object already removed")
+
+// ErrEndOfListing is returned from object listing with cursor
+// when storage can't return any more objects after provided
+// cursor. Use nil cursor object to start listing again.
+var ErrEndOfListing = errors.New("end of object listing")

--- a/pkg/local_object_storage/engine/control_test.go
+++ b/pkg/local_object_storage/engine/control_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
@@ -10,7 +11,10 @@ import (
 
 func TestExecBlocks(t *testing.T) {
 	e := testNewEngineWithShardNum(t, 2) // number doesn't matter in this test, 2 is several but not many
-	defer e.Close()
+	t.Cleanup(func() {
+		e.Close()
+		os.RemoveAll(t.Name())
+	})
 
 	// put some object
 	obj := generateRawObjectWithCID(t, cidtest.GenerateID()).Object()

--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/rand"
+	"path"
 	"sync"
 	"testing"
 
@@ -56,13 +57,13 @@ func testNewShard(t *testing.T, id int) *shard.Shard {
 		shard.WithID(sid),
 		shard.WithLogger(zap.L()),
 		shard.WithBlobStorOptions(
-			blobstor.WithRootPath(fmt.Sprintf("%s.%d.blobstor", t.Name(), id)),
+			blobstor.WithRootPath(path.Join(t.Name(), fmt.Sprintf("%d.blobstor", id))),
 			blobstor.WithBlobovniczaShallowWidth(2),
 			blobstor.WithBlobovniczaShallowDepth(2),
 			blobstor.WithRootPerm(0700),
 		),
 		shard.WithMetaBaseOptions(
-			meta.WithPath(fmt.Sprintf("%s.%d.metabase", t.Name(), id)),
+			meta.WithPath(path.Join(t.Name(), fmt.Sprintf("%d.metabase", id))),
 			meta.WithPermissions(0700),
 		))
 

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+)
+
+// ListWithCursorPrm contains parameters for ListWithCursor operation.
+type ListWithCursorPrm struct {
+	count  uint32
+	cursor string
+	shard  shard.ID
+}
+
+// WithCount sets maximum amount of addresses that ListWithCursor can return.
+func (p *ListWithCursorPrm) WithCount(count uint32) *ListWithCursorPrm {
+	p.count = count
+	return p
+}
+
+// WithCursor sets cursor for ListWithCursor operation. For initial request
+// ignore this param or use empty string. For continues requests, use  value
+// from ListWithCursorRes.
+func (p *ListWithCursorPrm) WithCursor(cursor string) *ListWithCursorPrm {
+	p.cursor = cursor
+	return p
+}
+
+// WithShardID sets shard where listing will process.
+func (p *ListWithCursorPrm) WithShardID(id shard.ID) *ListWithCursorPrm {
+	p.shard = id
+	return p
+}
+
+// ListWithCursorRes contains values returned from ListWithCursor operation.
+type ListWithCursorRes struct {
+	addrList []*object.Address
+	cursor   string
+}
+
+// AddressList returns addresses selected by ListWithCursor operation.
+func (l ListWithCursorRes) AddressList() []*object.Address {
+	return l.addrList
+}
+
+// Cursor returns cursor for consecutive listing requests.
+func (l ListWithCursorRes) Cursor() string {
+	return l.cursor
+}
+
+// ListWithCursor lists physical objects available in specified shard starting
+// from cursor. Includes regular,tombstone and storage group objects.
+// Does not include inhumed objects. Use cursor value from response
+// for consecutive requests.
+func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
+	e.mtx.RLock()
+	shardInstance, ok := e.shards[prm.shard.String()]
+	e.mtx.RUnlock()
+
+	if !ok {
+		return nil, errShardNotFound
+	}
+
+	shardPrm := new(shard.ListWithCursorPrm).WithCursor(prm.cursor).WithCount(prm.count)
+	res, err := shardInstance.ListWithCursor(shardPrm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListWithCursorRes{
+		addrList: res.AddressList(),
+		cursor:   res.Cursor(),
+	}, nil
+}

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -3,10 +3,14 @@ package engine
 import (
 	"sort"
 
-	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 )
+
+// ErrEndOfListing is returned from object listing with cursor
+// when storage can't return any more objects after provided
+// cursor. Use nil cursor object to start listing again.
+var ErrEndOfListing = shard.ErrEndOfListing
 
 // Cursor is a type for continuous object listing.
 type Cursor struct {
@@ -69,7 +73,7 @@ func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorR
 	e.mtx.RUnlock()
 
 	if len(shardIDs) == 0 {
-		return nil, core.ErrEndOfListing
+		return nil, ErrEndOfListing
 	}
 
 	sort.Slice(shardIDs, func(i, j int) bool {
@@ -116,7 +120,7 @@ func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorR
 	}
 
 	if len(result) == 0 {
-		return nil, core.ErrEndOfListing
+		return nil, ErrEndOfListing
 	}
 
 	return &ListWithCursorRes{

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -20,14 +20,14 @@ type ListWithCursorPrm struct {
 	cursor *Cursor
 }
 
-// WithCount sets maximum amount of addresses that ListWithCursor can return.
+// WithCount sets maximum amount of addresses that ListWithCursor should return.
 func (p *ListWithCursorPrm) WithCount(count uint32) *ListWithCursorPrm {
 	p.count = count
 	return p
 }
 
 // WithCursor sets cursor for ListWithCursor operation. For initial request
-// ignore this param or use nil value. For continues requests, use  value
+// ignore this param or use nil value. For consecutive requests, use  value
 // from ListWithCursorRes.
 func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 	p.cursor = cursor
@@ -50,10 +50,13 @@ func (l ListWithCursorRes) Cursor() *Cursor {
 	return l.cursor
 }
 
-// ListWithCursor lists physical objects available in specified shard starting
+// ListWithCursor lists physical objects available in engine starting
 // from cursor. Includes regular,tombstone and storage group objects.
 // Does not include inhumed objects. Use cursor value from response
 // for consecutive requests.
+//
+// Returns ErrEndOfListing if there are no more objects to return or count
+// parameter set to zero.
 func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
 	result := make([]*object.Address, 0, prm.count)
 

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"sort"
 
-	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
 )
 
 // Cursor is a type for continuous object listing.

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -1,7 +1,12 @@
 package engine
 
 import (
+	"fmt"
+	"sort"
+	"strconv"
+
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 )
 
@@ -9,7 +14,6 @@ import (
 type ListWithCursorPrm struct {
 	count  uint32
 	cursor string
-	shard  shard.ID
 }
 
 // WithCount sets maximum amount of addresses that ListWithCursor can return.
@@ -23,12 +27,6 @@ func (p *ListWithCursorPrm) WithCount(count uint32) *ListWithCursorPrm {
 // from ListWithCursorRes.
 func (p *ListWithCursorPrm) WithCursor(cursor string) *ListWithCursorPrm {
 	p.cursor = cursor
-	return p
-}
-
-// WithShardID sets shard where listing will process.
-func (p *ListWithCursorPrm) WithShardID(id shard.ID) *ListWithCursorPrm {
-	p.shard = id
 	return p
 }
 
@@ -53,22 +51,99 @@ func (l ListWithCursorRes) Cursor() string {
 // Does not include inhumed objects. Use cursor value from response
 // for consecutive requests.
 func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
+	var (
+		err    error
+		result = make([]*object.Address, 0, prm.count)
+	)
+
+	// 1. Get available shards and sort them.
 	e.mtx.RLock()
-	shardInstance, ok := e.shards[prm.shard.String()]
+	shardIDs := make([]string, 0, len(e.shards))
+	for id := range e.shards {
+		shardIDs = append(shardIDs, id)
+	}
 	e.mtx.RUnlock()
 
-	if !ok {
-		return nil, errShardNotFound
+	if len(shardIDs) == 0 {
+		return nil, core.ErrEndOfListing
 	}
 
-	shardPrm := new(shard.ListWithCursorPrm).WithCursor(prm.cursor).WithCount(prm.count)
-	res, err := shardInstance.ListWithCursor(shardPrm)
-	if err != nil {
-		return nil, err
+	sort.Slice(shardIDs, func(i, j int) bool {
+		return shardIDs[i] < shardIDs[j]
+	})
+
+	// 2. Decode shard ID from cursor.
+	cursor := prm.cursor
+	cursorShardID := shardIDs[0]
+	if len(cursor) > 0 {
+		cursorShardID, cursor, err = decodeID(cursor)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// 3. Iterate over available shards. Skip unavailable shards.
+	for i := range shardIDs {
+		if len(result) >= int(prm.count) {
+			break
+		}
+
+		if shardIDs[i] < cursorShardID {
+			continue
+		}
+
+		e.mtx.RLock()
+		shardInstance, ok := e.shards[shardIDs[i]]
+		e.mtx.RUnlock()
+		if !ok {
+			continue
+		}
+
+		count := uint32(int(prm.count) - len(result))
+		shardPrm := new(shard.ListWithCursorPrm).WithCount(count)
+		if shardIDs[i] == cursorShardID {
+			shardPrm.WithCursor(cursor)
+		}
+
+		res, err := shardInstance.ListWithCursor(shardPrm)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, res.AddressList()...)
+		cursor = res.Cursor()
+		cursorShardID = shardIDs[i]
+	}
+
+	if len(result) == 0 {
+		return nil, core.ErrEndOfListing
 	}
 
 	return &ListWithCursorRes{
-		addrList: res.AddressList(),
-		cursor:   res.Cursor(),
+		addrList: result,
+		cursor:   encodeID(cursorShardID, cursor),
 	}, nil
+}
+
+func decodeID(cursor string) (shardID string, shardCursor string, err error) {
+	ln := len(cursor)
+	if ln < 2 {
+		return "", "", fmt.Errorf("invalid cursor %s", cursor)
+	}
+
+	idLen, err := strconv.Atoi(cursor[:2])
+	if err != nil {
+		return "", "", fmt.Errorf("invalid cursor %s", cursor)
+	}
+
+	if len(cursor) < 2+idLen {
+		return "", "", fmt.Errorf("invalid cursor %s", cursor)
+	}
+
+	return cursor[2 : 2+idLen], cursor[2+idLen:], nil
+}
+
+func encodeID(id, cursor string) string {
+	prefix := fmt.Sprintf("%02d", len(id))
+	return prefix + id + cursor
 }

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -7,7 +7,7 @@ import (
 
 	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +45,7 @@ func TestListWithCursor(t *testing.T) {
 
 		got = append(got, res.AddressList()...)
 		_, err = e.ListWithCursor(prm.WithCursor(res.Cursor()))
-		require.ErrorIs(t, err, meta.ErrEndOfListing)
+		require.ErrorIs(t, err, core.ErrEndOfListing)
 	}
 
 	got = sortAddresses(got)

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"testing"
 
-	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/stretchr/testify/require"
@@ -46,14 +45,14 @@ func TestListWithCursor(t *testing.T) {
 
 	for i := 0; i < total-1; i++ {
 		res, err = e.ListWithCursor(prm.WithCursor(res.Cursor()))
-		if errors.Is(err, core.ErrEndOfListing) {
+		if errors.Is(err, ErrEndOfListing) {
 			break
 		}
 		got = append(got, res.AddressList()...)
 	}
 
 	_, err = e.ListWithCursor(prm.WithCursor(res.Cursor()))
-	require.ErrorIs(t, err, core.ErrEndOfListing)
+	require.ErrorIs(t, err, ErrEndOfListing)
 
 	got = sortAddresses(got)
 	require.Equal(t, expected, got)

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListWithCursor(t *testing.T) {
+	s1 := testNewShard(t, 1)
+	s2 := testNewShard(t, 2)
+	e := testNewEngineWithShards(s1, s2)
+
+	t.Cleanup(func() {
+		e.Close()
+		os.RemoveAll(t.Name())
+	})
+
+	const total = 20
+
+	expected := make([]*object.Address, 0, total)
+	got := make([]*object.Address, 0, total)
+
+	for i := 0; i < total; i++ {
+		containerID := cidtest.Generate()
+		obj := generateRawObjectWithCID(t, containerID)
+		prm := new(PutPrm).WithObject(obj.Object())
+		_, err := e.Put(prm)
+		require.NoError(t, err)
+		expected = append(expected, obj.Object().Address())
+	}
+
+	expected = sortAddresses(expected)
+
+	for _, shard := range e.DumpInfo().Shards {
+		prm := new(ListWithCursorPrm).WithShardID(*shard.ID).WithCount(total)
+		res, err := e.ListWithCursor(prm)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.AddressList())
+
+		got = append(got, res.AddressList()...)
+		_, err = e.ListWithCursor(prm.WithCursor(res.Cursor()))
+		require.ErrorIs(t, err, meta.ErrEndOfListing)
+	}
+
+	got = sortAddresses(got)
+	require.Equal(t, expected, got)
+}
+
+func sortAddresses(addr []*object.Address) []*object.Address {
+	sort.Slice(addr, func(i, j int) bool {
+		return addr[i].String() < addr[j].String()
+	})
+	return addr
+}

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"testing"
 
-	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
-	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +28,7 @@ func TestListWithCursor(t *testing.T) {
 	got := make([]*object.Address, 0, total)
 
 	for i := 0; i < total; i++ {
-		containerID := cidtest.Generate()
+		containerID := cidtest.GenerateID()
 		obj := generateRawObjectWithCID(t, containerID)
 		prm := new(PutPrm).WithObject(obj.Object())
 		_, err := e.Put(prm)

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"go.etcd.io/bbolt"
 )
 
@@ -50,14 +51,7 @@ const (
 	cursorPrefixSG        = 's'
 )
 
-var (
-	// ErrEndOfListing returns from ListWithCursor when metabase can't return
-	// any more objects after provided cursor.
-	// Use empty cursor to start listing again.
-	ErrEndOfListing = errors.New("end of metabase records")
-
-	errStopIterator = errors.New("stop")
-)
+var errStopIterator = errors.New("stop")
 
 // ListWithCursor lists physical objects available in metabase. Includes regular,
 // tombstone and storage group objects. Does not include inhumed objects. Use
@@ -148,7 +142,7 @@ func (db *DB) listWithCursor(tx *bbolt.Tx, count int, cursor string) ([]*object.
 	})
 
 	if len(result) == 0 {
-		return nil, "", ErrEndOfListing
+		return nil, "", core.ErrEndOfListing
 	}
 
 	return result, string(cursorPrefix) + cursor, nil

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -1,0 +1,208 @@
+package meta
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-api-go/pkg/object"
+	"go.etcd.io/bbolt"
+)
+
+// ListPrm contains parameters for ListWithCursor operation.
+type ListPrm struct {
+	count  int
+	cursor string
+}
+
+// WithCount sets maximum amount of addresses that ListWithCursor can return.
+func (l *ListPrm) WithCount(count uint32) *ListPrm {
+	l.count = int(count)
+	return l
+}
+
+// WithCursor sets cursor for ListWithCursor operation. For initial request
+// ignore this param or use empty string. For continues requests, use value
+// from ListRes.
+func (l *ListPrm) WithCursor(cursor string) *ListPrm {
+	l.cursor = cursor
+	return l
+}
+
+// ListRes contains values returned from ListWithCursor operation.
+type ListRes struct {
+	addrList []*object.Address
+	cursor   string
+}
+
+// AddressList returns addresses selected by ListWithCursor operation.
+func (l ListRes) AddressList() []*object.Address {
+	return l.addrList
+}
+
+// Cursor returns cursor for consecutive listing requests.
+func (l ListRes) Cursor() string {
+	return l.cursor
+}
+
+const (
+	cursorPrefixPrimary   = 'p'
+	cursorPrefixTombstone = 't'
+	cursorPrefixSG        = 's'
+)
+
+var (
+	// ErrEndOfListing returns from ListWithCursor when metabase can't return
+	// any more objects after provided cursor.
+	// Use empty cursor to start listing again.
+	ErrEndOfListing = errors.New("end of metabase records")
+
+	errStopIterator = errors.New("stop")
+)
+
+// ListWithCursor lists physical objects available in metabase. Includes regular,
+// tombstone and storage group objects. Does not include inhumed objects. Use
+// cursor value from response for consecutive requests.
+func ListWithCursor(db *DB, count uint32, cursor string) ([]*object.Address, string, error) {
+	r, err := db.ListWithCursor(new(ListPrm).WithCount(count).WithCursor(cursor))
+	if err != nil {
+		return nil, "", err
+	}
+
+	return r.AddressList(), r.Cursor(), nil
+}
+
+// ListWithCursor lists physical objects available in metabase. Includes regular,
+// tombstone and storage group objects. Does not include inhumed objects. Use
+// cursor value from response for consecutive requests.
+func (db *DB) ListWithCursor(prm *ListPrm) (res *ListRes, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		res = new(ListRes)
+		res.addrList, res.cursor, err = db.listWithCursor(tx, prm.count, prm.cursor)
+		return err
+	})
+
+	return res, err
+}
+
+func (db *DB) listWithCursor(tx *bbolt.Tx, count int, cursor string) ([]*object.Address, string, error) {
+	threshold := len(cursor) == 0 // threshold is a flag to ignore cursor
+	a := object.NewAddress()
+	var cursorPrefix uint8
+
+	if !threshold { // if cursor is present, then decode it and check sanity
+		cursorPrefix = cursor[0]
+		switch cursorPrefix {
+		case cursorPrefixPrimary, cursorPrefixSG, cursorPrefixTombstone:
+		default:
+			return nil, "", fmt.Errorf("invalid cursor prefix %s", string(cursorPrefix))
+		}
+
+		cursor = cursor[1:]
+		if err := a.Parse(cursor); err != nil {
+			return nil, "", fmt.Errorf("invalid cursor address: %w", err)
+		}
+	}
+
+	result := make([]*object.Address, 0, count)
+	unique := make(map[string]struct{}) // do not parse the same containerID twice
+
+	_ = tx.ForEach(func(name []byte, _ *bbolt.Bucket) error {
+		containerID := parseContainerID(name, unique)
+		if containerID == nil {
+			return nil
+		}
+
+		unique[containerID.String()] = struct{}{}
+
+		if !threshold && !containerID.Equal(a.ContainerID()) {
+			return nil // ignore buckets until we find cursor bucket
+		}
+
+		prefix := containerID.String() + "/"
+
+		lookupBuckets := [...]struct {
+			name   []byte
+			prefix uint8
+		}{
+			{primaryBucketName(containerID), cursorPrefixPrimary},
+			{tombstoneBucketName(containerID), cursorPrefixTombstone},
+			{storageGroupBucketName(containerID), cursorPrefixSG},
+		}
+
+		for _, lb := range lookupBuckets {
+			if !threshold && cursorPrefix != lb.prefix {
+				continue // start from the bucket, specified in the cursor prefix
+			}
+
+			cursorPrefix = lb.prefix
+			result, cursor = selectNFromBucket(tx, lb.name, prefix, result, count, cursor, threshold)
+			if len(result) >= count {
+				return errStopIterator
+			}
+
+			// set threshold flag after first `selectNFromBucket` invocation
+			// first invocation must look for cursor object
+			threshold = true
+		}
+		return nil
+	})
+
+	if len(result) == 0 {
+		return nil, "", ErrEndOfListing
+	}
+
+	return result, string(cursorPrefix) + cursor, nil
+}
+
+// selectNFromBucket similar to selectAllFromBucket but uses cursor to find
+// object to start selecting from. Ignores inhumed objects.
+func selectNFromBucket(tx *bbolt.Tx,
+	name []byte, // bucket name
+	prefix string, // string of CID, optimization
+	to []*object.Address, // listing result
+	limit int, // stop listing at `limit` items in result
+	cursor string, // start from cursor object
+	threshold bool, // ignore cursor and start immediately
+) ([]*object.Address, string) {
+	bkt := tx.Bucket(name)
+	if bkt == nil {
+		return to, cursor
+	}
+
+	count := len(to)
+
+	_ = bkt.ForEach(func(k, v []byte) error {
+		if count >= limit {
+			return errStopIterator
+		}
+
+		key := prefix + string(k)
+
+		if !threshold {
+			if cursor == key {
+				// ignore cursor object and start adding next objects
+				threshold = true
+			}
+			return nil
+		}
+
+		threshold = true
+		cursor = key
+
+		a := object.NewAddress()
+		if err := a.Parse(key); err != nil {
+			return err
+		}
+
+		if inGraveyard(tx, a) > 0 {
+			return nil
+		}
+
+		to = append(to, a)
+		count++
+
+		return nil
+	})
+
+	return to, cursor
+}

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -1,8 +1,8 @@
 package meta
 
 import (
-	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
 )
 

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -1,13 +1,18 @@
 package meta
 
 import (
+	"errors"
 	"strings"
 
-	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
 )
+
+// ErrEndOfListing is returned from object listing with cursor
+// when storage can't return any more objects after provided
+// cursor. Use nil cursor object to start listing again.
+var ErrEndOfListing = errors.New("end of object listing")
 
 // Cursor is a type for continuous object listing.
 type Cursor struct {
@@ -121,7 +126,7 @@ loop:
 	}
 
 	if len(result) == 0 {
-		return nil, nil, core.ErrEndOfListing
+		return nil, nil, ErrEndOfListing
 	}
 
 	// new slice is much faster but less memory efficient

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -1,15 +1,18 @@
 package meta
 
 import (
+	"strings"
+
 	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
 )
 
 // Cursor is a type for continuous object listing.
 type Cursor struct {
-	bucket  uint8
-	address *object.Address
+	bucketName     []byte
+	inBucketOffset []byte
 }
 
 // ListPrm contains parameters for ListWithCursor operation.
@@ -48,12 +51,6 @@ func (l ListRes) Cursor() *Cursor {
 	return l.cursor
 }
 
-const (
-	cursorBucketPrimary = iota
-	cursorBucketTombstone
-	cursorBucketSG
-)
-
 // ListWithCursor lists physical objects available in metabase starting from
 // cursor. Includes regular, tombstone and storage group objects. Does not
 // include inhumed objects. Use cursor value from response for consecutive requests.
@@ -88,54 +85,49 @@ func (db *DB) ListWithCursor(prm *ListPrm) (res *ListRes, err error) {
 func (db *DB) listWithCursor(tx *bbolt.Tx, count int, cursor *Cursor) ([]*object.Address, *Cursor, error) {
 	threshold := cursor == nil // threshold is a flag to ignore cursor
 	result := make([]*object.Address, 0, count)
-	unique := make(map[string]struct{}) // do not parse the same containerID twice
+	var bucketName []byte
 
 	c := tx.Cursor()
 	name, _ := c.First()
 
 	if !threshold {
-		name, _ = c.Seek([]byte(cursor.address.ContainerID().String()))
+		name, _ = c.Seek(cursor.bucketName)
 	}
 
 loop:
 	for ; name != nil; name, _ = c.Next() {
-		containerID := parseContainerID(name, unique)
+		containerID, postfix := parseContainerIDWithPostfix(name)
 		if containerID == nil {
 			continue
 		}
 
-		unique[containerID.String()] = struct{}{}
+		switch postfix {
+		case "", storageGroupPostfix, tombstonePostfix:
+		default:
+			continue
+		}
+
 		prefix := containerID.String() + "/"
 
-		lookupBuckets := [...]struct {
-			name   []byte
-			bucket uint8
-		}{
-			{primaryBucketName(containerID), cursorBucketPrimary},
-			{tombstoneBucketName(containerID), cursorBucketTombstone},
-			{storageGroupBucketName(containerID), cursorBucketSG},
+		result, cursor = selectNFromBucket(tx, name, prefix, result, count, cursor, threshold)
+		bucketName = name
+		if len(result) >= count {
+			break loop
 		}
 
-		for _, lb := range lookupBuckets {
-			if !threshold && cursor.bucket != lb.bucket {
-				continue // start from the bucket, specified in the cursor bucket
-			}
-
-			result, cursor = selectNFromBucket(tx, lb.name, prefix, result, count, cursor, threshold)
-			cursor.bucket = lb.bucket
-			if len(result) >= count {
-				break loop
-			}
-
-			// set threshold flag after first `selectNFromBucket` invocation
-			// first invocation must look for cursor object
-			threshold = true
-		}
+		// set threshold flag after first `selectNFromBucket` invocation
+		// first invocation must look for cursor object
+		threshold = true
 	}
 
 	if len(result) == 0 {
 		return nil, nil, core.ErrEndOfListing
 	}
+
+	// new slice is much faster but less memory efficient
+	// we need to copy, because bucketName exists during bbolt tx
+	cursor.bucketName = make([]byte, len(bucketName))
+	copy(cursor.bucketName, bucketName)
 
 	return result, cursor, nil
 }
@@ -163,8 +155,10 @@ func selectNFromBucket(tx *bbolt.Tx,
 	c := bkt.Cursor()
 	k, _ := c.First()
 
+	offset := cursor.inBucketOffset
+
 	if !threshold {
-		c.Seek([]byte(cursor.address.ObjectID().String()))
+		c.Seek(offset)
 		k, _ = c.Next() // we are looking for objects _after_ the cursor
 	}
 
@@ -176,7 +170,7 @@ func selectNFromBucket(tx *bbolt.Tx,
 		if err := a.Parse(prefix + string(k)); err != nil {
 			break
 		}
-		cursor.address = a
+		offset = k
 		if inGraveyard(tx, a) > 0 {
 			continue
 		}
@@ -184,5 +178,30 @@ func selectNFromBucket(tx *bbolt.Tx,
 		count++
 	}
 
+	// new slice is much faster but less memory efficient
+	// we need to copy, because offset exists during bbolt tx
+	cursor.inBucketOffset = make([]byte, len(offset))
+	copy(cursor.inBucketOffset, offset)
+
 	return to, cursor
+}
+
+func parseContainerIDWithPostfix(name []byte) (*cid.ID, string) {
+	var (
+		containerID    = cid.New()
+		containerIDStr = string(name)
+		postfix        string
+	)
+
+	ind := strings.Index(string(name), invalidBase58String)
+	if ind > 0 {
+		postfix = containerIDStr[ind:]
+		containerIDStr = containerIDStr[:ind]
+	}
+
+	if err := containerID.Parse(containerIDStr); err != nil {
+		return nil, ""
+	}
+
+	return containerID, postfix
 }

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -18,14 +18,14 @@ type ListPrm struct {
 	cursor *Cursor
 }
 
-// WithCount sets maximum amount of addresses that ListWithCursor can return.
+// WithCount sets maximum amount of addresses that ListWithCursor should return.
 func (l *ListPrm) WithCount(count uint32) *ListPrm {
 	l.count = int(count)
 	return l
 }
 
 // WithCursor sets cursor for ListWithCursor operation. For initial request
-// ignore this param or use nil value. For continues requests, use value
+// ignore this param or use nil value. For consecutive requests, use value
 // from ListRes.
 func (l *ListPrm) WithCursor(cursor *Cursor) *ListPrm {
 	l.cursor = cursor
@@ -54,9 +54,12 @@ const (
 	cursorBucketSG
 )
 
-// ListWithCursor lists physical objects available in metabase. Includes regular,
-// tombstone and storage group objects. Does not include inhumed objects. Use
-// cursor value from response for consecutive requests.
+// ListWithCursor lists physical objects available in metabase starting from
+// cursor. Includes regular, tombstone and storage group objects. Does not
+// include inhumed objects. Use cursor value from response for consecutive requests.
+//
+// Returns ErrEndOfListing if there are no more objects to return or count
+// parameter set to zero.
 func ListWithCursor(db *DB, count uint32, cursor *Cursor) ([]*object.Address, *Cursor, error) {
 	r, err := db.ListWithCursor(new(ListPrm).WithCount(count).WithCursor(cursor))
 	if err != nil {
@@ -66,9 +69,12 @@ func ListWithCursor(db *DB, count uint32, cursor *Cursor) ([]*object.Address, *C
 	return r.AddressList(), r.Cursor(), nil
 }
 
-// ListWithCursor lists physical objects available in metabase. Includes regular,
-// tombstone and storage group objects. Does not include inhumed objects. Use
-// cursor value from response for consecutive requests.
+// ListWithCursor lists physical objects available in metabase starting from
+// cursor. Includes regular, tombstone and storage group objects. Does not
+// include inhumed objects. Use cursor value from response for consecutive requests.
+//
+// Returns ErrEndOfListing if there are no more objects to return or count
+// parameter set to zero.
 func (db *DB) ListWithCursor(prm *ListPrm) (res *ListRes, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
 		res = new(ListRes)

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -1,0 +1,173 @@
+package meta_test
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
+	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLisObjectsWithCursor(t *testing.T) {
+	db := newDB(t)
+
+	const (
+		containers = 5
+		total      = containers * 4 // regular + ts + sg + child
+	)
+
+	expected := make([]*objectSDK.Address, 0, total)
+
+	// fill metabase with objects
+	for i := 0; i < containers; i++ {
+		containerID := cidtest.Generate()
+
+		// add one regular object
+		obj := generateRawObjectWithCID(t, containerID)
+		obj.SetType(objectSDK.TypeRegular)
+		err := putBig(db, obj.Object())
+		require.NoError(t, err)
+		expected = append(expected, obj.Object().Address())
+
+		// add one tombstone
+		obj = generateRawObjectWithCID(t, containerID)
+		obj.SetType(objectSDK.TypeTombstone)
+		err = putBig(db, obj.Object())
+		require.NoError(t, err)
+		expected = append(expected, obj.Object().Address())
+
+		// add one storage group
+		obj = generateRawObjectWithCID(t, containerID)
+		obj.SetType(objectSDK.TypeStorageGroup)
+		err = putBig(db, obj.Object())
+		require.NoError(t, err)
+		expected = append(expected, obj.Object().Address())
+
+		// add one inhumed (do not include into expected)
+		obj = generateRawObjectWithCID(t, containerID)
+		obj.SetType(objectSDK.TypeRegular)
+		err = putBig(db, obj.Object())
+		require.NoError(t, err)
+		ts := generateRawObjectWithCID(t, containerID)
+		err = meta.Inhume(db, obj.Object().Address(), ts.Object().Address())
+		require.NoError(t, err)
+
+		// add one child object (do not include parent into expected)
+		splitID := objectSDK.NewSplitID()
+		parent := generateRawObjectWithCID(t, containerID)
+		addAttribute(parent, "foo", "bar")
+		child := generateRawObjectWithCID(t, containerID)
+		child.SetParent(parent.Object().SDK())
+		child.SetParentID(parent.ID())
+		child.SetSplitID(splitID)
+		err = putBig(db, child.Object())
+		require.NoError(t, err)
+		expected = append(expected, child.Object().Address())
+	}
+
+	expected = sortAddresses(expected)
+
+	t.Run("success with various count", func(t *testing.T) {
+		for countPerReq := 1; countPerReq <= total; countPerReq++ {
+			got := make([]*objectSDK.Address, 0, total)
+
+			res, cursor, err := meta.ListWithCursor(db, uint32(countPerReq), "")
+			require.NoError(t, err, "count:%d", countPerReq)
+			got = append(got, res...)
+
+			expectedIterations := total / countPerReq
+			if total%countPerReq == 0 { // remove initial list if aligned
+				expectedIterations--
+			}
+
+			for i := 0; i < expectedIterations; i++ {
+				res, cursor, err = meta.ListWithCursor(db, uint32(countPerReq), cursor)
+				require.NoError(t, err, "count:%d", countPerReq)
+				got = append(got, res...)
+			}
+
+			_, _, err = meta.ListWithCursor(db, uint32(countPerReq), cursor)
+			require.ErrorIs(t, err, meta.ErrEndOfListing, "count:%d", countPerReq, cursor)
+
+			got = sortAddresses(got)
+			require.Equal(t, expected, got, "count:%d", countPerReq)
+		}
+	})
+
+	t.Run("invalid cursor", func(t *testing.T) {
+		_, cursor, err := meta.ListWithCursor(db, total/2, "")
+		require.NoError(t, err)
+
+		_, _, err = meta.ListWithCursor(db, total/2, "x"+cursor[1:])
+		require.Error(t, err)
+
+		_, _, err = meta.ListWithCursor(db, total/2, cursor[1:])
+		require.Error(t, err)
+	})
+
+	t.Run("invalid count", func(t *testing.T) {
+		_, _, err := meta.ListWithCursor(db, 0, "")
+		require.ErrorIs(t, err, meta.ErrEndOfListing)
+	})
+}
+
+func TestAddObjectDuringListingWithCursor(t *testing.T) {
+	db := newDB(t)
+
+	const total = 5
+
+	expected := make(map[string]int, total)
+
+	// fill metabase with objects
+	for i := 0; i < total; i++ {
+		obj := generateRawObject(t)
+		err := putBig(db, obj.Object())
+		require.NoError(t, err)
+		expected[obj.Object().Address().String()] = 0
+	}
+
+	// get half of the objects
+	got, cursor, err := meta.ListWithCursor(db, total/2, "")
+	require.NoError(t, err)
+	for _, obj := range got {
+		if _, ok := expected[obj.String()]; ok {
+			expected[obj.String()]++
+		}
+	}
+
+	// add new objects
+	for i := 0; i < total; i++ {
+		obj := generateRawObject(t)
+		err = putBig(db, obj.Object())
+		require.NoError(t, err)
+	}
+
+	// get remaining objects
+	for {
+		got, cursor, err = meta.ListWithCursor(db, total, cursor)
+		if errors.Is(err, meta.ErrEndOfListing) {
+			break
+		}
+		for _, obj := range got {
+			if _, ok := expected[obj.String()]; ok {
+				expected[obj.String()]++
+			}
+		}
+	}
+
+	// check if all expected objects were fetched after database update
+	for _, v := range expected {
+		require.Equal(t, 1, v)
+	}
+
+}
+
+func sortAddresses(addr []*objectSDK.Address) []*objectSDK.Address {
+	sort.Slice(addr, func(i, j int) bool {
+		return addr[i].String() < addr[j].String()
+	})
+	return addr
+}

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -7,6 +7,7 @@ import (
 
 	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
+	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/stretchr/testify/require"
 )
@@ -90,7 +91,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 			}
 
 			_, _, err = meta.ListWithCursor(db, uint32(countPerReq), cursor)
-			require.ErrorIs(t, err, meta.ErrEndOfListing, "count:%d", countPerReq, cursor)
+			require.ErrorIs(t, err, core.ErrEndOfListing, "count:%d", countPerReq, cursor)
 
 			got = sortAddresses(got)
 			require.Equal(t, expected, got, "count:%d", countPerReq)
@@ -110,7 +111,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 
 	t.Run("invalid count", func(t *testing.T) {
 		_, _, err := meta.ListWithCursor(db, 0, "")
-		require.ErrorIs(t, err, meta.ErrEndOfListing)
+		require.ErrorIs(t, err, core.ErrEndOfListing)
 	})
 }
 
@@ -148,7 +149,7 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 	// get remaining objects
 	for {
 		got, cursor, err = meta.ListWithCursor(db, total, cursor)
-		if errors.Is(err, meta.ErrEndOfListing) {
+		if errors.Is(err, core.ErrEndOfListing) {
 			break
 		}
 		for _, obj := range got {

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -75,7 +75,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 		for countPerReq := 1; countPerReq <= total; countPerReq++ {
 			got := make([]*objectSDK.Address, 0, total)
 
-			res, cursor, err := meta.ListWithCursor(db, uint32(countPerReq), "")
+			res, cursor, err := meta.ListWithCursor(db, uint32(countPerReq), nil)
 			require.NoError(t, err, "count:%d", countPerReq)
 			got = append(got, res...)
 
@@ -98,19 +98,8 @@ func TestLisObjectsWithCursor(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid cursor", func(t *testing.T) {
-		_, cursor, err := meta.ListWithCursor(db, total/2, "")
-		require.NoError(t, err)
-
-		_, _, err = meta.ListWithCursor(db, total/2, "x"+cursor[1:])
-		require.Error(t, err)
-
-		_, _, err = meta.ListWithCursor(db, total/2, cursor[1:])
-		require.Error(t, err)
-	})
-
 	t.Run("invalid count", func(t *testing.T) {
-		_, _, err := meta.ListWithCursor(db, 0, "")
+		_, _, err := meta.ListWithCursor(db, 0, nil)
 		require.ErrorIs(t, err, core.ErrEndOfListing)
 	})
 }
@@ -131,7 +120,7 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 	}
 
 	// get half of the objects
-	got, cursor, err := meta.ListWithCursor(db, total/2, "")
+	got, cursor, err := meta.ListWithCursor(db, total/2, nil)
 	require.NoError(t, err)
 	for _, obj := range got {
 		if _, ok := expected[obj.String()]; ok {

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
@@ -91,7 +90,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 			}
 
 			_, _, err = meta.ListWithCursor(db, uint32(countPerReq), cursor)
-			require.ErrorIs(t, err, core.ErrEndOfListing, "count:%d", countPerReq, cursor)
+			require.ErrorIs(t, err, meta.ErrEndOfListing, "count:%d", countPerReq, cursor)
 
 			got = sortAddresses(got)
 			require.Equal(t, expected, got, "count:%d", countPerReq)
@@ -100,7 +99,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 
 	t.Run("invalid count", func(t *testing.T) {
 		_, _, err := meta.ListWithCursor(db, 0, nil)
-		require.ErrorIs(t, err, core.ErrEndOfListing)
+		require.ErrorIs(t, err, meta.ErrEndOfListing)
 	})
 }
 
@@ -138,7 +137,7 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 	// get remaining objects
 	for {
 		got, cursor, err = meta.ListWithCursor(db, total, cursor)
-		if errors.Is(err, core.ErrEndOfListing) {
+		if errors.Is(err, meta.ErrEndOfListing) {
 			break
 		}
 		for _, obj := range got {

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -5,10 +5,10 @@ import (
 	"sort"
 	"testing"
 
-	cidtest "github.com/nspcc-dev/neofs-api-go/pkg/container/id/test"
-	objectSDK "github.com/nspcc-dev/neofs-api-go/pkg/object"
 	core "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +24,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 
 	// fill metabase with objects
 	for i := 0; i < containers; i++ {
-		containerID := cidtest.Generate()
+		containerID := cidtest.GenerateID()
 
 		// add one regular object
 		obj := generateRawObjectWithCID(t, containerID)

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -9,6 +9,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// Cursor is a type for continuous object listing.
+type Cursor = meta.Cursor
+
 type ListContainersPrm struct{}
 
 type ListContainersRes struct {
@@ -22,13 +25,13 @@ func (r *ListContainersRes) Containers() []*cid.ID {
 // ListWithCursorPrm contains parameters for ListWithCursor operation.
 type ListWithCursorPrm struct {
 	count  uint32
-	cursor string
+	cursor *Cursor
 }
 
 // ListWithCursorRes contains values returned from ListWithCursor operation.
 type ListWithCursorRes struct {
 	addrList []*object.Address
-	cursor   string
+	cursor   *Cursor
 }
 
 // WithCount sets maximum amount of addresses that ListWithCursor can return.
@@ -38,9 +41,9 @@ func (p *ListWithCursorPrm) WithCount(count uint32) *ListWithCursorPrm {
 }
 
 // WithCursor sets cursor for ListWithCursor operation. For initial request,
-// ignore this param or use empty string. For continues requests, use value
+// ignore this param or use nil value. For continues requests, use value
 // from ListWithCursorRes.
-func (p *ListWithCursorPrm) WithCursor(cursor string) *ListWithCursorPrm {
+func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 	p.cursor = cursor
 	return p
 }
@@ -51,7 +54,7 @@ func (r ListWithCursorRes) AddressList() []*object.Address {
 }
 
 // Cursor returns cursor for consecutive listing requests.
-func (r ListWithCursorRes) Cursor() string {
+func (r ListWithCursorRes) Cursor() *Cursor {
 	return r.cursor
 }
 
@@ -121,11 +124,11 @@ func (s *Shard) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, erro
 // ListWithCursor lists physical objects available in shard starting from
 // cursor. Includes regular, tombstone and storage group objects. Does not
 // include inhumed objects. Use cursor value from response for consecutive requests.
-func ListWithCursor(s *Shard, count uint32, cursor string) ([]*object.Address, string, error) {
+func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]*object.Address, *Cursor, error) {
 	prm := new(ListWithCursorPrm).WithCount(count).WithCursor(cursor)
 	res, err := s.ListWithCursor(prm)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	return res.AddressList(), res.Cursor(), nil

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -34,14 +34,14 @@ type ListWithCursorRes struct {
 	cursor   *Cursor
 }
 
-// WithCount sets maximum amount of addresses that ListWithCursor can return.
+// WithCount sets maximum amount of addresses that ListWithCursor should return.
 func (p *ListWithCursorPrm) WithCount(count uint32) *ListWithCursorPrm {
 	p.count = count
 	return p
 }
 
 // WithCursor sets cursor for ListWithCursor operation. For initial request,
-// ignore this param or use nil value. For continues requests, use value
+// ignore this param or use nil value. For consecutive requests, use value
 // from ListWithCursorRes.
 func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 	p.cursor = cursor
@@ -108,6 +108,9 @@ func ListContainers(s *Shard) ([]*cid.ID, error) {
 // ListWithCursor lists physical objects available in shard starting from
 // cursor. Includes regular, tombstone and storage group objects. Does not
 // include inhumed objects. Use cursor value from response for consecutive requests.
+//
+// Returns ErrEndOfListing if there are no more objects to return or count
+// parameter set to zero.
 func (s *Shard) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
 	metaPrm := new(meta.ListPrm).WithCount(prm.count).WithCursor(prm.cursor)
 	res, err := s.metaBase.ListWithCursor(metaPrm)
@@ -124,6 +127,9 @@ func (s *Shard) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, erro
 // ListWithCursor lists physical objects available in shard starting from
 // cursor. Includes regular, tombstone and storage group objects. Does not
 // include inhumed objects. Use cursor value from response for consecutive requests.
+//
+// Returns ErrEndOfListing if there are no more objects to return or count
+// parameter set to zero.
 func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]*object.Address, *Cursor, error) {
 	prm := new(ListWithCursorPrm).WithCount(count).WithCursor(cursor)
 	res, err := s.ListWithCursor(prm)

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -12,6 +12,11 @@ import (
 // Cursor is a type for continuous object listing.
 type Cursor = meta.Cursor
 
+// ErrEndOfListing is returned from object listing with cursor
+// when storage can't return any more objects after provided
+// cursor. Use nil cursor object to start listing again.
+var ErrEndOfListing = meta.ErrEndOfListing
+
 type ListContainersPrm struct{}
 
 type ListContainersRes struct {

--- a/pkg/local_object_storage/shard/shard_test.go
+++ b/pkg/local_object_storage/shard/shard_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
@@ -60,7 +61,7 @@ func newShard(t testing.TB, enableWriteCache bool) *shard.Shard {
 
 func releaseShard(s *shard.Shard, t testing.TB) {
 	s.Close()
-	os.RemoveAll(t.Name())
+	os.RemoveAll(strings.Split(t.Name(), string(os.PathSeparator))[0])
 }
 
 func generateRawObject(t *testing.T) *object.RawObject {


### PR DESCRIPTION
Object listing operation is required for replication mechanism. Replicator iterates over available physically stored object and tries to verify and restore placement policy for each of them.

Current listing mechanism is quite inefficient. Engine provides `List` method that gathers **all** available objects from every shard. Replicator uses it without the count limit, so it may create giant list of object addresses.

```go
res, err := engine.List(q.localStorage, 0) // res contains all available object addresses in the node
if err != nil {
	return nil, err
}
```

The better way is to iterate over small chunks of object addresses using cursor. This PR implements such listing operations on metabase, shard and storage engine. 

```go
prm := new(ListObjectsWithCursorPrm).WithCount(10)
res, err := engine.ListObjectsWithCursor(prm) // res contains at most 10 addresses
if err != nil {
	return nil, err
}

// do something with res

for {
	// repeat reading small chunks at 10 addresses
	res, err = engine.ListObjectsWithCursor(prm.WithCursor(res.Cursor())) // 10 more address
	if err != nil {
		break // repeat until ErrEndOfListing is returned
	}

	// do something with res
}
```

:information_source: `shard.ID` encoded directly into the cursor so the engine iterates over shards one by one. However it might slow replication, because shards will block each other. With explicit shard control, it is possible to replicate data from shards in parallel.

---

Metabase implementation still questionable: there is no guarantee that boltDB bucket iterators are stable enough. However in all local test, including metabase change during the listing, results are pretty stable. In fact, if they going to be completely random, this will work for replication scheme as well. 