### PR TITLE
locode: Use the nearest polygon when continent can't be found

### DIFF
--- a/pkg/util/locode/db/continents/geojson/calls.go
+++ b/pkg/util/locode/db/continents/geojson/calls.go
@@ -31,7 +31,10 @@ func (db *DB) PointContinent(point *locodedb.Point) (*locodedb.Continent, error)
 
 	planarPoint := orb.Point{point.Longitude(), point.Latitude()}
 
-	var continent string
+	var (
+		continent string
+		minDst    float64
+	)
 
 	for _, feature := range db.features {
 		if multiPolygon, ok := feature.Geometry.(orb.MultiPolygon); ok {
@@ -44,6 +47,11 @@ func (db *DB) PointContinent(point *locodedb.Point) (*locodedb.Continent, error)
 				continent = feature.Properties.MustString(continentProperty)
 				break
 			}
+		}
+		distance := planar.DistanceFrom(feature.Geometry, planarPoint)
+		if minDst == 0 || minDst > distance {
+			minDst = distance
+			continent = feature.Properties.MustString(continentProperty)
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neofs-locode-db/issues/3

Tried with files from [v0.2.0](https://github.com/nspcc-dev/neofs-locode-db/releases/tag/v0.2.0) release:
```
$ md5sum *                  
aa5cf0c45f27db3941d72aaed1419e7f  2021-1 SubdivisionCodes.csv
fe16f76ad454017f23e8c979c82e4193  2021-1 UNLOCODE CodeListPart1.csv
9f4ce9eb9abb2b792c07c8227fb9cd08  2021-1 UNLOCODE CodeListPart2.csv
29c5035dbf6edd6de1e507da4fb7f093  2021-1 UNLOCODE CodeListPart3.csv
acfcde754e66b4f224562fa74b567b2b  airports.dat
c071299e8583cc5df070e09dcf4cd5fd  continents.geojson
6807f95b4259edb4c87c12cf1677d3e4  countries.dat
```

After the fix both `SE STO` and `RU VAO` are present in the database.

```
$ neofs-cli util locode info --db a.db --locode 'SE STO'
Country: Sweden
Location: Stockholm
Continent: Europe
Subdivision: [AB] Stockholms l�n
Coordinates: 59.33, 18.05

$ neofs-cli util locode info --db a.db --locode 'RU VAO'
Country: Russia
Location: Vassilevsky Ostrov/St Petersburg
Continent: Europe
Coordinates: 59.93, 30.22
```