### PR TITLE
cli/locode: Open RO database in `info` command

### DIFF
--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -159,7 +159,7 @@ var (
 		Run: func(cmd *cobra.Command, _ []string) {
 			targetDB := locodebolt.New(locodebolt.Prm{
 				Path: locodeInfoDBPath,
-			})
+			}, locodebolt.ReadOnly())
 
 			err := targetDB.Open()
 			exitOnErr(cmd, err)


### PR DESCRIPTION
Closes #958.