### PR TITLE
Make notary deposit on notification instead of timer

### DIFF
--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -50,12 +50,6 @@ type (
 
 	depositor func() (util.Uint256, error)
 	awaiter   func(context.Context, util.Uint256) error
-
-	notaryDepositArgs struct {
-		l *zap.Logger
-
-		depositor depositor
-	}
 )
 
 func (s *Server) addBlockTimer(t *timer.BlockTimer) {
@@ -147,14 +141,4 @@ func newEmissionTimer(args *emitTimerArgs) *timer.BlockTimer {
 			args.ap.HandleGasEmission(timerEvent.NewAlphabetEmitTick{})
 		},
 	)
-}
-
-func newNotaryDepositHandler(args *notaryDepositArgs) newEpochHandler {
-	return func() {
-		_, err := args.depositor()
-		if err != nil {
-			args.l.Warn("can't deposit notary contract",
-				zap.String("error", err.Error()))
-		}
-	}
 }

--- a/pkg/innerring/processors/netmap/handlers.go
+++ b/pkg/innerring/processors/netmap/handlers.go
@@ -32,7 +32,7 @@ func (np *Processor) handleNewEpoch(ev event.Event) {
 	// send event to the worker pool
 
 	err := np.pool.Submit(func() {
-		np.processNewEpoch(epochEvent.EpochNumber())
+		np.processNewEpoch(epochEvent)
 	})
 	if err != nil {
 		// there system can be moved into controlled degradation stage

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -4,12 +4,15 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/audit"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/governance"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement"
+	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
 	"go.uber.org/zap"
 )
 
 // Process new epoch notification by setting global epoch value and resetting
 // local epoch timer.
-func (np *Processor) processNewEpoch(epoch uint64) {
+func (np *Processor) processNewEpoch(event netmapEvent.NewEpoch) {
+	epoch := event.EpochNumber()
+
 	epochDuration, err := np.netmapClient.EpochDuration()
 	if err != nil {
 		np.log.Warn("can't get epoch duration",
@@ -48,6 +51,7 @@ func (np *Processor) processNewEpoch(epoch uint64) {
 	np.handleNewAudit(audit.NewAuditStartEvent(epoch))
 	np.handleAuditSettlements(settlement.NewAuditEvent(epoch))
 	np.handleAlphabetSync(governance.NewSyncEvent())
+	np.handleNotaryDeposit(event)
 }
 
 // Process new epoch tick by invoking new epoch method in network map contract.

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -65,6 +65,7 @@ type (
 		handleNewAudit         event.Handler
 		handleAuditSettlements event.Handler
 		handleAlphabetSync     event.Handler
+		handleNotaryDeposit    event.Handler
 
 		nodeValidator NodeValidator
 
@@ -86,6 +87,7 @@ type (
 		HandleAudit             event.Handler
 		AuditSettlementsHandler event.Handler
 		AlphabetSyncHandler     event.Handler
+		NotaryDepositHandler    event.Handler
 
 		NodeValidator NodeValidator
 
@@ -116,6 +118,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/netmap: audit settlement handler is not set")
 	case p.AlphabetSyncHandler == nil:
 		return nil, errors.New("ir/netmap: alphabet sync handler is not set")
+	case p.NotaryDepositHandler == nil:
+		return nil, errors.New("ir/netmap: notary deposit handler is not set")
 	case p.ContainerWrapper == nil:
 		return nil, errors.New("ir/netmap: container contract wrapper is not set")
 	case p.NodeValidator == nil:
@@ -143,6 +147,8 @@ func New(p *Params) (*Processor, error) {
 		handleAuditSettlements: p.AuditSettlementsHandler,
 
 		handleAlphabetSync: p.AlphabetSyncHandler,
+
+		handleNotaryDeposit: p.NotaryDepositHandler,
 
 		nodeValidator: p.NodeValidator,
 


### PR DESCRIPTION
Related to #910 

During v0.26.1 pre release testing, I saw this warning in IR logs:
```
warn    innerring/blocktimer.go:106     can't stop epoch estimation     {"epoch": 17, "error": "could not invoke method (stopContainerEstimation): failed to submit notary request: Block or transaction validation failed. (-504) - fallback transaction is valid after deposit is unlocked: V
alidUntilBlock is 3300, deposit lock expires at 3245"}
```

Turns out, that notary deposit did not trigger by new epoch event. Instead deposits were triggered by epoch timer. It is not correct, because timer can never fire up, due to desynchronization or external epoch changes.