### PR TITLE
Feat/Generate nonce and vub based on notifications information

### DIFF
--- a/cmd/neofs-ir/main.go
+++ b/cmd/neofs-ir/main.go
@@ -7,10 +7,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neofs-node/misc"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring"
 	httputil "github.com/nspcc-dev/neofs-node/pkg/util/http"
@@ -37,7 +35,6 @@ func exitErr(err error) {
 
 func main() {
 	configFile := flag.String("config", "", "path to config")
-	validators := flag.String("vote", "", "hex encoded public keys split with comma")
 	versionFlag := flag.Bool("version", false, "neofs-ir node version")
 	flag.Parse()
 
@@ -74,16 +71,6 @@ func main() {
 
 	innerRing, err := innerring.New(ctx, log, cfg)
 	exitErr(err)
-
-	if len(*validators) != 0 {
-		validatorKeys, err := parsePublicKeysFromString(*validators)
-		exitErr(err)
-
-		err = innerRing.InitAndVoteForSidechainValidator(validatorKeys)
-		exitErr(err)
-
-		return
-	}
 
 	// start HTTP servers
 	for i := range httpServers {
@@ -127,12 +114,6 @@ func main() {
 	}
 
 	log.Info("application stopped")
-}
-
-func parsePublicKeysFromString(argument string) (keys.PublicKeys, error) {
-	publicKeysString := strings.Split(argument, ",")
-
-	return innerring.ParsePublicKeysFromStrings(publicKeysString)
 }
 
 func initHTTPServers(cfg *viper.Viper) []*httputil.Server {

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -476,7 +476,10 @@ func (c *cfg) bootstrap() error {
 	ni := c.cfgNodeInfo.localInfo
 	ni.SetState(netmap.NodeStateOnline)
 
-	return c.cfgNetmap.wrapper.AddPeer(&ni)
+	prm := nmwrapper.AddPeerPrm{}
+	prm.SetNodeInfo(&ni)
+
+	return c.cfgNetmap.wrapper.AddPeer(prm)
 }
 
 // needBootstrap checks if local node should be registered in network on bootup.

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -221,7 +221,12 @@ func (w *morphLoadWriter) Put(a containerSDK.UsedSpaceAnnouncement) error {
 		zap.Uint64("size", a.UsedSpace()),
 	)
 
-	return w.cnrMorphClient.AnnounceLoad(a, w.key)
+	prm := wrapper.AnnounceLoadPrm{}
+
+	prm.SetAnnouncement(a)
+	prm.SetReporter(w.key)
+
+	return w.cnrMorphClient.AnnounceLoad(prm)
 }
 
 func (*morphLoadWriter) Close() error {

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -9,6 +9,7 @@ import (
 	netmapGRPC "github.com/nspcc-dev/neofs-api-go/v2/netmap/grpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
@@ -283,10 +284,12 @@ func (c *cfg) SetNetmapStatus(st control.NetmapStatus) error {
 
 	c.cfgNetmap.reBoostrapTurnedOff.Store(true)
 
-	return c.cfgNetmap.wrapper.UpdatePeerState(
-		c.key.PublicKey().Bytes(),
-		apiState,
-	)
+	prm := wrapper.UpdatePeerPrm{}
+
+	prm.SetKey(c.key.PublicKey().Bytes())
+	prm.SetState(apiState)
+
+	return c.cfgNetmap.wrapper.UpdatePeerState(prm)
 }
 
 type netInfo struct {

--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -95,7 +95,10 @@ func newEpochTimer(args *epochTimerArgs) *timer.BlockTimer {
 				return
 			}
 
-			err := args.cnrWrapper.StopEstimation(epochN - 1)
+			prm := container.StopEstimationPrm{}
+			prm.SetEpoch(epochN - 1)
+
+			err := args.cnrWrapper.StopEstimation(prm)
 			if err != nil {
 				args.l.Warn("can't stop epoch estimation",
 					zap.Uint64("epoch", epochN),

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -191,8 +191,11 @@ func (s *Server) Start(ctx context.Context, intError chan<- error) (err error) {
 		}
 	}
 
+	prm := governance.VoteValidatorPrm{}
+	prm.Validators = s.predefinedValidators
+
 	// vote for sidechain validator if it is prepared in config
-	err = s.voteForSidechainValidator(s.predefinedValidators)
+	err = s.voteForSidechainValidator(prm)
 	if err != nil {
 		// we don't stop inner ring execution on this error
 		s.log.Warn("can't vote for prepared validators",

--- a/pkg/innerring/processors/balance/process_assets.go
+++ b/pkg/innerring/processors/balance/process_assets.go
@@ -1,6 +1,7 @@
 package balance
 
 import (
+	neofscontract "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofs/wrapper"
 	balanceEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/balance"
 	"go.uber.org/zap"
 )
@@ -13,11 +14,15 @@ func (bp *Processor) processLock(lock *balanceEvent.Lock) {
 		return
 	}
 
-	err := bp.neofsClient.Cheque(
-		lock.ID(),
-		lock.User(),
-		bp.converter.ToFixed8(lock.Amount()),
-		lock.LockAccount())
+	prm := neofscontract.ChequePrm{}
+
+	prm.SetID(lock.ID())
+	prm.SetUser(lock.User())
+	prm.SetAmount(bp.converter.ToFixed8(lock.Amount()))
+	prm.SetLock(lock.LockAccount())
+	prm.SetHash(lock.TxHash())
+
+	err := bp.neofsClient.Cheque(prm)
 	if err != nil {
 		bp.log.Error("can't send lock asset tx", zap.Error(err))
 	}

--- a/pkg/innerring/processors/container/common.go
+++ b/pkg/innerring/processors/container/common.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
@@ -65,7 +66,10 @@ func (cp *Processor) checkKeyOwnership(ownerIDSrc ownerIDSource, key *keys.Publi
 		return nil
 	}
 
-	ownerKeys, err := cp.idClient.AccountKeys(ownerIDSrc.OwnerID())
+	prm := neofsid.AccountKeysPrm{}
+	prm.SetID(ownerIDSrc.OwnerID())
+
+	ownerKeys, err := cp.idClient.AccountKeys(prm)
 	if err != nil {
 		return fmt.Errorf("could not received owner keys %s: %w", ownerIDSrc.OwnerID(), err)
 	}

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
+	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
 	containerSDK "github.com/nspcc-dev/neofs-sdk-go/container"
@@ -198,8 +199,11 @@ func (cp *Processor) checkDeleteContainer(e *containerEvent.Delete) error {
 
 		checkKeys = keys.PublicKeys{key}
 	} else {
+		prm := neofsid.AccountKeysPrm{}
+		prm.SetID(cnr.OwnerID())
+
 		// receive all owner keys from NeoFS ID contract
-		checkKeys, err = cp.idClient.AccountKeys(cnr.OwnerID())
+		checkKeys, err = cp.idClient.AccountKeys(prm)
 		if err != nil {
 			return fmt.Errorf("could not received owner keys %s: %w", cnr.OwnerID(), err)
 		}

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -6,12 +6,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
-
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"

--- a/pkg/innerring/processors/container/process_eacl.go
+++ b/pkg/innerring/processors/container/process_eacl.go
@@ -85,12 +85,19 @@ func (cp *Processor) checkSetEACL(e container.SetEACL) error {
 func (cp *Processor) approveSetEACL(e container.SetEACL) {
 	var err error
 
+	prm := wrapper.PutEACLPrm{}
+
+	prm.SetTable(e.Table())
+	prm.SetKey(e.PublicKey())
+	prm.SetSignature(e.Signature())
+	prm.SetToken(e.SessionToken())
+
 	if nr := e.NotaryRequest(); nr != nil {
 		// setEACL event was received via Notary service
 		err = cp.cnrClient.Morph().NotarySignAndInvokeTX(nr.MainTransaction)
 	} else {
 		// setEACL event was received via notification service
-		err = cp.cnrClient.PutEACL(e.Table(), e.PublicKey(), e.Signature(), e.SessionToken())
+		err = cp.cnrClient.PutEACL(prm)
 	}
 	if err != nil {
 		cp.log.Error("could not approve set EACL",

--- a/pkg/innerring/processors/governance/events.go
+++ b/pkg/innerring/processors/governance/events.go
@@ -1,11 +1,26 @@
 package governance
 
-// Sync is a event to start governance synchronization.
-type Sync struct{}
+import "github.com/nspcc-dev/neo-go/pkg/util"
+
+// Sync is an event to start governance synchronization.
+type Sync struct {
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
+}
+
+// TxHash returns hash of the TX that triggers
+// synchronization process.
+func (s Sync) TxHash() util.Uint256 {
+	return s.txHash
+}
 
 // MorphEvent implements Event interface.
 func (s Sync) MorphEvent() {}
 
-func NewSyncEvent() Sync {
-	return Sync{}
+// NewSyncEvent creates Sync event that was produced
+// in transaction with txHash hash.
+func NewSyncEvent(txHash util.Uint256) Sync {
+	return Sync{txHash: txHash}
 }

--- a/pkg/innerring/processors/governance/handlers.go
+++ b/pkg/innerring/processors/governance/handlers.go
@@ -3,22 +3,29 @@ package governance
 import (
 	"github.com/nspcc-dev/neo-go/pkg/core/native"
 	"github.com/nspcc-dev/neo-go/pkg/core/native/noderoles"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event/rolemanagement"
 	"go.uber.org/zap"
 )
 
 func (gp *Processor) HandleAlphabetSync(e event.Event) {
-	var typ string
+	var (
+		typ  string
+		hash util.Uint256
+	)
 
 	switch et := e.(type) {
 	case Sync:
 		typ = "sync"
+		hash = et.TxHash()
 	case rolemanagement.Designate:
 		if et.Role != noderoles.NeoFSAlphabet {
 			return
 		}
+
 		typ = native.DesignationEventName
+		hash = et.TxHash
 	default:
 		return
 	}
@@ -27,7 +34,7 @@ func (gp *Processor) HandleAlphabetSync(e event.Event) {
 
 	// send event to the worker pool
 
-	err := gp.pool.Submit(func() { gp.processAlphabetSync() })
+	err := gp.pool.Submit(func() { gp.processAlphabetSync(hash) })
 	if err != nil {
 		// there system can be moved into controlled degradation stage
 		gp.log.Warn("governance worker pool drained",

--- a/pkg/innerring/processors/governance/process_update.go
+++ b/pkg/innerring/processors/governance/process_update.go
@@ -6,12 +6,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
-
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	neofscontract "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofs/wrapper"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	"go.uber.org/zap"
 )
 

--- a/pkg/innerring/processors/governance/processor.go
+++ b/pkg/innerring/processors/governance/processor.go
@@ -26,12 +26,21 @@ type (
 	AlphabetState interface {
 		IsAlphabet() bool
 	}
+)
 
-	// Voter is a callback interface for alphabet contract voting.
-	Voter interface {
-		VoteForSidechainValidator(keys keys.PublicKeys) error
-	}
+// VoteValidatorPrm groups parameters of the VoteForSidechainValidator
+// operation.
+type VoteValidatorPrm struct {
+	Validators keys.PublicKeys
+	Hash       *util.Uint256 // hash of the transaction that triggered voting
+}
 
+// Voter is a callback interface for alphabet contract voting.
+type Voter interface {
+	VoteForSidechainValidator(VoteValidatorPrm) error
+}
+
+type (
 	// EpochState is a callback interface for innerring global state.
 	EpochState interface {
 		EpochCounter() uint64

--- a/pkg/innerring/processors/neofs/process_bind.go
+++ b/pkg/innerring/processors/neofs/process_bind.go
@@ -4,6 +4,8 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
+	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
+
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
@@ -15,6 +17,7 @@ import (
 type bindCommon interface {
 	User() []byte
 	Keys() [][]byte
+	TxHash() util.Uint256
 }
 
 func (np *Processor) processBind(e bindCommon) {
@@ -93,7 +96,14 @@ func (np *Processor) approveBindCommon(e *bindCommonContext) {
 		return
 	}
 
-	err = np.neofsIDClient.ManageKeys(wallet, e.Keys(), e.bind)
+	prm := neofsid.ManageKeysPrm{}
+
+	prm.SetOwnerID(wallet)
+	prm.SetKeys(e.Keys())
+	prm.SetAdd(e.bind)
+	prm.SetHash(e.bindCommon.TxHash())
+
+	err = np.neofsIDClient.ManageKeys(prm)
 	if err != nil {
 		var typ string
 

--- a/pkg/innerring/processors/neofs/process_bind.go
+++ b/pkg/innerring/processors/neofs/process_bind.go
@@ -4,12 +4,11 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
-	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
-
 	"github.com/mr-tron/base58"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	neofsid "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event/neofs"
 	"go.uber.org/zap"
 )

--- a/pkg/innerring/processors/neofs/process_config.go
+++ b/pkg/innerring/processors/neofs/process_config.go
@@ -1,6 +1,7 @@
 package neofs
 
 import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap/wrapper"
 	neofsEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/neofs"
 	"go.uber.org/zap"
 )
@@ -13,7 +14,14 @@ func (np *Processor) processConfig(config *neofsEvent.Config) {
 		return
 	}
 
-	err := np.netmapClient.SetConfig(config.ID(), config.Key(), config.Value())
+	prm := wrapper.SetConfigPrm{}
+
+	prm.SetID(config.ID())
+	prm.SetKey(config.Key())
+	prm.SetValue(config.Value())
+	prm.SetHash(config.TxHash())
+
+	err := np.netmapClient.SetConfig(prm)
 	if err != nil {
 		np.log.Error("can't relay set config event", zap.Error(err))
 	}

--- a/pkg/innerring/processors/netmap/internal_events.go
+++ b/pkg/innerring/processors/netmap/internal_events.go
@@ -1,8 +1,21 @@
 package netmap
 
+import "github.com/nspcc-dev/neo-go/pkg/util"
+
 // netmapCleanupTick is a event to remove offline nodes.
 type netmapCleanupTick struct {
 	epoch uint64
+
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
+}
+
+// TxHash returns hash of the TX that triggers
+// synchronization process.
+func (s netmapCleanupTick) TxHash() util.Uint256 {
+	return s.txHash
 }
 
 // MorphEvent implements Event interface.

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -4,6 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/audit"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/governance"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container/wrapper"
 	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
 	"go.uber.org/zap"
 )
@@ -36,8 +37,13 @@ func (np *Processor) processNewEpoch(ev netmapEvent.NewEpoch) {
 		return
 	}
 
+	prm := wrapper.StartEstimationPrm{}
+
+	prm.SetEpoch(epoch - 1)
+	prm.SetHash(ev.TxHash())
+
 	if epoch > 0 { // estimates are invalid in genesis epoch
-		err = np.containerWrp.StartEstimation(epoch - 1)
+		err = np.containerWrp.StartEstimation(prm)
 
 		if err != nil {
 			np.log.Warn("can't start container size estimation",

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -10,8 +10,8 @@ import (
 
 // Process new epoch notification by setting global epoch value and resetting
 // local epoch timer.
-func (np *Processor) processNewEpoch(event netmapEvent.NewEpoch) {
-	epoch := event.EpochNumber()
+func (np *Processor) processNewEpoch(ev netmapEvent.NewEpoch) {
+	epoch := ev.EpochNumber()
 
 	epochDuration, err := np.netmapClient.EpochDuration()
 	if err != nil {
@@ -47,11 +47,11 @@ func (np *Processor) processNewEpoch(event netmapEvent.NewEpoch) {
 	}
 
 	np.netmapSnapshot.update(networkMap, epoch)
-	np.handleCleanupTick(netmapCleanupTick{epoch: epoch})
+	np.handleCleanupTick(netmapCleanupTick{epoch: epoch, txHash: ev.TxHash()})
 	np.handleNewAudit(audit.NewAuditStartEvent(epoch))
 	np.handleAuditSettlements(settlement.NewAuditEvent(epoch))
-	np.handleAlphabetSync(governance.NewSyncEvent())
-	np.handleNotaryDeposit(event)
+	np.handleAlphabetSync(governance.NewSyncEvent(ev.TxHash()))
+	np.handleNotaryDeposit(ev)
 }
 
 // Process new epoch tick by invoking new epoch method in network map contract.

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/governance"
+	auditwrp "github.com/nspcc-dev/neofs-node/pkg/morph/client/audit/wrapper"
 	"github.com/nspcc-dev/neofs-node/pkg/services/audit"
 	control "github.com/nspcc-dev/neofs-node/pkg/services/control/ir"
 	"github.com/nspcc-dev/neofs-node/pkg/util/state"
@@ -145,7 +146,10 @@ func (s *Server) WriteReport(r *audit.Report) error {
 	res := r.Result()
 	res.SetPublicKey(s.pubKey)
 
-	return s.auditClient.PutAuditResult(res)
+	prm := auditwrp.PutPrm{}
+	prm.SetResult(res)
+
+	return s.auditClient.PutAuditResult(prm)
 }
 
 // ResetEpochTimer resets block timer that produces events to update epoch

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -118,18 +118,6 @@ func (s *Server) voteForSidechainValidator(validators keys.PublicKeys) error {
 	return nil
 }
 
-// InitAndVoteForSidechainValidator is a public function to use outside of
-// inner ring daemon execution. It initialize inner ring structure with data
-// from blockchain and then calls vote method on alphabet contracts.
-func (s *Server) InitAndVoteForSidechainValidator(validators keys.PublicKeys) error {
-	err := s.initConfigFromBlockchain()
-	if err != nil {
-		return err
-	}
-
-	return s.VoteForSidechainValidator(validators)
-}
-
 // VoteForSidechainValidator calls vote method on alphabet contracts with
 // provided list of keys.
 func (s *Server) VoteForSidechainValidator(validators keys.PublicKeys) error {

--- a/pkg/morph/client/audit/get_result.go
+++ b/pkg/morph/client/audit/get_result.go
@@ -31,10 +31,12 @@ func (v *GetAuditResultValue) Result() []byte {
 // GetAuditResult invokes the call of "get audit result" method
 // of NeoFS Audit contract.
 func (c *Client) GetAuditResult(args GetAuditResultArgs) (*GetAuditResultValue, error) {
-	prms, err := c.client.TestInvoke(
-		c.getResultMethod,
-		args.id,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.getResultMethod)
+	invokePrm.SetArgs(args.id)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.getResultMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/audit/list_results.go
+++ b/pkg/morph/client/audit/list_results.go
@@ -63,9 +63,11 @@ func (v *ListResultsByNodeArgs) SetNodeKey(key []byte) {
 // ListAuditResults performs the test invoke of "list all audit result IDs"
 // method of NeoFS Audit contract.
 func (c *Client) ListAuditResults(args ListResultsArgs) (*ListResultsValues, error) {
-	items, err := c.client.TestInvoke(
-		c.listResultsMethod,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listResultsMethod)
+
+	items, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listResultsMethod, err)
 	}
@@ -76,10 +78,12 @@ func (c *Client) ListAuditResults(args ListResultsArgs) (*ListResultsValues, err
 // ListAuditResultsByEpoch performs the test invoke of "list audit result IDs
 // by epoch" method of NeoFS Audit contract.
 func (c *Client) ListAuditResultsByEpoch(args ListResultsByEpochArgs) (*ListResultsValues, error) {
-	items, err := c.client.TestInvoke(
-		c.listByEpochResultsMethod,
-		args.epoch,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listByEpochResultsMethod)
+	invokePrm.SetArgs(args.epoch)
+
+	items, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listByEpochResultsMethod, err)
 	}
@@ -90,11 +94,12 @@ func (c *Client) ListAuditResultsByEpoch(args ListResultsByEpochArgs) (*ListResu
 // ListAuditResultsByCID performs the test invoke of "list audit result IDs
 // by epoch and CID" method of NeoFS Audit contract.
 func (c *Client) ListAuditResultsByCID(args ListResultsByCIDArgs) (*ListResultsValues, error) {
-	items, err := c.client.TestInvoke(
-		c.listByCIDResultsMethod,
-		args.epoch,
-		args.cid,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listByCIDResultsMethod)
+	invokePrm.SetArgs(args.epoch, args.cid)
+
+	items, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listByCIDResultsMethod, err)
 	}
@@ -105,12 +110,12 @@ func (c *Client) ListAuditResultsByCID(args ListResultsByCIDArgs) (*ListResultsV
 // ListAuditResultsByNode performs the test invoke of "list audit result IDs
 // by epoch, CID, and node key" method of NeoFS Audit contract.
 func (c *Client) ListAuditResultsByNode(args ListResultsByNodeArgs) (*ListResultsValues, error) {
-	items, err := c.client.TestInvoke(
-		c.listByNodeResultsMethod,
-		args.epoch,
-		args.cid,
-		args.nodeKey,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listByNodeResultsMethod)
+	invokePrm.SetArgs(args.epoch, args.cid, args.nodeKey)
+
+	items, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listByNodeResultsMethod, err)
 	}

--- a/pkg/morph/client/audit/put_result.go
+++ b/pkg/morph/client/audit/put_result.go
@@ -2,6 +2,8 @@ package audit
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // PutAuditResultArgs groups the arguments
@@ -19,10 +21,12 @@ func (g *PutAuditResultArgs) SetRawResult(v []byte) {
 // PutAuditResult invokes the call of "put audit result" method
 // of NeoFS Audit contract.
 func (c *Client) PutAuditResult(args PutAuditResultArgs) error {
-	err := c.client.Invoke(
-		c.putResultMethod,
-		args.rawResult,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.putResultMethod)
+	prm.SetArgs(args.rawResult)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.putResultMethod, err)

--- a/pkg/morph/client/audit/put_result.go
+++ b/pkg/morph/client/audit/put_result.go
@@ -10,6 +10,8 @@ import (
 // of "put audit result" invocation call.
 type PutAuditResultArgs struct {
 	rawResult []byte // audit result in NeoFS API-compatible binary representation
+
+	client.InvokePrmOptional
 }
 
 // SetRawResult sets audit result structure
@@ -25,6 +27,7 @@ func (c *Client) PutAuditResult(args PutAuditResultArgs) error {
 
 	prm.SetMethod(c.putResultMethod)
 	prm.SetArgs(args.rawResult)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 

--- a/pkg/morph/client/audit/wrapper/result.go
+++ b/pkg/morph/client/audit/wrapper/result.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/audit"
 	auditAPI "github.com/nspcc-dev/neofs-sdk-go/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -14,18 +15,31 @@ type ResultID []byte
 
 var errUnsupported = errors.New("unsupported structure version")
 
+// PutPrm groups parameters of PutAuditResult operation.
+type PutPrm struct {
+	result *auditAPI.Result
+
+	client.InvokePrmOptional
+}
+
+// SetResult sets audit result.
+func (p *PutPrm) SetResult(result *auditAPI.Result) {
+	p.result = result
+}
+
 // PutAuditResult saves passed audit result structure in NeoFS system
 // through Audit contract call.
 //
 // Returns encountered error that caused the saving to interrupt.
-func (w *ClientWrapper) PutAuditResult(result *auditAPI.Result) error {
-	rawResult, err := result.Marshal()
+func (w *ClientWrapper) PutAuditResult(prm PutPrm) error {
+	rawResult, err := prm.result.Marshal()
 	if err != nil {
 		return fmt.Errorf("could not marshal audit result: %w", err)
 	}
 
 	args := audit.PutAuditResultArgs{}
 	args.SetRawResult(rawResult)
+	args.InvokePrmOptional = prm.InvokePrmOptional
 
 	return w.client.
 		PutAuditResult(args)

--- a/pkg/morph/client/audit/wrapper/result_test.go
+++ b/pkg/morph/client/audit/wrapper/result_test.go
@@ -40,7 +40,10 @@ func TestAuditResults(t *testing.T) {
 	auditRes.SetPublicKey(key.PublicKey().Bytes())
 	auditRes.SetContainerID(id)
 
-	require.NoError(t, auditClientWrapper.PutAuditResult(auditRes))
+	prm := auditWrapper.PutPrm{}
+	prm.SetResult(auditRes)
+
+	require.NoError(t, auditClientWrapper.PutAuditResult(prm))
 
 	time.Sleep(5 * time.Second)
 

--- a/pkg/morph/client/balance/balanceOf.go
+++ b/pkg/morph/client/balance/balanceOf.go
@@ -33,10 +33,12 @@ func (g *GetBalanceOfValues) Amount() *big.Int {
 // BalanceOf performs the test invoke of "balance of"
 // method of NeoFS Balance contract.
 func (c *Client) BalanceOf(args GetBalanceOfArgs) (*GetBalanceOfValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.balanceOfMethod,
-		args.wallet,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.balanceOfMethod)
+	invokePrm.SetArgs(args.wallet)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.balanceOfMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/balance/decimals.go
+++ b/pkg/morph/client/balance/decimals.go
@@ -25,9 +25,11 @@ func (d *DecimalsValues) Decimals() int64 {
 // Decimals performs the test invoke of decimals
 // method of NeoFS Balance contract.
 func (c *Client) Decimals(args DecimalsArgs) (*DecimalsValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.decimalsMethod,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.decimalsMethod)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.decimalsMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -16,6 +16,8 @@ type TransferXArgs struct {
 	recipient []byte // recipient's wallet script hash
 
 	details []byte // transfer details
+
+	client.InvokePrmOptional
 }
 
 // SetAmount sets amount of funds to transfer
@@ -49,6 +51,7 @@ func (c *Client) TransferX(args TransferXArgs) error {
 
 	prm.SetMethod(c.transferXMethod)
 	prm.SetArgs(args.sender, args.recipient, args.amount, args.details)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 	if err != nil {
@@ -58,32 +61,119 @@ func (c *Client) TransferX(args TransferXArgs) error {
 	return nil
 }
 
+// MintPrm groups parameters of Mint operation.
+type MintPrm struct {
+	to     []byte
+	amount int64
+	id     []byte
+
+	client.InvokePrmOptional
+}
+
+// SetTo sets receiver of the transfer.
+func (m *MintPrm) SetTo(to []byte) {
+	m.to = to
+}
+
+// SetAmount sets amount of the transfer.
+func (m *MintPrm) SetAmount(amount int64) {
+	m.amount = amount
+}
+
+// SetID sets ID.
+func (m *MintPrm) SetID(id []byte) {
+	m.id = id
+}
+
 // Mint invokes `mint` method of the balance contract.
-func (c *Client) Mint(to []byte, amount int64, id []byte) error {
+func (c *Client) Mint(args MintPrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(c.mintMethod)
-	prm.SetArgs(to, amount, id)
+	prm.SetArgs(args.to, args.amount, args.id)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return c.client.Invoke(prm)
+}
+
+// BurnPrm groups parameters of Burn operation.
+type BurnPrm struct {
+	to     []byte
+	amount int64
+	id     []byte
+
+	client.InvokePrmOptional
+}
+
+// SetTo sets receiver.
+func (b *BurnPrm) SetTo(to []byte) {
+	b.to = to
+}
+
+// SetAmount sets amount.
+func (b *BurnPrm) SetAmount(amount int64) {
+	b.amount = amount
+}
+
+// SetID sets ID
+func (b *BurnPrm) SetID(id []byte) {
+	b.id = id
 }
 
 // Burn invokes `burn` method of the balance contract.
-func (c *Client) Burn(to []byte, amount int64, id []byte) error {
+func (c *Client) Burn(args BurnPrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(c.burnMethod)
-	prm.SetArgs(to, amount, id)
+	prm.SetArgs(args.to, args.amount, args.id)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return c.client.Invoke(prm)
 }
 
+// LockPrm groups parameters of Lock operation.
+type LockPrm struct {
+	id       []byte
+	user     []byte
+	lock     []byte
+	amount   int64
+	dueEpoch int64
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID.
+func (l *LockPrm) SetID(id []byte) {
+	l.id = id
+}
+
+// SetUser set user.
+func (l *LockPrm) SetUser(user []byte) {
+	l.user = user
+}
+
+// SetLock sets lock.
+func (l *LockPrm) SetLock(lock []byte) {
+	l.lock = lock
+}
+
+// SetAmount sets amount.
+func (l *LockPrm) SetAmount(amount int64) {
+	l.amount = amount
+}
+
+// SetDueEpoch sets end of the lock.
+func (l *LockPrm) SetDueEpoch(dueEpoch int64) {
+	l.dueEpoch = dueEpoch
+}
+
 // Lock invokes `lock` method of the balance contract.
-func (c *Client) Lock(id, user, lock []byte, amount, dueEpoch int64) error {
+func (c *Client) Lock(args LockPrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(c.lockMethod)
-	prm.SetArgs(id, user, lock, amount, dueEpoch)
+	prm.SetArgs(args.id, args.user, args.lock, args.amount, args.dueEpoch)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return c.client.Invoke(prm)
 }

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -115,7 +115,7 @@ func (b *BurnPrm) SetAmount(amount int64) {
 	b.amount = amount
 }
 
-// SetID sets ID
+// SetID sets ID.
 func (b *BurnPrm) SetID(id []byte) {
 	b.id = id
 }

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -2,6 +2,8 @@ package balance
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // TransferXArgs groups the arguments
@@ -43,13 +45,12 @@ func (t *TransferXArgs) SetDetails(v []byte) {
 // TransferX directly invokes the call of "transferX" method
 // of NeoFS Balance contract.
 func (c *Client) TransferX(args TransferXArgs) error {
-	err := c.client.Invoke(
-		c.transferXMethod,
-		args.sender,
-		args.recipient,
-		args.amount,
-		args.details,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.transferXMethod)
+	prm.SetArgs(args.sender, args.recipient, args.amount, args.details)
+
+	err := c.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.transferXMethod, err)
 	}
@@ -59,15 +60,30 @@ func (c *Client) TransferX(args TransferXArgs) error {
 
 // Mint invokes `mint` method of the balance contract.
 func (c *Client) Mint(to []byte, amount int64, id []byte) error {
-	return c.client.Invoke(c.mintMethod, to, amount, id)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.mintMethod)
+	prm.SetArgs(to, amount, id)
+
+	return c.client.Invoke(prm)
 }
 
 // Burn invokes `burn` method of the balance contract.
 func (c *Client) Burn(to []byte, amount int64, id []byte) error {
-	return c.client.Invoke(c.burnMethod, to, amount, id)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.burnMethod)
+	prm.SetArgs(to, amount, id)
+
+	return c.client.Invoke(prm)
 }
 
 // Lock invokes `lock` method of the balance contract.
 func (c *Client) Lock(id, user, lock []byte, amount, dueEpoch int64) error {
-	return c.client.Invoke(c.lockMethod, id, user, lock, amount, dueEpoch)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.lockMethod)
+	prm.SetArgs(id, user, lock, amount, dueEpoch)
+
+	return c.client.Invoke(prm)
 }

--- a/pkg/morph/client/balance/wrapper/transfer.go
+++ b/pkg/morph/client/balance/wrapper/transfer.go
@@ -3,6 +3,7 @@ package wrapper
 import (
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/balance"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 )
@@ -14,6 +15,8 @@ type TransferPrm struct {
 	From, To *owner.ID
 
 	Details []byte
+
+	client.InvokePrmOptional
 }
 
 // TransferX transfers p.Amount of GASe-12 from p.From to p.To
@@ -36,21 +39,129 @@ func (w *Wrapper) TransferX(p TransferPrm) error {
 	args.SetRecipient(to.BytesBE())
 	args.SetAmount(p.Amount)
 	args.SetDetails(p.Details)
+	args.InvokePrmOptional = p.InvokePrmOptional
 
 	return w.client.TransferX(args)
 }
 
+// MintPrm groups parameters of Mint operation.
+type MintPrm struct {
+	to     util.Uint160
+	amount int64
+	id     []byte
+
+	client.InvokePrmOptional
+}
+
+// SetTo sets receiver of the transfer.
+func (m *MintPrm) SetTo(to util.Uint160) {
+	m.to = to
+}
+
+// SetAmount sets amount of the transfer.
+func (m *MintPrm) SetAmount(amount int64) {
+	m.amount = amount
+}
+
+// SetID sets ID.
+func (m *MintPrm) SetID(id []byte) {
+	m.id = id
+}
+
 // Mint sends funds to the account.
-func (w *Wrapper) Mint(to util.Uint160, amount int64, id []byte) error {
-	return w.client.Mint(to.BytesBE(), amount, id)
+func (w *Wrapper) Mint(prm MintPrm) error {
+	args := balance.MintPrm{}
+
+	args.SetTo(prm.to.BytesBE())
+	args.SetAmount(prm.amount)
+	args.SetID(prm.id)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return w.client.Mint(args)
+}
+
+// BurnPrm groups parameters of Burn operation.
+type BurnPrm struct {
+	to     util.Uint160
+	amount int64
+	id     []byte
+
+	client.InvokePrmOptional
+}
+
+// SetTo sets receiver.
+func (b *BurnPrm) SetTo(to util.Uint160) {
+	b.to = to
+}
+
+// SetAmount sets amount.
+func (b *BurnPrm) SetAmount(amount int64) {
+	b.amount = amount
+}
+
+// SetID sets ID
+func (b *BurnPrm) SetID(id []byte) {
+	b.id = id
 }
 
 // Burn destroys funds from the account.
-func (w *Wrapper) Burn(to util.Uint160, amount int64, id []byte) error {
-	return w.client.Burn(to.BytesBE(), amount, id)
+func (w *Wrapper) Burn(prm BurnPrm) error {
+	args := balance.BurnPrm{}
+
+	args.SetTo(prm.to.BytesBE())
+	args.SetAmount(prm.amount)
+	args.SetID(prm.id)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return w.client.Burn(args)
+}
+
+// LockPrm groups parameters of Lock operation.
+type LockPrm struct {
+	id       []byte
+	user     util.Uint160
+	lock     util.Uint160
+	amount   int64
+	dueEpoch int64
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID.
+func (l *LockPrm) SetID(id []byte) {
+	l.id = id
+}
+
+// SetUser set user.
+func (l *LockPrm) SetUser(user util.Uint160) {
+	l.user = user
+}
+
+// SetLock sets lock.
+func (l *LockPrm) SetLock(lock util.Uint160) {
+	l.lock = lock
+}
+
+// SetAmount sets amount.
+func (l *LockPrm) SetAmount(amount int64) {
+	l.amount = amount
+}
+
+// SetDueEpoch sets end of the lock.
+func (l *LockPrm) SetDueEpoch(dueEpoch int64) {
+	l.dueEpoch = dueEpoch
 }
 
 // Lock locks fund on the user account.
-func (w *Wrapper) Lock(id []byte, user, lock util.Uint160, amount, dueEpoch int64) error {
-	return w.client.Lock(id, user.BytesBE(), lock.BytesBE(), amount, dueEpoch)
+func (w *Wrapper) Lock(prm LockPrm) error {
+	args := balance.LockPrm{}
+
+	args.SetID(prm.id)
+	args.SetUser(prm.user.BytesBE())
+	args.SetLock(prm.lock.BytesBE())
+	args.SetAmount(prm.amount)
+	args.SetDueEpoch(prm.dueEpoch)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return w.client.Lock(args)
 }

--- a/pkg/morph/client/container/delete.go
+++ b/pkg/morph/client/container/delete.go
@@ -14,6 +14,8 @@ type DeleteArgs struct {
 	sig []byte // container identifier signature
 
 	token []byte // binary session token
+
+	client.InvokePrmOptional
 }
 
 // SetCID sets the container identifier
@@ -42,6 +44,7 @@ func (c *Client) Delete(args DeleteArgs) error {
 
 	prm.SetMethod(c.deleteMethod)
 	prm.SetArgs(args.cid, args.sig, args.token)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 

--- a/pkg/morph/client/container/delete.go
+++ b/pkg/morph/client/container/delete.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // DeleteArgs groups the arguments
@@ -36,12 +38,12 @@ func (p *DeleteArgs) SetSessionToken(v []byte) {
 // Delete invokes the call of delete container
 // method of NeoFS Container contract.
 func (c *Client) Delete(args DeleteArgs) error {
-	err := c.client.Invoke(
-		c.deleteMethod,
-		args.cid,
-		args.sig,
-		args.token,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.deleteMethod)
+	prm.SetArgs(args.cid, args.sig, args.token)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.deleteMethod, err)

--- a/pkg/morph/client/container/eacl.go
+++ b/pkg/morph/client/container/eacl.go
@@ -55,10 +55,12 @@ func (g *EACLValues) SessionToken() []byte {
 // EACL performs the test invoke of get eACL
 // method of NeoFS Container contract.
 func (c *Client) EACL(args EACLArgs) (*EACLValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.eaclMethod,
-		args.cid,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.eaclMethod)
+	invokePrm.SetArgs(args.cid)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.eaclMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/container/eacl_set.go
+++ b/pkg/morph/client/container/eacl_set.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // SetEACLArgs groups the arguments
@@ -44,13 +46,12 @@ func (p *SetEACLArgs) SetSessionToken(v []byte) {
 // SetEACL invokes the call of set eACL method
 // of NeoFS Container contract.
 func (c *Client) SetEACL(args SetEACLArgs) error {
-	err := c.client.Invoke(
-		c.setEACLMethod,
-		args.eacl,
-		args.sig,
-		args.pubkey,
-		args.token,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.setEACLMethod)
+	prm.SetArgs(args.eacl, args.sig, args.pubkey, args.token)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.setEACLMethod, err)

--- a/pkg/morph/client/container/eacl_set.go
+++ b/pkg/morph/client/container/eacl_set.go
@@ -16,6 +16,8 @@ type SetEACLArgs struct {
 	pubkey []byte // binary public key
 
 	token []byte // binary session token
+
+	client.InvokePrmOptional
 }
 
 // SetEACL sets the extended ACL table
@@ -50,6 +52,7 @@ func (c *Client) SetEACL(args SetEACLArgs) error {
 
 	prm.SetMethod(c.setEACLMethod)
 	prm.SetArgs(args.eacl, args.sig, args.pubkey, args.token)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 

--- a/pkg/morph/client/container/estimations.go
+++ b/pkg/morph/client/container/estimations.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 type StartEstimation struct {
@@ -21,14 +23,24 @@ func (e *StopEstimation) SetEpoch(v int64) {
 }
 
 func (c *Client) StartEstimation(args StartEstimation) error {
-	if err := c.client.Invoke(c.startEstimation, args.epoch); err != nil {
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.startEstimation)
+	prm.SetArgs(args.epoch)
+
+	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.startEstimation, err)
 	}
 	return nil
 }
 
 func (c *Client) StopEstimation(args StopEstimation) error {
-	if err := c.client.Invoke(c.stopEstimation, args.epoch); err != nil {
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.stopEstimation)
+	prm.SetArgs(args.epoch)
+
+	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.stopEstimation, err)
 	}
 	return nil

--- a/pkg/morph/client/container/estimations.go
+++ b/pkg/morph/client/container/estimations.go
@@ -6,8 +6,11 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
+// StartEstimation groups parameters of StartEstimation operation.
 type StartEstimation struct {
 	epoch int64
+
+	client.InvokePrmOptional
 }
 
 func (e *StartEstimation) SetEpoch(v int64) {
@@ -16,6 +19,8 @@ func (e *StartEstimation) SetEpoch(v int64) {
 
 type StopEstimation struct {
 	epoch int64
+
+	client.InvokePrmOptional
 }
 
 func (e *StopEstimation) SetEpoch(v int64) {
@@ -27,6 +32,7 @@ func (c *Client) StartEstimation(args StartEstimation) error {
 
 	prm.SetMethod(c.startEstimation)
 	prm.SetArgs(args.epoch)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.startEstimation, err)
@@ -39,6 +45,7 @@ func (c *Client) StopEstimation(args StopEstimation) error {
 
 	prm.SetMethod(c.stopEstimation)
 	prm.SetArgs(args.epoch)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.stopEstimation, err)

--- a/pkg/morph/client/container/get.go
+++ b/pkg/morph/client/container/get.go
@@ -55,10 +55,12 @@ func (g *GetValues) SessionToken() []byte {
 // Get performs the test invoke of get container
 // method of NeoFS Container contract.
 func (c *Client) Get(args GetArgs) (*GetValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.getMethod,
-		args.cid,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.getMethod)
+	invokePrm.SetArgs(args.cid)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.getMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/container/list.go
+++ b/pkg/morph/client/container/list.go
@@ -33,14 +33,12 @@ func (l *ListValues) CIDList() [][]byte {
 // List performs the test invoke of list container
 // method of NeoFS Container contract.
 func (c *Client) List(args ListArgs) (*ListValues, error) {
-	invokeArgs := make([]interface{}, 0, 1)
+	invokePrm := client.TestInvokePrm{}
 
-	invokeArgs = append(invokeArgs, args.ownerID)
+	invokePrm.SetMethod(c.listMethod)
+	invokePrm.SetArgs(args.ownerID)
 
-	prms, err := c.client.TestInvoke(
-		c.listMethod,
-		invokeArgs...,
-	)
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/container/load.go
+++ b/pkg/morph/client/container/load.go
@@ -44,13 +44,12 @@ func (p *PutSizeArgs) SetReporterKey(v []byte) {
 // PutSize invokes the call of put container size method
 // of NeoFS Container contract.
 func (c *Client) PutSize(args PutSizeArgs) error {
-	err := c.client.Invoke(
-		c.putSizeMethod,
-		args.epoch,
-		args.cid,
-		args.size,
-		args.reporterKey,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.putSizeMethod)
+	prm.SetArgs(args.epoch, args.cid, args.size, args.reporterKey)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.putSizeMethod, err)
@@ -76,19 +75,21 @@ type ListSizesValues struct {
 	ids [][]byte
 }
 
-// Announcements returns list of identifiers of the
+// IDList returns list of identifiers of the
 // container load estimations.
 func (v *ListSizesValues) IDList() [][]byte {
 	return v.ids
 }
 
-// List performs the test invoke of "list container sizes"
+// ListSizes performs the test invoke of "list container sizes"
 // method of NeoFS Container contract.
 func (c *Client) ListSizes(args ListSizesArgs) (*ListSizesValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.listSizesMethod,
-		args.epoch,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listSizesMethod)
+	invokePrm.SetArgs(args.epoch)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listSizesMethod, err)
 	} else if ln := len(prms); ln != 1 {
@@ -153,10 +154,12 @@ func (v *GetSizeValues) Estimations() Estimations {
 // GetContainerSize performs the test invoke of "get container size"
 // method of NeoFS Container contract.
 func (c *Client) GetContainerSize(args GetSizeArgs) (*GetSizeValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.getSizeMethod,
-		args.id,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.getSizeMethod)
+	invokePrm.SetArgs(args.id)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.getSizeMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/container/load.go
+++ b/pkg/morph/client/container/load.go
@@ -16,6 +16,8 @@ type PutSizeArgs struct {
 	cid []byte
 
 	reporterKey []byte
+
+	client.InvokePrmOptional
 }
 
 // SetEpoch sets the number of the epoch when
@@ -48,6 +50,7 @@ func (c *Client) PutSize(args PutSizeArgs) error {
 
 	prm.SetMethod(c.putSizeMethod)
 	prm.SetArgs(args.epoch, args.cid, args.size, args.reporterKey)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 

--- a/pkg/morph/client/container/put.go
+++ b/pkg/morph/client/container/put.go
@@ -18,6 +18,8 @@ type PutArgs struct {
 	token []byte // binary session token
 
 	name, zone string // native name and zone
+
+	client.InvokePrmOptional
 }
 
 // SetPublicKey sets the public key of container owner
@@ -69,6 +71,7 @@ func (c *Client) Put(args PutArgs) error {
 	}
 
 	prm.SetMethod(method)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
 	if err != nil {

--- a/pkg/morph/client/container/put.go
+++ b/pkg/morph/client/container/put.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // PutArgs groups the arguments
@@ -52,34 +54,23 @@ func (p *PutArgs) SetNativeNameWithZone(name, zone string) {
 // of NeoFS Container contract.
 func (c *Client) Put(args PutArgs) error {
 	var (
-		err    error
 		method string
+		prm    client.InvokePrm
 	)
 
 	if args.name != "" {
-		err = c.client.Invoke(
-			c.putNamedMethod,
-			args.cnr,
-			args.sig,
-			args.publicKey,
-			args.token,
-			args.name,
-			args.zone,
-		)
-
 		method = c.putNamedMethod
-	} else {
-		err = c.client.Invoke(
-			c.putMethod,
-			args.cnr,
-			args.sig,
-			args.publicKey,
-			args.token,
-		)
 
+		prm.SetArgs(args.cnr, args.sig, args.publicKey, args.token, args.name, args.zone)
+	} else {
 		method = c.putMethod
+
+		prm.SetArgs(args.cnr, args.sig, args.publicKey, args.token)
 	}
 
+	prm.SetMethod(method)
+
+	err := c.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", method, err)
 	}

--- a/pkg/morph/client/container/wrapper/estimations.go
+++ b/pkg/morph/client/container/wrapper/estimations.go
@@ -1,21 +1,48 @@
 package wrapper
 
 import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
 )
 
+// StartEstimationPrm groups parameters of StartEstimation operation.
+type StartEstimationPrm struct {
+	epoch uint64
+
+	client.InvokePrmOptional
+}
+
+// SetEpoch sets epoch.
+func (s *StartEstimationPrm) SetEpoch(epoch uint64) {
+	s.epoch = epoch
+}
+
 // StartEstimation votes to produce start estimation notification.
-func (w *Wrapper) StartEstimation(epoch uint64) error {
+func (w *Wrapper) StartEstimation(prm StartEstimationPrm) error {
 	args := container.StartEstimation{}
-	args.SetEpoch(int64(epoch))
+	args.SetEpoch(int64(prm.epoch))
+	args.InvokePrmOptional = prm.InvokePrmOptional
 
 	return w.client.StartEstimation(args)
 }
 
+// StopEstimationPrm groups parameters of StopEstimation operation.
+type StopEstimationPrm struct {
+	epoch uint64
+
+	client.InvokePrmOptional
+}
+
+// SetEpoch sets epoch.
+func (s *StopEstimationPrm) SetEpoch(epoch uint64) {
+	s.epoch = epoch
+}
+
 // StopEstimation votes to produce stop estimation notification.
-func (w *Wrapper) StopEstimation(epoch uint64) error {
+func (w *Wrapper) StopEstimation(prm StopEstimationPrm) error {
 	args := container.StopEstimation{}
-	args.SetEpoch(int64(epoch))
+	args.SetEpoch(int64(prm.epoch))
+	args.InvokePrmOptional = prm.InvokePrmOptional
 
 	return w.client.StopEstimation(args)
 }

--- a/pkg/morph/client/neofs/bind.go
+++ b/pkg/morph/client/neofs/bind.go
@@ -22,6 +22,13 @@ type commonBindArgs struct {
 	scriptHash []byte // script hash of account identifier
 
 	keys [][]byte // list of serialized public keys
+
+	client.InvokePrmOptional
+}
+
+// SetOptionalPrm sets optional client parameters.
+func (x *commonBindArgs) SetOptionalPrm(op client.InvokePrmOptional) {
+	x.InvokePrmOptional = op
 }
 
 // SetScriptHash sets script hash of the NeoFS account identifier.
@@ -41,6 +48,7 @@ func (x *Client) BindKeys(args BindKeysArgs) error {
 
 	prm.SetMethod(x.bindKeysMethod)
 	prm.SetArgs(args.scriptHash, args.keys)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := x.client.Invoke(prm)
 	if err != nil {
@@ -57,6 +65,7 @@ func (x *Client) UnbindKeys(args UnbindKeysArgs) error {
 
 	prm.SetMethod(x.unbindKeysMethod)
 	prm.SetArgs(args.scriptHash, args.keys)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := x.client.Invoke(prm)
 	if err != nil {

--- a/pkg/morph/client/neofs/bind.go
+++ b/pkg/morph/client/neofs/bind.go
@@ -2,6 +2,8 @@ package neofscontract
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // BindKeysArgs groups the arguments
@@ -35,11 +37,12 @@ func (x *commonBindArgs) SetKeys(v [][]byte) {
 // BindKeys invokes the call of key binding method
 // of NeoFS contract.
 func (x *Client) BindKeys(args BindKeysArgs) error {
-	err := x.client.Invoke(
-		x.bindKeysMethod,
-		args.scriptHash,
-		args.keys,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.bindKeysMethod)
+	prm.SetArgs(args.scriptHash, args.keys)
+
+	err := x.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", x.bindKeysMethod, err)
 	}
@@ -50,11 +53,12 @@ func (x *Client) BindKeys(args BindKeysArgs) error {
 // UnbindKeys invokes the call of key unbinding method
 // of NeoFS contract.
 func (x *Client) UnbindKeys(args UnbindKeysArgs) error {
-	err := x.client.Invoke(
-		x.unbindKeysMethod,
-		args.scriptHash,
-		args.keys,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.unbindKeysMethod)
+	prm.SetArgs(args.scriptHash, args.keys)
+
+	err := x.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", x.unbindKeysMethod, err)
 	}

--- a/pkg/morph/client/neofs/cheque.go
+++ b/pkg/morph/client/neofs/cheque.go
@@ -6,22 +6,73 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
+// ChequePrm groups the arguments of Cheque operation.
+type ChequePrm struct {
+	id     []byte
+	user   util.Uint160
+	amount int64
+	lock   util.Uint160
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID of the cheque.
+func (c *ChequePrm) SetID(id []byte) {
+	c.id = id
+}
+
+// SetUser sets user.
+func (c *ChequePrm) SetUser(user util.Uint160) {
+	c.user = user
+}
+
+// SetAmount sets amount.
+func (c *ChequePrm) SetAmount(amount int64) {
+	c.amount = amount
+}
+
+// SetLock sets lock.
+func (c *ChequePrm) SetLock(lock util.Uint160) {
+	c.lock = lock
+}
+
 // Cheque invokes `cheque` method of NeoFS contract.
-func (x *Client) Cheque(id []byte, user util.Uint160, amount int64, lock util.Uint160) error {
+func (x *Client) Cheque(args ChequePrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(x.chequeMethod)
-	prm.SetArgs(id, user.BytesBE(), amount, lock.BytesBE())
+	prm.SetArgs(args.id, args.user.BytesBE(), args.amount, args.lock.BytesBE())
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return x.client.Invoke(prm)
 }
 
+// AlphabetUpdatePrm groups the arguments
+// of alphabet nodes update invocation call.
+type AlphabetUpdatePrm struct {
+	id   []byte
+	pubs keys.PublicKeys
+
+	client.InvokePrmOptional
+}
+
+// SetID sets update ID.
+func (a *AlphabetUpdatePrm) SetID(id []byte) {
+	a.id = id
+}
+
+// SetPubs sets new alphabet public keys.
+func (a *AlphabetUpdatePrm) SetPubs(pubs keys.PublicKeys) {
+	a.pubs = pubs
+}
+
 // AlphabetUpdate update list of alphabet nodes.
-func (x *Client) AlphabetUpdate(id []byte, pubs keys.PublicKeys) error {
+func (x *Client) AlphabetUpdate(args AlphabetUpdatePrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(x.alphabetUpdateMethod)
-	prm.SetArgs(id, pubs)
+	prm.SetArgs(args.id, args.pubs)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return x.client.Invoke(prm)
 }

--- a/pkg/morph/client/neofs/cheque.go
+++ b/pkg/morph/client/neofs/cheque.go
@@ -3,14 +3,25 @@ package neofscontract
 import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // Cheque invokes `cheque` method of NeoFS contract.
 func (x *Client) Cheque(id []byte, user util.Uint160, amount int64, lock util.Uint160) error {
-	return x.client.Invoke(x.chequeMethod, id, user.BytesBE(), amount, lock.BytesBE())
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.chequeMethod)
+	prm.SetArgs(id, user.BytesBE(), amount, lock.BytesBE())
+
+	return x.client.Invoke(prm)
 }
 
 // AlphabetUpdate update list of alphabet nodes.
 func (x *Client) AlphabetUpdate(id []byte, pubs keys.PublicKeys) error {
-	return x.client.Invoke(x.alphabetUpdateMethod, id, pubs)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.alphabetUpdateMethod)
+	prm.SetArgs(id, pubs)
+
+	return x.client.Invoke(prm)
 }

--- a/pkg/morph/client/neofs/wrapper/bind.go
+++ b/pkg/morph/client/neofs/wrapper/bind.go
@@ -1,14 +1,40 @@
 package neofscontract
 
 import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	neofscontract "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofs"
 )
 
+// ManageKeysPrm groups parameters of ManageKeys operation.
+type ManageKeysPrm struct {
+	scriptHash []byte
+	ks         [][]byte
+	bind       bool
+
+	client.InvokePrmOptional
+}
+
+// SetScriptHash sets script hash.
+func (m *ManageKeysPrm) SetScriptHash(scriptHash []byte) {
+	m.scriptHash = scriptHash
+}
+
+// SetKeys sets keys.
+func (m *ManageKeysPrm) SetKeys(ks [][]byte) {
+	m.ks = ks
+}
+
+// SetBind sets operation type: bind/unbind.
+func (m *ManageKeysPrm) SetBind(bind bool) {
+	m.bind = bind
+}
+
 // ManageKeys binds/unbinds list of public keys from NeoFS account by script hash.
-func (x *ClientWrapper) ManageKeys(scriptHash []byte, ks [][]byte, bind bool) error {
+func (x *ClientWrapper) ManageKeys(prm ManageKeysPrm) error {
 	type args interface {
 		SetScriptHash([]byte)
 		SetKeys([][]byte)
+		SetOptionalPrm(optional client.InvokePrmOptional)
 	}
 
 	var (
@@ -16,7 +42,7 @@ func (x *ClientWrapper) ManageKeys(scriptHash []byte, ks [][]byte, bind bool) er
 		call func(args) error
 	)
 
-	if bind {
+	if prm.bind {
 		a = new(neofscontract.BindKeysArgs)
 		call = func(a args) error {
 			return x.client.BindKeys(*a.(*neofscontract.BindKeysArgs))
@@ -28,8 +54,9 @@ func (x *ClientWrapper) ManageKeys(scriptHash []byte, ks [][]byte, bind bool) er
 		}
 	}
 
-	a.SetScriptHash(scriptHash)
-	a.SetKeys(ks)
+	a.SetScriptHash(prm.scriptHash)
+	a.SetKeys(prm.ks)
+	a.SetOptionalPrm(prm.InvokePrmOptional)
 
 	return call(a)
 }

--- a/pkg/morph/client/neofs/wrapper/cheque.go
+++ b/pkg/morph/client/neofs/wrapper/cheque.go
@@ -3,14 +3,78 @@ package neofscontract
 import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	neofscontract "github.com/nspcc-dev/neofs-node/pkg/morph/client/neofs"
 )
 
+// ChequePrm groups parameters of AlphabetUpdate operation.
+type ChequePrm struct {
+	id     []byte
+	user   util.Uint160
+	amount int64
+	lock   util.Uint160
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID of the cheque.
+func (c *ChequePrm) SetID(id []byte) {
+	c.id = id
+}
+
+// SetUser sets user.
+func (c *ChequePrm) SetUser(user util.Uint160) {
+	c.user = user
+}
+
+// SetAmount sets amount.
+func (c *ChequePrm) SetAmount(amount int64) {
+	c.amount = amount
+}
+
+// SetLock sets lock.
+func (c *ChequePrm) SetLock(lock util.Uint160) {
+	c.lock = lock
+}
+
 // Cheque invokes `cheque` method of NeoFS contract.
-func (x *ClientWrapper) Cheque(id []byte, user util.Uint160, amount int64, lock util.Uint160) error {
-	return x.client.Cheque(id, user, amount, lock)
+func (x *ClientWrapper) Cheque(prm ChequePrm) error {
+	args := neofscontract.ChequePrm{}
+
+	args.SetID(prm.id)
+	args.SetUser(prm.user)
+	args.SetAmount(prm.amount)
+	args.SetLock(prm.lock)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return x.client.Cheque(args)
+}
+
+// AlphabetUpdatePrm groups parameters of AlphabetUpdate operation.
+type AlphabetUpdatePrm struct {
+	id   []byte
+	pubs keys.PublicKeys
+
+	client.InvokePrmOptional
+}
+
+// SetID sets update ID.
+func (a *AlphabetUpdatePrm) SetID(id []byte) {
+	a.id = id
+}
+
+// SetPubs sets new alphabet public keys.
+func (a *AlphabetUpdatePrm) SetPubs(pubs keys.PublicKeys) {
+	a.pubs = pubs
 }
 
 // AlphabetUpdate update list of alphabet nodes.
-func (x *ClientWrapper) AlphabetUpdate(id []byte, pubs keys.PublicKeys) error {
-	return x.client.AlphabetUpdate(id, pubs)
+func (x *ClientWrapper) AlphabetUpdate(prm AlphabetUpdatePrm) error {
+	args := neofscontract.AlphabetUpdatePrm{}
+
+	args.SetID(prm.id)
+	args.SetPubs(prm.pubs)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return x.client.AlphabetUpdate(args)
 }

--- a/pkg/morph/client/neofsid/addrm_keys.go
+++ b/pkg/morph/client/neofsid/addrm_keys.go
@@ -22,6 +22,12 @@ type commonBindArgs struct {
 	ownerID []byte // NeoFS account identifier
 
 	keys [][]byte // list of serialized public keys
+
+	client.InvokePrmOptional
+}
+
+func (x *commonBindArgs) SetOptionalPrm(prm client.InvokePrmOptional) {
+	x.InvokePrmOptional = prm
 }
 
 // SetOwnerID sets NeoFS account identifier.
@@ -41,6 +47,7 @@ func (x *Client) AddKeys(args AddKeysArgs) error {
 
 	prm.SetMethod(x.addKeysMethod)
 	prm.SetArgs(args.ownerID, args.keys)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := x.client.Invoke(prm)
 	if err != nil {
@@ -57,6 +64,7 @@ func (x *Client) RemoveKeys(args RemoveKeysArgs) error {
 
 	prm.SetMethod(x.removeKeysMethod)
 	prm.SetArgs(args.ownerID, args.keys)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := x.client.Invoke(prm)
 	if err != nil {

--- a/pkg/morph/client/neofsid/addrm_keys.go
+++ b/pkg/morph/client/neofsid/addrm_keys.go
@@ -2,6 +2,8 @@ package neofsid
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // AddKeysArgs groups the arguments
@@ -35,11 +37,12 @@ func (x *commonBindArgs) SetKeys(v [][]byte) {
 // AddKeys invokes the call of key adding method
 // of NeoFS contract.
 func (x *Client) AddKeys(args AddKeysArgs) error {
-	err := x.client.Invoke(
-		x.addKeysMethod,
-		args.ownerID,
-		args.keys,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.addKeysMethod)
+	prm.SetArgs(args.ownerID, args.keys)
+
+	err := x.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", x.addKeysMethod, err)
 	}
@@ -50,11 +53,12 @@ func (x *Client) AddKeys(args AddKeysArgs) error {
 // RemoveKeys invokes the call of key removing method
 // of NeoFS contract.
 func (x *Client) RemoveKeys(args RemoveKeysArgs) error {
-	err := x.client.Invoke(
-		x.removeKeysMethod,
-		args.ownerID,
-		args.keys,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(x.removeKeysMethod)
+	prm.SetArgs(args.ownerID, args.keys)
+
+	err := x.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", x.removeKeysMethod, err)
 	}

--- a/pkg/morph/client/neofsid/keys.go
+++ b/pkg/morph/client/neofsid/keys.go
@@ -33,14 +33,12 @@ func (l *KeyListingValues) Keys() [][]byte {
 // AccountKeys requests public keys of NeoFS account
 // through method of NeoFS ID contract.
 func (x *Client) AccountKeys(args KeyListingArgs) (*KeyListingValues, error) {
-	invokeArgs := make([]interface{}, 0, 1)
+	invokePrm := client.TestInvokePrm{}
 
-	invokeArgs = append(invokeArgs, args.ownerID)
+	invokePrm.SetMethod(x.keyListingMethod)
+	invokePrm.SetArgs(args.ownerID)
 
-	items, err := x.client.TestInvoke(
-		x.keyListingMethod,
-		invokeArgs...,
-	)
+	items, err := x.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", x.keyListingMethod, err)
 	} else if ln := len(items); ln != 1 {

--- a/pkg/morph/client/neofsid/wrapper/keys.go
+++ b/pkg/morph/client/neofsid/wrapper/keys.go
@@ -4,9 +4,8 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
-
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 )

--- a/pkg/morph/client/neofsid/wrapper/keys.go
+++ b/pkg/morph/client/neofsid/wrapper/keys.go
@@ -4,16 +4,28 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/neofsid"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 )
 
+// AccountKeysPrm groups parameters of AccountKeys operation.
+type AccountKeysPrm struct {
+	id *owner.ID
+}
+
+// SetID sets owner ID.
+func (a *AccountKeysPrm) SetID(id *owner.ID) {
+	a.id = id
+}
+
 // AccountKeys requests public keys of NeoFS account from NeoFS ID contract.
-func (x *ClientWrapper) AccountKeys(id *owner.ID) (keys.PublicKeys, error) {
+func (x *ClientWrapper) AccountKeys(prm AccountKeysPrm) (keys.PublicKeys, error) {
 	var args neofsid.KeyListingArgs
 
-	args.SetOwnerID(id.ToV2().GetValue())
+	args.SetOwnerID(prm.id.ToV2().GetValue())
 
 	res, err := x.client.AccountKeys(args)
 	if err != nil {
@@ -37,11 +49,36 @@ func (x *ClientWrapper) AccountKeys(id *owner.ID) (keys.PublicKeys, error) {
 	return ks, nil
 }
 
+// ManageKeysPrm groups parameters of ManageKeys operation.
+type ManageKeysPrm struct {
+	ownerID []byte
+	ks      [][]byte
+	add     bool
+
+	client.InvokePrmOptional
+}
+
+// SetOwnerID sets Owner ID.
+func (m *ManageKeysPrm) SetOwnerID(ownerID []byte) {
+	m.ownerID = ownerID
+}
+
+// SetKeys sets keys to add/remove.
+func (m *ManageKeysPrm) SetKeys(ks [][]byte) {
+	m.ks = ks
+}
+
+// SetAdd sets operation type.
+func (m *ManageKeysPrm) SetAdd(add bool) {
+	m.add = add
+}
+
 // ManageKeys adds/removes list of public keys to/from NeoFS account.
-func (x *ClientWrapper) ManageKeys(ownerID []byte, ks [][]byte, add bool) error {
+func (x *ClientWrapper) ManageKeys(prm ManageKeysPrm) error {
 	type args interface {
 		SetOwnerID([]byte)
 		SetKeys([][]byte)
+		SetOptionalPrm(optional client.InvokePrmOptional)
 	}
 
 	var (
@@ -49,7 +86,7 @@ func (x *ClientWrapper) ManageKeys(ownerID []byte, ks [][]byte, add bool) error 
 		call func(args) error
 	)
 
-	if add {
+	if prm.add {
 		a = new(neofsid.AddKeysArgs)
 		call = func(a args) error {
 			return x.client.AddKeys(*a.(*neofsid.AddKeysArgs))
@@ -61,8 +98,9 @@ func (x *ClientWrapper) ManageKeys(ownerID []byte, ks [][]byte, add bool) error 
 		}
 	}
 
-	a.SetOwnerID(ownerID)
-	a.SetKeys(ks)
+	a.SetOwnerID(prm.ownerID)
+	a.SetKeys(prm.ks)
+	a.SetOptionalPrm(prm.InvokePrmOptional)
 
 	return call(a)
 }

--- a/pkg/morph/client/netmap/add_peer.go
+++ b/pkg/morph/client/netmap/add_peer.go
@@ -2,6 +2,8 @@ package netmap
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // AddPeerArgs groups the arguments
@@ -18,7 +20,12 @@ func (a *AddPeerArgs) SetInfo(v []byte) {
 // AddPeer invokes the call of add peer method
 // of NeoFS Netmap contract.
 func (c *Client) AddPeer(args AddPeerArgs) error {
-	if err := c.client.Invoke(c.addPeerMethod, args.info); err != nil {
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.addPeerMethod)
+	prm.SetArgs(args.info)
+
+	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.addPeerMethod, err)
 	}
 	return nil

--- a/pkg/morph/client/netmap/add_peer.go
+++ b/pkg/morph/client/netmap/add_peer.go
@@ -10,6 +10,8 @@ import (
 // of add peer invocation call.
 type AddPeerArgs struct {
 	info []byte
+
+	client.InvokePrmOptional
 }
 
 // SetInfo sets the peer information.
@@ -24,6 +26,7 @@ func (c *Client) AddPeer(args AddPeerArgs) error {
 
 	prm.SetMethod(c.addPeerMethod)
 	prm.SetArgs(args.info)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.addPeerMethod, err)

--- a/pkg/morph/client/netmap/config.go
+++ b/pkg/morph/client/netmap/config.go
@@ -13,15 +13,15 @@ type ConfigArgs struct {
 	key []byte
 }
 
+// SetKey sets binary key to configuration parameter.
+func (c *ConfigArgs) SetKey(v []byte) {
+	c.key = v
+}
+
 // ConfigValues groups the stack parameters
 // returned by get config test invoke.
 type ConfigValues struct {
 	val interface{}
-}
-
-// SetKey sets binary key to configuration parameter.
-func (c *ConfigArgs) SetKey(v []byte) {
-	c.key = v
 }
 
 // Value returns configuration value.
@@ -58,12 +58,37 @@ func (c *Client) Config(args ConfigArgs, assert func(stackitem.Item) (interface{
 	}, nil
 }
 
+// SetConfigPrm groups parameters of SetConfig operation.
+type SetConfigPrm struct {
+	id    []byte
+	key   []byte
+	value interface{}
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID of the config value.
+func (s *SetConfigPrm) SetID(id []byte) {
+	s.id = id
+}
+
+// SetKey sets key of the config value.
+func (s *SetConfigPrm) SetKey(key []byte) {
+	s.key = key
+}
+
+// SetValue sets value of the config value.
+func (s *SetConfigPrm) SetValue(value interface{}) {
+	s.value = value
+}
+
 // SetConfig invokes `setConfig` method of NeoFS Netmap contract.
-func (c *Client) SetConfig(id, key []byte, value interface{}) error {
+func (c *Client) SetConfig(args SetConfigPrm) error {
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(c.setConfigMethod)
-	prm.SetArgs(id, key, value)
+	prm.SetArgs(args.id, args.key, args.value)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	return c.client.Invoke(prm)
 }
@@ -120,7 +145,7 @@ func (x ListConfigValues) IterateRecords(f func(key, value []byte) error) error 
 }
 
 // ListConfig performs the test invoke of config listing method of NeoFS Netmap contract.
-func (c *Client) ListConfig(args ListConfigArgs) (*ListConfigValues, error) {
+func (c *Client) ListConfig(_ ListConfigArgs) (*ListConfigValues, error) {
 	prm := client.TestInvokePrm{}
 
 	prm.SetMethod(c.configListMethod)

--- a/pkg/morph/client/netmap/config.go
+++ b/pkg/morph/client/netmap/config.go
@@ -32,10 +32,12 @@ func (c ConfigValues) Value() interface{} {
 // Config performs the test invoke of get config value
 // method of NeoFS Netmap contract.
 func (c *Client) Config(args ConfigArgs, assert func(stackitem.Item) (interface{}, error)) (*ConfigValues, error) {
-	items, err := c.client.TestInvoke(
-		c.configMethod,
-		args.key,
-	)
+	prm := client.TestInvokePrm{}
+
+	prm.SetMethod(c.configMethod)
+	prm.SetArgs(args.key)
+
+	items, err := c.client.TestInvoke(prm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.configMethod, err)
@@ -58,7 +60,12 @@ func (c *Client) Config(args ConfigArgs, assert func(stackitem.Item) (interface{
 
 // SetConfig invokes `setConfig` method of NeoFS Netmap contract.
 func (c *Client) SetConfig(id, key []byte, value interface{}) error {
-	return c.client.Invoke(c.setConfigMethod, id, key, value)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.setConfigMethod)
+	prm.SetArgs(id, key, value)
+
+	return c.client.Invoke(prm)
 }
 
 func IntegerAssert(item stackitem.Item) (interface{}, error) {
@@ -74,7 +81,7 @@ func StringAssert(item stackitem.Item) (interface{}, error) {
 type ListConfigArgs struct {
 }
 
-// ConfigValues groups the stack parameters
+// ListConfigValues groups the stack parameters
 // returned by config listing test invoke.
 type ListConfigValues struct {
 	rs []stackitem.Item
@@ -114,9 +121,11 @@ func (x ListConfigValues) IterateRecords(f func(key, value []byte) error) error 
 
 // ListConfig performs the test invoke of config listing method of NeoFS Netmap contract.
 func (c *Client) ListConfig(args ListConfigArgs) (*ListConfigValues, error) {
-	items, err := c.client.TestInvoke(
-		c.configListMethod,
-	)
+	prm := client.TestInvokePrm{}
+
+	prm.SetMethod(c.configListMethod)
+
+	items, err := c.client.TestInvoke(prm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.configListMethod, err)

--- a/pkg/morph/client/netmap/epoch.go
+++ b/pkg/morph/client/netmap/epoch.go
@@ -8,8 +8,7 @@ import (
 
 // EpochArgs groups the arguments
 // of get epoch number test invoke call.
-type EpochArgs struct {
-}
+type EpochArgs struct{}
 
 // EpochValues groups the stack parameters
 // returned by get epoch number test invoke.
@@ -20,22 +19,6 @@ type EpochValues struct {
 // Number return the number of NeoFS epoch.
 func (e EpochValues) Number() int64 {
 	return e.num
-}
-
-// EpochBlockArgs groups the arguments of
-// get epoch block number test invoke call.
-type EpochBlockArgs struct {
-}
-
-// EpochBlockValues groups the stack parameters
-// returned by get epoch block number test invoke.
-type EpochBlockValues struct {
-	block int64
-}
-
-// Block return the block number of NeoFS epoch.
-func (e EpochBlockValues) Block() int64 {
-	return e.block
 }
 
 // Epoch performs the test invoke of get epoch number
@@ -63,6 +46,21 @@ func (c *Client) Epoch(_ EpochArgs) (*EpochValues, error) {
 	return &EpochValues{
 		num: num,
 	}, nil
+}
+
+// EpochBlockArgs groups the arguments of
+// get epoch block number test invoke call.
+type EpochBlockArgs struct{}
+
+// EpochBlockValues groups the stack parameters
+// returned by get epoch block number test invoke.
+type EpochBlockValues struct {
+	block int64
+}
+
+// Block return the block number of NeoFS epoch.
+func (e EpochBlockValues) Block() int64 {
+	return e.block
 }
 
 // LastEpochBlock performs the test invoke of get epoch block number

--- a/pkg/morph/client/netmap/epoch.go
+++ b/pkg/morph/client/netmap/epoch.go
@@ -41,9 +41,10 @@ func (e EpochBlockValues) Block() int64 {
 // Epoch performs the test invoke of get epoch number
 // method of NeoFS Netmap contract.
 func (c *Client) Epoch(_ EpochArgs) (*EpochValues, error) {
-	items, err := c.client.TestInvoke(
-		c.epochMethod,
-	)
+	prm := client.TestInvokePrm{}
+	prm.SetMethod(c.epochMethod)
+
+	items, err := c.client.TestInvoke(prm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.epochMethod, err)
@@ -67,7 +68,10 @@ func (c *Client) Epoch(_ EpochArgs) (*EpochValues, error) {
 // LastEpochBlock performs the test invoke of get epoch block number
 // method of NeoFS Netmap contract.
 func (c *Client) LastEpochBlock(_ EpochBlockArgs) (*EpochBlockValues, error) {
-	items, err := c.client.TestInvoke(c.lastEpochBlockMethod)
+	prm := client.TestInvokePrm{}
+	prm.SetMethod(c.lastEpochBlockMethod)
+
+	items, err := c.client.TestInvoke(prm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.lastEpochBlockMethod, err)

--- a/pkg/morph/client/netmap/innerring.go
+++ b/pkg/morph/client/netmap/innerring.go
@@ -16,15 +16,21 @@ func (c *Client) UpdateInnerRing(keys keys.PublicKeys) error {
 		args[i] = keys[i].Bytes()
 	}
 
-	return c.client.Invoke(c.updateInnerRing, args)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.updateInnerRing)
+	prm.SetArgs(args)
+
+	return c.client.Invoke(prm)
 }
 
 // InnerRingList returns public keys of inner ring members in
 // netmap contract.
 func (c *Client) InnerRingList() (keys.PublicKeys, error) {
-	prms, err := c.client.TestInvoke(
-		c.innerRingList,
-	)
+	invokePrm := client.TestInvokePrm{}
+	invokePrm.SetMethod(c.innerRingList)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.innerRingList, err)
 	}

--- a/pkg/morph/client/netmap/innerring.go
+++ b/pkg/morph/client/netmap/innerring.go
@@ -9,17 +9,32 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
+// UpdateIRPrm groups parameters of UpdateInnerRing
+// invocation.
+type UpdateIRPrm struct {
+	keys keys.PublicKeys
+
+	client.InvokePrmOptional
+}
+
+// SetKeys sets new inner ring keys.
+func (u *UpdateIRPrm) SetKeys(keys keys.PublicKeys) {
+	u.keys = keys
+}
+
 // UpdateInnerRing updates inner ring members in netmap contract.
-func (c *Client) UpdateInnerRing(keys keys.PublicKeys) error {
-	args := make([][]byte, len(keys))
+func (c *Client) UpdateInnerRing(p UpdateIRPrm) error {
+	args := make([][]byte, len(p.keys))
+
 	for i := range args {
-		args[i] = keys[i].Bytes()
+		args[i] = p.keys[i].Bytes()
 	}
 
 	prm := client.InvokePrm{}
 
 	prm.SetMethod(c.updateInnerRing)
 	prm.SetArgs(args)
+	prm.InvokePrmOptional = p.InvokePrmOptional
 
 	return c.client.Invoke(prm)
 }

--- a/pkg/morph/client/netmap/netmap.go
+++ b/pkg/morph/client/netmap/netmap.go
@@ -106,9 +106,10 @@ func (g GetNetMapValues) Peers() [][]byte {
 // NetMap performs the test invoke of get network map
 // method of NeoFS Netmap contract.
 func (c *Client) NetMap(_ GetNetMapArgs) (*GetNetMapValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.netMapMethod,
-	)
+	invokePrm := client.TestInvokePrm{}
+	invokePrm.SetMethod(c.netMapMethod)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.netMapMethod, err)
@@ -121,10 +122,12 @@ func (c *Client) NetMap(_ GetNetMapArgs) (*GetNetMapValues, error) {
 // from NeoFS Netmap contract. Contract saves only one previous epoch,
 // so all invokes with diff > 1 return error.
 func (c *Client) Snapshot(a GetSnapshotArgs) (*GetNetMapValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.snapshotMethod,
-		int64(a.diff),
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.snapshotMethod)
+	invokePrm.SetArgs(int64(a.diff))
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.netMapMethod, err)
@@ -136,10 +139,12 @@ func (c *Client) Snapshot(a GetSnapshotArgs) (*GetNetMapValues, error) {
 // EpochSnapshot performs the test invoke of get snapshot of network map by epoch
 // from NeoFS Netmap contract.
 func (c *Client) EpochSnapshot(args EpochSnapshotArgs) (*EpochSnapshotValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.epochSnapshotMethod,
-		int64(args.epoch),
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.epochSnapshotMethod)
+	invokePrm.SetArgs(int64(args.epoch))
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w",
 			c.epochSnapshotMethod, err)
@@ -156,9 +161,10 @@ func (c *Client) EpochSnapshot(args EpochSnapshotArgs) (*EpochSnapshotValues, er
 }
 
 func (c *Client) Candidates(_ GetNetMapCandidatesArgs) (*GetNetMapCandidatesValues, error) {
-	prms, err := c.client.TestInvoke(
-		c.netMapCandidatesMethod,
-	)
+	invokePrm := client.TestInvokePrm{}
+	invokePrm.SetMethod(c.netMapCandidatesMethod)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.netMapCandidatesMethod, err)
 	}

--- a/pkg/morph/client/netmap/netmap.go
+++ b/pkg/morph/client/netmap/netmap.go
@@ -7,48 +7,10 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
-// GetNetMapArgs groups the arguments
-// of get network map test invoke call.
-type GetNetMapArgs struct {
-}
-
-// GetSnapshotArgs groups the arguments
-// of get netmap snapshot test invoke call.
-type GetSnapshotArgs struct {
-	diff uint64
-}
-
 // GetNetMapValues groups the stack parameters
 // returned by get network map test invoke.
 type GetNetMapValues struct {
 	peers [][]byte
-}
-
-// EpochSnapshotArgs groups the arguments
-// of snapshot by epoch test invoke call.
-type EpochSnapshotArgs struct {
-	epoch uint64
-}
-
-// EpochSnapshotValues groups the stack parameters
-// returned by snapshot by epoch test invoke.
-type EpochSnapshotValues struct {
-	*GetNetMapValues
-}
-
-// GetNetMapCandidatesArgs groups the arguments
-// of get network map candidates test invoke call.
-type GetNetMapCandidatesArgs struct {
-}
-
-// GetNetMapCandidatesValues groups the stack parameters
-// returned by get network map candidates test invoke.
-type GetNetMapCandidatesValues struct {
-	netmapNodes []*PeerWithState
-}
-
-func (g GetNetMapCandidatesValues) NetmapNodes() []*PeerWithState {
-	return g.netmapNodes
 }
 
 // State is an enumeration of various states of the NeoFS node.
@@ -86,22 +48,15 @@ const (
 	peerWithStateFixedPrmNumber = 2
 )
 
-// SetDiff sets argument for snapshot method of
-// netmap contract.
-func (g *GetSnapshotArgs) SetDiff(d uint64) {
-	g.diff = d
-}
-
-// SetEpoch sets epoch number to get snapshot.
-func (a *EpochSnapshotArgs) SetEpoch(d uint64) {
-	a.epoch = d
-}
-
 // Peers return the list of peers from
 // network map in a binary format.
 func (g GetNetMapValues) Peers() [][]byte {
 	return g.peers
 }
+
+// GetNetMapArgs groups the arguments
+// of get network map test invoke call.
+type GetNetMapArgs struct{}
 
 // NetMap performs the test invoke of get network map
 // method of NeoFS Netmap contract.
@@ -116,6 +71,18 @@ func (c *Client) NetMap(_ GetNetMapArgs) (*GetNetMapValues, error) {
 	}
 
 	return peersFromStackItems(prms, c.netMapMethod)
+}
+
+// GetSnapshotArgs groups the arguments
+// of get netmap snapshot test invoke call.
+type GetSnapshotArgs struct {
+	diff uint64
+}
+
+// SetDiff sets argument for snapshot method of
+// netmap contract.
+func (g *GetSnapshotArgs) SetDiff(d uint64) {
+	g.diff = d
 }
 
 // Snapshot performs the test invoke of get snapshot of network map
@@ -134,6 +101,23 @@ func (c *Client) Snapshot(a GetSnapshotArgs) (*GetNetMapValues, error) {
 	}
 
 	return peersFromStackItems(prms, c.snapshotMethod)
+}
+
+// EpochSnapshotArgs groups the arguments
+// of snapshot by epoch test invoke call.
+type EpochSnapshotArgs struct {
+	epoch uint64
+}
+
+// SetEpoch sets epoch number to get snapshot.
+func (a *EpochSnapshotArgs) SetEpoch(d uint64) {
+	a.epoch = d
+}
+
+// EpochSnapshotValues groups the stack parameters
+// returned by snapshot by epoch test invoke.
+type EpochSnapshotValues struct {
+	*GetNetMapValues
 }
 
 // EpochSnapshot performs the test invoke of get snapshot of network map by epoch
@@ -158,6 +142,20 @@ func (c *Client) EpochSnapshot(args EpochSnapshotArgs) (*EpochSnapshotValues, er
 	return &EpochSnapshotValues{
 		GetNetMapValues: nmVals,
 	}, nil
+}
+
+// GetNetMapCandidatesArgs groups the arguments
+// of get network map candidates test invoke call.
+type GetNetMapCandidatesArgs struct{}
+
+// GetNetMapCandidatesValues groups the stack parameters
+// returned by get network map candidates test invoke.
+type GetNetMapCandidatesValues struct {
+	netmapNodes []*PeerWithState
+}
+
+func (g GetNetMapCandidatesValues) NetmapNodes() []*PeerWithState {
+	return g.netmapNodes
 }
 
 func (c *Client) Candidates(_ GetNetMapCandidatesArgs) (*GetNetMapCandidatesValues, error) {

--- a/pkg/morph/client/netmap/new_epoch.go
+++ b/pkg/morph/client/netmap/new_epoch.go
@@ -2,6 +2,8 @@ package netmap
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // NewEpochArgs groups the arguments
@@ -18,7 +20,12 @@ func (a *NewEpochArgs) SetEpochNumber(v int64) {
 // NewEpoch invokes the call of new epoch method
 // of NeoFS Netmap contract.
 func (c *Client) NewEpoch(args NewEpochArgs) error {
-	if err := c.client.Invoke(c.newEpochMethod, args.number); err != nil {
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.newEpochMethod)
+	prm.SetArgs(args.number)
+
+	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.newEpochMethod, err)
 	}
 	return nil

--- a/pkg/morph/client/netmap/new_epoch.go
+++ b/pkg/morph/client/netmap/new_epoch.go
@@ -10,6 +10,8 @@ import (
 // of new epoch invocation call.
 type NewEpochArgs struct {
 	number int64 // new epoch number
+
+	client.InvokePrmOptional
 }
 
 // SetEpochNumber sets the new epoch number.
@@ -24,6 +26,7 @@ func (c *Client) NewEpoch(args NewEpochArgs) error {
 
 	prm.SetMethod(c.newEpochMethod)
 	prm.SetArgs(args.number)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.newEpochMethod, err)

--- a/pkg/morph/client/netmap/update_state.go
+++ b/pkg/morph/client/netmap/update_state.go
@@ -2,6 +2,8 @@ package netmap
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // UpdateStateArgs groups the arguments
@@ -26,11 +28,12 @@ func (u *UpdateStateArgs) SetState(v int64) {
 // UpdateState invokes the call of update state method
 // of NeoFS Netmap contract.
 func (c *Client) UpdateState(args UpdateStateArgs) error {
-	err := c.client.Invoke(
-		c.updateStateMethod,
-		args.state,
-		args.key,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.updateStateMethod)
+	prm.SetArgs(args.state, args.key)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.updateStateMethod, err)

--- a/pkg/morph/client/netmap/update_state.go
+++ b/pkg/morph/client/netmap/update_state.go
@@ -12,6 +12,8 @@ type UpdateStateArgs struct {
 	key []byte // peer public key
 
 	state int64 // new peer state
+
+	client.InvokePrmOptional
 }
 
 // SetPublicKey sets peer public key
@@ -32,9 +34,9 @@ func (c *Client) UpdateState(args UpdateStateArgs) error {
 
 	prm.SetMethod(c.updateStateMethod)
 	prm.SetArgs(args.state, args.key)
+	prm.InvokePrmOptional = args.InvokePrmOptional
 
 	err := c.client.Invoke(prm)
-
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.updateStateMethod, err)
 	}

--- a/pkg/morph/client/netmap/wrapper/add_peer.go
+++ b/pkg/morph/client/netmap/wrapper/add_peer.go
@@ -4,23 +4,37 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 )
 
+// AddPeerPrm groups parameters of AddPeer operation.
+type AddPeerPrm struct {
+	nodeInfo *netmap.NodeInfo
+
+	client.InvokePrmOptional
+}
+
+// SetNodeInfo sets new peer NodeInfo.
+func (a *AddPeerPrm) SetNodeInfo(nodeInfo *netmap.NodeInfo) {
+	a.nodeInfo = nodeInfo
+}
+
 // AddPeer registers peer in NeoFS network through
 // Netmap contract call.
-func (w *Wrapper) AddPeer(nodeInfo *netmap.NodeInfo) error {
-	if nodeInfo == nil {
+func (w *Wrapper) AddPeer(prm AddPeerPrm) error {
+	if prm.nodeInfo == nil {
 		return errors.New("nil node info")
 	}
 
-	rawNodeInfo, err := nodeInfo.Marshal()
+	rawNodeInfo, err := prm.nodeInfo.Marshal()
 	if err != nil {
 		return err
 	}
 
 	args := netmap.AddPeerArgs{}
 	args.SetInfo(rawNodeInfo)
+	args.InvokePrmOptional = prm.InvokePrmOptional
 
 	if err := w.client.AddPeer(args); err != nil {
 		return fmt.Errorf("could not invoke smart contract: %w", err)

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 )
@@ -168,9 +170,40 @@ func (w *Wrapper) readStringConfig(key string) (string, error) {
 	return str, nil
 }
 
+// SetConfigPrm groups parameters of SetConfig operation.
+type SetConfigPrm struct {
+	id    []byte
+	key   []byte
+	value interface{}
+
+	client.InvokePrmOptional
+}
+
+// SetID sets ID of the config value.
+func (s *SetConfigPrm) SetID(id []byte) {
+	s.id = id
+}
+
+// SetKey sets key of the config value.
+func (s *SetConfigPrm) SetKey(key []byte) {
+	s.key = key
+}
+
+// SetValue sets value of the config value.
+func (s *SetConfigPrm) SetValue(value interface{}) {
+	s.value = value
+}
+
 // SetConfig sets config field.
-func (w *Wrapper) SetConfig(id, key []byte, value interface{}) error {
-	return w.client.SetConfig(id, key, value)
+func (w *Wrapper) SetConfig(prm SetConfigPrm) error {
+	args := netmap.SetConfigPrm{}
+
+	args.SetID(prm.id)
+	args.SetKey(prm.key)
+	args.SetValue(prm.value)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return w.client.SetConfig(args)
 }
 
 // IterateConfigParameters iterates over configuration parameters stored in Netmap contract and passes them to f.

--- a/pkg/morph/client/netmap/wrapper/config.go
+++ b/pkg/morph/client/netmap/wrapper/config.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
-
 	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 )
 

--- a/pkg/morph/client/netmap/wrapper/innerring.go
+++ b/pkg/morph/client/netmap/wrapper/innerring.go
@@ -1,10 +1,32 @@
 package wrapper
 
-import "github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+import (
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
+)
+
+// UpdateIRPrm groups parameters of UpdateInnerRing
+// invocation.
+type UpdateIRPrm struct {
+	keys keys.PublicKeys
+
+	client.InvokePrmOptional
+}
+
+// SetKeys sets new inner ring keys.
+func (u *UpdateIRPrm) SetKeys(keys keys.PublicKeys) {
+	u.keys = keys
+}
 
 // UpdateInnerRing updates inner ring keys.
-func (w *Wrapper) UpdateInnerRing(keys keys.PublicKeys) error {
-	return w.client.UpdateInnerRing(keys)
+func (w *Wrapper) UpdateInnerRing(prm UpdateIRPrm) error {
+	args := netmap.UpdateIRPrm{}
+
+	args.SetKeys(prm.keys)
+	args.InvokePrmOptional = prm.InvokePrmOptional
+
+	return w.client.UpdateInnerRing(args)
 }
 
 // GetInnerRingList return current IR list.

--- a/pkg/morph/client/netmap/wrapper/update_state.go
+++ b/pkg/morph/client/netmap/wrapper/update_state.go
@@ -3,16 +3,37 @@ package wrapper
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	contract "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 )
 
+// UpdatePeerPrm groups parameters of UpdatePeerState operation.
+type UpdatePeerPrm struct {
+	key   []byte
+	state netmap.NodeState
+
+	client.InvokePrmOptional
+}
+
+// SetKey sets public key.
+func (u *UpdatePeerPrm) SetKey(key []byte) {
+	u.key = key
+}
+
+// SetState sets node state.
+func (u *UpdatePeerPrm) SetState(state netmap.NodeState) {
+	u.state = state
+}
+
 // UpdatePeerState changes peer status through Netmap contract
 // call.
-func (w *Wrapper) UpdatePeerState(key []byte, state netmap.NodeState) error {
+func (w *Wrapper) UpdatePeerState(prm UpdatePeerPrm) error {
 	args := contract.UpdateStateArgs{}
-	args.SetPublicKey(key)
-	args.SetState(int64(state.ToV2()))
+
+	args.SetPublicKey(prm.key)
+	args.SetState(int64(prm.state.ToV2()))
+	args.InvokePrmOptional = prm.InvokePrmOptional
 
 	// invoke smart contract call
 	if err := w.client.UpdateState(args); err != nil {

--- a/pkg/morph/client/reputation/get.go
+++ b/pkg/morph/client/reputation/get.go
@@ -47,11 +47,12 @@ func (g GetResult) Reputations() [][]byte {
 
 // Get invokes the call of "get reputation value" method of reputation contract.
 func (c *Client) Get(args GetArgs) (*GetResult, error) {
-	prms, err := c.client.TestInvoke(
-		c.getMethod,
-		int64(args.epoch),
-		args.peerID,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.getMethod)
+	invokePrm.SetArgs(int64(args.epoch), args.peerID)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.getMethod, err)
 	}
@@ -62,10 +63,12 @@ func (c *Client) Get(args GetArgs) (*GetResult, error) {
 // GetByID invokes the call of "get reputation value by reputation id" method
 // of reputation contract.
 func (c *Client) GetByID(args GetByIDArgs) (*GetResult, error) {
-	prms, err := c.client.TestInvoke(
-		c.getByIDMethod,
-		args.id,
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.getByIDMethod)
+	invokePrm.SetArgs(args.id)
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.getByIDMethod, err)
 	}

--- a/pkg/morph/client/reputation/list.go
+++ b/pkg/morph/client/reputation/list.go
@@ -31,10 +31,12 @@ func (l ListByEpochResult) IDs() [][]byte {
 // ListByEpoch invokes the call of "list reputation ids by epoch" method of
 // reputation contract.
 func (c *Client) ListByEpoch(args ListByEpochArgs) (*ListByEpochResult, error) {
-	prms, err := c.client.TestInvoke(
-		c.listByEpochMethod,
-		int64(args.epoch),
-	)
+	invokePrm := client.TestInvokePrm{}
+
+	invokePrm.SetMethod(c.listByEpochMethod)
+	invokePrm.SetArgs(int64(args.epoch))
+
+	prms, err := c.client.TestInvoke(invokePrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", c.listByEpochMethod, err)
 	} else if ln := len(prms); ln != 1 {

--- a/pkg/morph/client/reputation/put.go
+++ b/pkg/morph/client/reputation/put.go
@@ -2,6 +2,8 @@ package reputation
 
 import (
 	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 )
 
 // PutArgs groups the arguments of "put reputation value" invocation call.
@@ -28,12 +30,12 @@ func (p *PutArgs) SetValue(v []byte) {
 
 // Put invokes direct call of "put reputation value" method of reputation contract.
 func (c *Client) Put(args PutArgs) error {
-	err := c.client.Invoke(
-		c.putMethod,
-		int64(args.epoch),
-		args.peerID,
-		args.value,
-	)
+	prm := client.InvokePrm{}
+
+	prm.SetMethod(c.putMethod)
+	prm.SetArgs(int64(args.epoch), args.peerID, args.value)
+
+	err := c.client.Invoke(prm)
 
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", c.putMethod, err)

--- a/pkg/morph/event/balance/lock.go
+++ b/pkg/morph/event/balance/lock.go
@@ -17,6 +17,11 @@ type Lock struct {
 	lock   util.Uint160
 	amount int64 // Fixed16
 	until  int64
+
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
 }
 
 // MorphEvent implements Neo:Morph Event interface.
@@ -34,8 +39,12 @@ func (l Lock) LockAccount() util.Uint160 { return l.lock }
 // Amount of the locked assets.
 func (l Lock) Amount() int64 { return l.amount }
 
-// Until is a epoch before locked account exists.
+// Until is an epoch before locked account exists.
 func (l Lock) Until() int64 { return l.until }
+
+// TxHash returns hash of the TX with lock
+// notification.
+func (l Lock) TxHash() util.Uint256 { return l.txHash }
 
 // ParseLock from notification into lock structure.
 func ParseLock(e *subscriptions.NotificationEvent) (event.Event, error) {
@@ -92,6 +101,8 @@ func ParseLock(e *subscriptions.NotificationEvent) (event.Event, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get lock deadline: %w", err)
 	}
+
+	ev.txHash = e.Container
 
 	return ev, nil
 }

--- a/pkg/morph/event/balance/lock.go
+++ b/pkg/morph/event/balance/lock.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
-
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"

--- a/pkg/morph/event/balance/lock.go
+++ b/pkg/morph/event/balance/lock.go
@@ -3,8 +3,9 @@ package balance
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -37,11 +38,16 @@ func (l Lock) Amount() int64 { return l.amount }
 func (l Lock) Until() int64 { return l.until }
 
 // ParseLock from notification into lock structure.
-func ParseLock(params []stackitem.Item) (event.Event, error) {
+func ParseLock(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Lock
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != 5 {
 		return nil, event.WrongNumberOfParameters(5, ln)

--- a/pkg/morph/event/container/delete.go
+++ b/pkg/morph/event/container/delete.go
@@ -3,8 +3,9 @@ package container
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -46,11 +47,16 @@ const expectedItemNumDelete = 3
 // ParseDelete from notification into container event structure.
 //
 // Expects 3 stack items.
-func ParseDelete(params []stackitem.Item) (event.Event, error) {
+func ParseDelete(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Delete
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != expectedItemNumDelete {
 		return nil, event.WrongNumberOfParameters(expectedItemNumDelete, ln)

--- a/pkg/morph/event/container/delete.go
+++ b/pkg/morph/event/container/delete.go
@@ -3,9 +3,8 @@ package container
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
-
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )

--- a/pkg/morph/event/container/delete_test.go
+++ b/pkg/morph/event/container/delete_test.go
@@ -20,43 +20,43 @@ func TestParseDelete(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseDelete(prms)
+		_, err := ParseDelete(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(3, len(prms)).Error())
 	})
 
 	t.Run("wrong container parameter", func(t *testing.T) {
-		_, err := ParseDelete([]stackitem.Item{
+		_, err := ParseDelete(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong signature parameter", func(t *testing.T) {
-		_, err := ParseDelete([]stackitem.Item{
+		_, err := ParseDelete(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerID),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong session token parameter", func(t *testing.T) {
-		_, err := ParseDelete([]stackitem.Item{
+		_, err := ParseDelete(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerID),
 			stackitem.NewByteArray(signature),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseDelete([]stackitem.Item{
+		ev, err := ParseDelete(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerID),
 			stackitem.NewByteArray(signature),
 			stackitem.NewByteArray(token),
-		})
+		}))
 
 		require.NoError(t, err)
 

--- a/pkg/morph/event/container/eacl_test.go
+++ b/pkg/morph/event/container/eacl_test.go
@@ -1,11 +1,12 @@
-package container_test
+package container
 
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
-	"github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,64 +24,72 @@ func TestParseEACL(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := container.ParseSetEACL(items)
+		_, err := ParseSetEACL(createNotifyEventFromItems(items))
 		require.EqualError(t, err, event.WrongNumberOfParameters(4, len(items)).Error())
 	})
 
 	t.Run("wrong container parameter", func(t *testing.T) {
-		_, err := container.ParseSetEACL([]stackitem.Item{
+		_, err := ParseSetEACL(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
 			stackitem.NewMap(),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong signature parameter", func(t *testing.T) {
-		_, err := container.ParseSetEACL([]stackitem.Item{
+		_, err := ParseSetEACL(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(binaryTable),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong key parameter", func(t *testing.T) {
-		_, err := container.ParseSetEACL([]stackitem.Item{
+		_, err := ParseSetEACL(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(binaryTable),
 			stackitem.NewByteArray(signature),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong session token parameter", func(t *testing.T) {
-		_, err := container.ParseSetEACL([]stackitem.Item{
+		_, err := ParseSetEACL(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(binaryTable),
 			stackitem.NewByteArray(signature),
 			stackitem.NewByteArray(publicKey),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := container.ParseSetEACL([]stackitem.Item{
+		ev, err := ParseSetEACL(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(binaryTable),
 			stackitem.NewByteArray(signature),
 			stackitem.NewByteArray(publicKey),
 			stackitem.NewByteArray(token),
-		})
+		}))
 		require.NoError(t, err)
 
-		e := ev.(container.SetEACL)
+		e := ev.(SetEACL)
 
 		require.Equal(t, binaryTable, e.Table())
 		require.Equal(t, signature, e.Signature())
 		require.Equal(t, publicKey, e.PublicKey())
 		require.Equal(t, token, e.SessionToken())
 	})
+}
+
+func createNotifyEventFromItems(items []stackitem.Item) *subscriptions.NotificationEvent {
+	return &subscriptions.NotificationEvent{
+		NotificationEvent: state.NotificationEvent{
+			Item: stackitem.NewArray(items),
+		},
+	}
 }

--- a/pkg/morph/event/container/estimates.go
+++ b/pkg/morph/event/container/estimates.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
-
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"

--- a/pkg/morph/event/container/estimates.go
+++ b/pkg/morph/event/container/estimates.go
@@ -3,6 +3,8 @@ package container
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -33,7 +35,12 @@ func (s StartEstimation) Epoch() uint64 { return s.epoch }
 func (s StopEstimation) Epoch() uint64 { return s.epoch }
 
 // ParseStartEstimation from notification into container event structure.
-func ParseStartEstimation(params []stackitem.Item) (event.Event, error) {
+func ParseStartEstimation(e *subscriptions.NotificationEvent) (event.Event, error) {
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
+
 	epoch, err := parseEstimation(params)
 	if err != nil {
 		return nil, err
@@ -43,7 +50,12 @@ func ParseStartEstimation(params []stackitem.Item) (event.Event, error) {
 }
 
 // ParseStopEstimation from notification into container event structure.
-func ParseStopEstimation(params []stackitem.Item) (event.Event, error) {
+func ParseStopEstimation(e *subscriptions.NotificationEvent) (event.Event, error) {
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
+
 	epoch, err := parseEstimation(params)
 	if err != nil {
 		return nil, err

--- a/pkg/morph/event/container/estimates_test.go
+++ b/pkg/morph/event/container/estimates_test.go
@@ -19,22 +19,22 @@ func TestStartEstimation(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseStartEstimation(prms)
+		_, err := ParseStartEstimation(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(1, len(prms)).Error())
 	})
 
 	t.Run("wrong estimation parameter", func(t *testing.T) {
-		_, err := ParseStartEstimation([]stackitem.Item{
+		_, err := ParseStartEstimation(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseStartEstimation([]stackitem.Item{
+		ev, err := ParseStartEstimation(createNotifyEventFromItems([]stackitem.Item{
 			epochItem,
-		})
+		}))
 
 		require.NoError(t, err)
 
@@ -54,22 +54,22 @@ func TestStopEstimation(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseStopEstimation(prms)
+		_, err := ParseStopEstimation(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(1, len(prms)).Error())
 	})
 
 	t.Run("wrong estimation parameter", func(t *testing.T) {
-		_, err := ParseStopEstimation([]stackitem.Item{
+		_, err := ParseStopEstimation(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseStopEstimation([]stackitem.Item{
+		ev, err := ParseStopEstimation(createNotifyEventFromItems([]stackitem.Item{
 			epochItem,
-		})
+		}))
 
 		require.NoError(t, err)
 

--- a/pkg/morph/event/container/put.go
+++ b/pkg/morph/event/container/put.go
@@ -3,8 +3,9 @@ package container
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -65,11 +66,16 @@ func (x PutNamed) Zone() string {
 }
 
 // ParsePut from notification into container event structure.
-func ParsePut(params []stackitem.Item) (event.Event, error) {
+func ParsePut(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Put
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != expectedItemNumPut {
 		return nil, event.WrongNumberOfParameters(expectedItemNumPut, ln)

--- a/pkg/morph/event/container/put.go
+++ b/pkg/morph/event/container/put.go
@@ -3,9 +3,8 @@ package container
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
-
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )

--- a/pkg/morph/event/container/put_test.go
+++ b/pkg/morph/event/container/put_test.go
@@ -22,55 +22,55 @@ func TestParsePut(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParsePut(prms)
+		_, err := ParsePut(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(expectedItemNumPut, len(prms)).Error())
 	})
 
 	t.Run("wrong container parameter", func(t *testing.T) {
-		_, err := ParsePut([]stackitem.Item{
+		_, err := ParsePut(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong signature parameter", func(t *testing.T) {
-		_, err := ParsePut([]stackitem.Item{
+		_, err := ParsePut(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerData),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong key parameter", func(t *testing.T) {
-		_, err := ParsePut([]stackitem.Item{
+		_, err := ParsePut(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerData),
 			stackitem.NewByteArray(signature),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong session token parameter", func(t *testing.T) {
-		_, err := ParsePut([]stackitem.Item{
+		_, err := ParsePut(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerData),
 			stackitem.NewByteArray(signature),
 			stackitem.NewByteArray(publicKey),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParsePut([]stackitem.Item{
+		ev, err := ParsePut(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(containerData),
 			stackitem.NewByteArray(signature),
 			stackitem.NewByteArray(publicKey),
 			stackitem.NewByteArray(token),
-		})
+		}))
 		require.NoError(t, err)
 
 		require.Equal(t, Put{

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -285,19 +285,6 @@ func (l listener) parseAndHandleNotification(notifyEvent *subscriptions.Notifica
 		zap.String("script hash LE", notifyEvent.ScriptHash.StringLE()),
 	)
 
-	// stack item must be an array of items
-	arr, err := client.ArrayFromStackItem(notifyEvent.Item)
-	if err != nil {
-		log.Warn("stack item is not an array type",
-			zap.String("error", err.Error()),
-		)
-
-		return
-	} else if len(arr) == 0 {
-		log.Warn("stack item array is empty")
-		return
-	}
-
 	// calculate event type from bytes
 	typEvent := TypeFromString(notifyEvent.Name)
 
@@ -321,7 +308,7 @@ func (l listener) parseAndHandleNotification(notifyEvent *subscriptions.Notifica
 	}
 
 	// parse the notification event
-	event, err := parser(arr)
+	event, err := parser(notifyEvent)
 	if err != nil {
 		log.Warn("could not parse notification event",
 			zap.String("error", err.Error()),

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
-	"github.com/nspcc-dev/neo-go/pkg/core/state"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
@@ -185,7 +184,7 @@ func (l *listener) listen(ctx context.Context, intError chan<- error) error {
 	return nil
 }
 
-func (l listener) listenLoop(ctx context.Context, chEvent <-chan *state.NotificationEvent, intErr chan<- error) {
+func (l listener) listenLoop(ctx context.Context, chEvent <-chan *subscriptions.NotificationEvent, intErr chan<- error) {
 	var (
 		blockChan <-chan *block.Block
 
@@ -281,7 +280,7 @@ loop:
 	}
 }
 
-func (l listener) parseAndHandleNotification(notifyEvent *state.NotificationEvent) {
+func (l listener) parseAndHandleNotification(notifyEvent *subscriptions.NotificationEvent) {
 	log := l.log.With(
 		zap.String("script hash LE", notifyEvent.ScriptHash.StringLE()),
 	)

--- a/pkg/morph/event/neofs/bind.go
+++ b/pkg/morph/event/neofs/bind.go
@@ -3,6 +3,7 @@ package neofs
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -24,11 +25,16 @@ func (b bindCommon) Keys() [][]byte { return b.keys }
 
 func (b bindCommon) User() []byte { return b.user }
 
-func ParseBind(params []stackitem.Item) (event.Event, error) {
+func ParseBind(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Bind
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	err = parseBind(&ev.bindCommon, params)
 	if err != nil {

--- a/pkg/morph/event/neofs/bind.go
+++ b/pkg/morph/event/neofs/bind.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -16,6 +17,17 @@ type Bind struct {
 type bindCommon struct {
 	user []byte
 	keys [][]byte
+
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
+}
+
+// TxHash returns hash of the TX with new epoch
+// notification.
+func (b bindCommon) TxHash() util.Uint256 {
+	return b.txHash
 }
 
 // MorphEvent implements Neo:Morph Event interface.
@@ -40,6 +52,8 @@ func ParseBind(e *subscriptions.NotificationEvent) (event.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	ev.txHash = e.Container
 
 	return ev, nil
 }

--- a/pkg/morph/event/neofs/bind_test.go
+++ b/pkg/morph/event/neofs/bind_test.go
@@ -3,6 +3,8 @@ package neofs
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/stretchr/testify/require"
@@ -23,36 +25,36 @@ func TestParseBind(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseBind(prms)
+		_, err := ParseBind(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(2, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter", func(t *testing.T) {
-		_, err := ParseBind([]stackitem.Item{
+		_, err := ParseBind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong second parameter", func(t *testing.T) {
-		_, err := ParseBind([]stackitem.Item{
+		_, err := ParseBind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct", func(t *testing.T) {
-		ev, err := ParseBind([]stackitem.Item{
+		ev, err := ParseBind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user),
 			stackitem.NewArray([]stackitem.Item{
 				stackitem.NewByteArray(publicKeys[0]),
 				stackitem.NewByteArray(publicKeys[1]),
 				stackitem.NewByteArray(publicKeys[2]),
 			}),
-		})
+		}))
 		require.NoError(t, err)
 
 		e := ev.(Bind)
@@ -60,4 +62,12 @@ func TestParseBind(t *testing.T) {
 		require.Equal(t, user, e.User())
 		require.Equal(t, publicKeys, e.Keys())
 	})
+}
+
+func createNotifyEventFromItems(items []stackitem.Item) *subscriptions.NotificationEvent {
+	return &subscriptions.NotificationEvent{
+		NotificationEvent: state.NotificationEvent{
+			Item: stackitem.NewArray(items),
+		},
+	}
 }

--- a/pkg/morph/event/neofs/cheque.go
+++ b/pkg/morph/event/neofs/cheque.go
@@ -3,8 +3,8 @@ package neofs
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -33,11 +33,16 @@ func (c Cheque) Amount() int64 { return c.amount }
 func (c Cheque) LockAccount() util.Uint160 { return c.lock }
 
 // ParseCheque from notification into cheque structure.
-func ParseCheque(params []stackitem.Item) (event.Event, error) {
+func ParseCheque(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Cheque
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != 4 {
 		return nil, event.WrongNumberOfParameters(4, ln)

--- a/pkg/morph/event/neofs/cheque_test.go
+++ b/pkg/morph/event/neofs/cheque_test.go
@@ -25,55 +25,55 @@ func TestParseCheque(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseCheque(prms)
+		_, err := ParseCheque(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(4, len(prms)).Error())
 	})
 
 	t.Run("wrong id parameter", func(t *testing.T) {
-		_, err := ParseCheque([]stackitem.Item{
+		_, err := ParseCheque(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong user parameter", func(t *testing.T) {
-		_, err := ParseCheque([]stackitem.Item{
+		_, err := ParseCheque(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong amount parameter", func(t *testing.T) {
-		_, err := ParseCheque([]stackitem.Item{
+		_, err := ParseCheque(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong lock parameter", func(t *testing.T) {
-		_, err := ParseCheque([]stackitem.Item{
+		_, err := ParseCheque(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseCheque([]stackitem.Item{
+		ev, err := ParseCheque(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewByteArray(lock.BytesBE()),
-		})
+		}))
 
 		require.NoError(t, err)
 		require.Equal(t, Cheque{

--- a/pkg/morph/event/neofs/config.go
+++ b/pkg/morph/event/neofs/config.go
@@ -3,7 +3,7 @@ package neofs
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -23,11 +23,16 @@ func (u Config) Key() []byte { return u.key }
 
 func (u Config) Value() []byte { return u.value }
 
-func ParseConfig(params []stackitem.Item) (event.Event, error) {
+func ParseConfig(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Config
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != 3 {
 		return nil, event.WrongNumberOfParameters(3, ln)

--- a/pkg/morph/event/neofs/config.go
+++ b/pkg/morph/event/neofs/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -12,6 +13,17 @@ type Config struct {
 	key   []byte
 	value []byte
 	id    []byte
+
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
+}
+
+// TxHash returns hash of the TX with new epoch
+// notification.
+func (u Config) TxHash() util.Uint256 {
+	return u.txHash
 }
 
 // MorphEvent implements Neo:Morph Event interface.
@@ -55,6 +67,8 @@ func ParseConfig(e *subscriptions.NotificationEvent) (event.Event, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get config value: %w", err)
 	}
+
+	ev.txHash = e.Container
 
 	return ev, nil
 }

--- a/pkg/morph/event/neofs/config_test.go
+++ b/pkg/morph/event/neofs/config_test.go
@@ -20,43 +20,43 @@ func TestParseConfig(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseConfig(prms)
+		_, err := ParseConfig(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(3, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter", func(t *testing.T) {
-		_, err := ParseConfig([]stackitem.Item{
+		_, err := ParseConfig(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong second parameter", func(t *testing.T) {
-		_, err := ParseConfig([]stackitem.Item{
+		_, err := ParseConfig(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong third parameter", func(t *testing.T) {
-		_, err := ParseConfig([]stackitem.Item{
+		_, err := ParseConfig(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewByteArray(key),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct", func(t *testing.T) {
-		ev, err := ParseConfig([]stackitem.Item{
+		ev, err := ParseConfig(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(id),
 			stackitem.NewByteArray(key),
 			stackitem.NewByteArray(value),
-		})
+		}))
 		require.NoError(t, err)
 
 		require.Equal(t, Config{

--- a/pkg/morph/event/neofs/deposit.go
+++ b/pkg/morph/event/neofs/deposit.go
@@ -3,8 +3,8 @@ package neofs
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -33,8 +33,13 @@ func (d Deposit) To() util.Uint160 { return d.to }
 func (d Deposit) Amount() int64 { return d.amount }
 
 // ParseDeposit notification into deposit structure.
-func ParseDeposit(params []stackitem.Item) (event.Event, error) {
+func ParseDeposit(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var ev Deposit
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != 4 {
 		return nil, event.WrongNumberOfParameters(4, ln)

--- a/pkg/morph/event/neofs/deposit_test.go
+++ b/pkg/morph/event/neofs/deposit_test.go
@@ -25,55 +25,55 @@ func TestParseDeposit(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseDeposit(prms)
+		_, err := ParseDeposit(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(4, len(prms)).Error())
 	})
 
 	t.Run("wrong from parameter", func(t *testing.T) {
-		_, err := ParseDeposit([]stackitem.Item{
+		_, err := ParseDeposit(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong amount parameter", func(t *testing.T) {
-		_, err := ParseDeposit([]stackitem.Item{
+		_, err := ParseDeposit(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(from.BytesBE()),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong to parameter", func(t *testing.T) {
-		_, err := ParseDeposit([]stackitem.Item{
+		_, err := ParseDeposit(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(from.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong id parameter", func(t *testing.T) {
-		_, err := ParseDeposit([]stackitem.Item{
+		_, err := ParseDeposit(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(from.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewByteArray(to.BytesBE()),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseDeposit([]stackitem.Item{
+		ev, err := ParseDeposit(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(from.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewByteArray(to.BytesBE()),
 			stackitem.NewByteArray(id),
-		})
+		}))
 
 		require.NoError(t, err)
 		require.Equal(t, Deposit{

--- a/pkg/morph/event/neofs/unbind.go
+++ b/pkg/morph/event/neofs/unbind.go
@@ -27,5 +27,7 @@ func ParseUnbind(e *subscriptions.NotificationEvent) (event.Event, error) {
 		return nil, err
 	}
 
+	ev.txHash = e.Container
+
 	return ev, nil
 }

--- a/pkg/morph/event/neofs/unbind.go
+++ b/pkg/morph/event/neofs/unbind.go
@@ -1,7 +1,9 @@
 package neofs
 
 import (
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"fmt"
+
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
@@ -9,11 +11,16 @@ type Unbind struct {
 	bindCommon
 }
 
-func ParseUnbind(params []stackitem.Item) (event.Event, error) {
+func ParseUnbind(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  Unbind
 		err error
 	)
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	err = parseBind(&ev.bindCommon, params)
 	if err != nil {

--- a/pkg/morph/event/neofs/unbind_test.go
+++ b/pkg/morph/event/neofs/unbind_test.go
@@ -23,36 +23,36 @@ func TestParseUnbind(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseUnbind(prms)
+		_, err := ParseUnbind(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(2, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter", func(t *testing.T) {
-		_, err := ParseUnbind([]stackitem.Item{
+		_, err := ParseUnbind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong second parameter", func(t *testing.T) {
-		_, err := ParseUnbind([]stackitem.Item{
+		_, err := ParseUnbind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct", func(t *testing.T) {
-		ev, err := ParseUnbind([]stackitem.Item{
+		ev, err := ParseUnbind(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user),
 			stackitem.NewArray([]stackitem.Item{
 				stackitem.NewByteArray(publicKeys[0]),
 				stackitem.NewByteArray(publicKeys[1]),
 				stackitem.NewByteArray(publicKeys[2]),
 			}),
-		})
+		}))
 		require.NoError(t, err)
 
 		e := ev.(Unbind)

--- a/pkg/morph/event/neofs/withdraw.go
+++ b/pkg/morph/event/neofs/withdraw.go
@@ -3,8 +3,8 @@ package neofs
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -29,8 +29,13 @@ func (w Withdraw) User() util.Uint160 { return w.user }
 func (w Withdraw) Amount() int64 { return w.amount }
 
 // ParseWithdraw notification into withdraw structure.
-func ParseWithdraw(params []stackitem.Item) (event.Event, error) {
+func ParseWithdraw(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var ev Withdraw
+
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
 
 	if ln := len(params); ln != 3 {
 		return nil, event.WrongNumberOfParameters(3, ln)

--- a/pkg/morph/event/neofs/withdraw_test.go
+++ b/pkg/morph/event/neofs/withdraw_test.go
@@ -24,43 +24,43 @@ func TestParseWithdraw(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseWithdraw(prms)
+		_, err := ParseWithdraw(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(3, len(prms)).Error())
 	})
 
 	t.Run("wrong user parameter", func(t *testing.T) {
-		_, err := ParseWithdraw([]stackitem.Item{
+		_, err := ParseWithdraw(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong amount parameter", func(t *testing.T) {
-		_, err := ParseWithdraw([]stackitem.Item{
+		_, err := ParseWithdraw(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong id parameter", func(t *testing.T) {
-		_, err := ParseWithdraw([]stackitem.Item{
+		_, err := ParseWithdraw(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseWithdraw([]stackitem.Item{
+		ev, err := ParseWithdraw(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(user.BytesBE()),
 			stackitem.NewBigInteger(new(big.Int).SetInt64(amount)),
 			stackitem.NewByteArray(id),
-		})
+		}))
 
 		require.NoError(t, err)
 		require.Equal(t, Withdraw{

--- a/pkg/morph/event/netmap/add_peer.go
+++ b/pkg/morph/event/netmap/add_peer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -32,17 +32,22 @@ func (s AddPeer) NotaryRequest() *payload.P2PNotaryRequest {
 
 const expectedItemNumAddPeer = 1
 
-func ParseAddPeer(prms []stackitem.Item) (event.Event, error) {
+func ParseAddPeer(e *subscriptions.NotificationEvent) (event.Event, error) {
 	var (
 		ev  AddPeer
 		err error
 	)
 
-	if ln := len(prms); ln != expectedItemNumAddPeer {
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
+
+	if ln := len(params); ln != expectedItemNumAddPeer {
 		return nil, event.WrongNumberOfParameters(expectedItemNumAddPeer, ln)
 	}
 
-	ev.node, err = client.BytesFromStackItem(prms[0])
+	ev.node, err = client.BytesFromStackItem(params[0])
 	if err != nil {
 		return nil, fmt.Errorf("could not get raw nodeinfo: %w", err)
 	}

--- a/pkg/morph/event/netmap/add_peer_test.go
+++ b/pkg/morph/event/netmap/add_peer_test.go
@@ -3,6 +3,8 @@ package netmap
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/stretchr/testify/require"
@@ -15,14 +17,14 @@ func TestParseAddPeer(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseAddPeer(prms)
+		_, err := ParseAddPeer(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(1, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter type", func(t *testing.T) {
-		_, err := ParseAddPeer([]stackitem.Item{
+		_, err := ParseAddPeer(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
@@ -30,13 +32,21 @@ func TestParseAddPeer(t *testing.T) {
 	t.Run("correct behavior", func(t *testing.T) {
 		info := []byte{1, 2, 3}
 
-		ev, err := ParseAddPeer([]stackitem.Item{
+		ev, err := ParseAddPeer(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(info),
-		})
+		}))
 
 		require.NoError(t, err)
 		require.Equal(t, AddPeer{
 			node: info,
 		}, ev)
 	})
+}
+
+func createNotifyEventFromItems(items []stackitem.Item) *subscriptions.NotificationEvent {
+	return &subscriptions.NotificationEvent{
+		NotificationEvent: state.NotificationEvent{
+			Item: stackitem.NewArray(items),
+		},
+	}
 }

--- a/pkg/morph/event/netmap/epoch.go
+++ b/pkg/morph/event/netmap/epoch.go
@@ -3,7 +3,7 @@ package netmap
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -24,12 +24,17 @@ func (s NewEpoch) EpochNumber() uint64 {
 // ParseNewEpoch is a parser of new epoch notification event.
 //
 // Result is type of NewEpoch.
-func ParseNewEpoch(prms []stackitem.Item) (event.Event, error) {
-	if ln := len(prms); ln != 1 {
+func ParseNewEpoch(e *subscriptions.NotificationEvent) (event.Event, error) {
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
+
+	if ln := len(params); ln != 1 {
 		return nil, event.WrongNumberOfParameters(1, ln)
 	}
 
-	prmEpochNum, err := client.IntFromStackItem(prms[0])
+	prmEpochNum, err := client.IntFromStackItem(params[0])
 	if err != nil {
 		return nil, fmt.Errorf("could not get integer epoch number: %w", err)
 	}

--- a/pkg/morph/event/netmap/epoch.go
+++ b/pkg/morph/event/netmap/epoch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
@@ -11,6 +12,11 @@ import (
 // NewEpoch is a new epoch Neo:Morph event.
 type NewEpoch struct {
 	num uint64
+
+	// txHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	txHash util.Uint256
 }
 
 // MorphEvent implements Neo:Morph Event interface.
@@ -19,6 +25,12 @@ func (NewEpoch) MorphEvent() {}
 // EpochNumber returns new epoch number.
 func (s NewEpoch) EpochNumber() uint64 {
 	return s.num
+}
+
+// TxHash returns hash of the TX with new epoch
+// notification.
+func (s NewEpoch) TxHash() util.Uint256 {
+	return s.txHash
 }
 
 // ParseNewEpoch is a parser of new epoch notification event.
@@ -40,6 +52,7 @@ func ParseNewEpoch(e *subscriptions.NotificationEvent) (event.Event, error) {
 	}
 
 	return NewEpoch{
-		num: uint64(prmEpochNum),
+		num:    uint64(prmEpochNum),
+		txHash: e.Container,
 	}, nil
 }

--- a/pkg/morph/event/netmap/epoch_test.go
+++ b/pkg/morph/event/netmap/epoch_test.go
@@ -16,14 +16,14 @@ func TestParseNewEpoch(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseNewEpoch(prms)
+		_, err := ParseNewEpoch(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(1, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter type", func(t *testing.T) {
-		_, err := ParseNewEpoch([]stackitem.Item{
+		_, err := ParseNewEpoch(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
@@ -31,9 +31,9 @@ func TestParseNewEpoch(t *testing.T) {
 	t.Run("correct behavior", func(t *testing.T) {
 		epochNum := uint64(100)
 
-		ev, err := ParseNewEpoch([]stackitem.Item{
+		ev, err := ParseNewEpoch(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewBigInteger(new(big.Int).SetUint64(epochNum)),
-		})
+		}))
 
 		require.NoError(t, err)
 		require.Equal(t, NewEpoch{

--- a/pkg/morph/event/netmap/update_peer.go
+++ b/pkg/morph/event/netmap/update_peer.go
@@ -4,10 +4,9 @@ import (
 	"crypto/elliptic"
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
-
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"

--- a/pkg/morph/event/netmap/update_peer.go
+++ b/pkg/morph/event/netmap/update_peer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
-	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"

--- a/pkg/morph/event/netmap/update_peer_test.go
+++ b/pkg/morph/event/netmap/update_peer_test.go
@@ -25,32 +25,32 @@ func TestParseUpdatePeer(t *testing.T) {
 			stackitem.NewMap(),
 		}
 
-		_, err := ParseUpdatePeer(prms)
+		_, err := ParseUpdatePeer(createNotifyEventFromItems(prms))
 		require.EqualError(t, err, event.WrongNumberOfParameters(2, len(prms)).Error())
 	})
 
 	t.Run("wrong first parameter type", func(t *testing.T) {
-		_, err := ParseUpdatePeer([]stackitem.Item{
+		_, err := ParseUpdatePeer(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("wrong second parameter type", func(t *testing.T) {
-		_, err := ParseUpdatePeer([]stackitem.Item{
+		_, err := ParseUpdatePeer(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewByteArray(publicKey.Bytes()),
 			stackitem.NewMap(),
-		})
+		}))
 
 		require.Error(t, err)
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
-		ev, err := ParseUpdatePeer([]stackitem.Item{
+		ev, err := ParseUpdatePeer(createNotifyEventFromItems([]stackitem.Item{
 			stackitem.NewBigInteger(new(big.Int).SetInt64(int64(state.ToV2()))),
 			stackitem.NewByteArray(publicKey.Bytes()),
-		})
+		}))
 		require.NoError(t, err)
 
 		require.Equal(t, UpdatePeer{

--- a/pkg/morph/event/parsers.go
+++ b/pkg/morph/event/parsers.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/network/payload"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 )
 
 // NotificationParser is a function that constructs Event
 // from the StackItem list.
-type NotificationParser func([]stackitem.Item) (Event, error)
+type NotificationParser func(*subscriptions.NotificationEvent) (Event, error)
 
 // NotificationParserInfo is a structure that groups
 // the parameters of particular contract

--- a/pkg/morph/event/rolemanagement/designate.go
+++ b/pkg/morph/event/rolemanagement/designate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/native/noderoles"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
@@ -17,7 +17,12 @@ type Designate struct {
 func (Designate) MorphEvent() {}
 
 // ParseDesignate from notification into container event structure.
-func ParseDesignate(params []stackitem.Item) (event.Event, error) {
+func ParseDesignate(e *subscriptions.NotificationEvent) (event.Event, error) {
+	params, err := event.ParseStackArray(e)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse stack items from notify event: %w", err)
+	}
+
 	if len(params) != 2 {
 		return nil, event.WrongNumberOfParameters(2, len(params))
 	}

--- a/pkg/morph/event/rolemanagement/designate.go
+++ b/pkg/morph/event/rolemanagement/designate.go
@@ -5,12 +5,18 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/native/noderoles"
 	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
+	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
 // Designate represents designation event of the mainnet RoleManagement contract.
 type Designate struct {
 	Role noderoles.Role
+
+	// TxHash is used in notary environmental
+	// for calculating unique but same for
+	// all notification receivers values.
+	TxHash util.Uint256
 }
 
 // MorphEvent implements Neo:Morph Event interface.
@@ -32,5 +38,8 @@ func ParseDesignate(e *subscriptions.NotificationEvent) (event.Event, error) {
 		return nil, fmt.Errorf("invalid stackitem type: %w", err)
 	}
 
-	return Designate{Role: noderoles.Role(bi.Int64())}, nil
+	return Designate{
+		Role:   noderoles.Role(bi.Int64()),
+		TxHash: e.Container,
+	}, nil
 }

--- a/pkg/morph/event/rolemanagement/designate_test.go
+++ b/pkg/morph/event/rolemanagement/designate_test.go
@@ -4,24 +4,34 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/native/noderoles"
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseRoleUpdate(t *testing.T) {
 	t.Run("wrong number of arguments", func(t *testing.T) {
-		_, err := ParseDesignate([]stackitem.Item{})
+		_, err := ParseDesignate(createNotifyEventFromItems([]stackitem.Item{}))
 		require.Error(t, err)
 	})
 	t.Run("invalid item type", func(t *testing.T) {
 		args := []stackitem.Item{stackitem.NewMap(), stackitem.Make(123)}
-		_, err := ParseDesignate(args)
+		_, err := ParseDesignate(createNotifyEventFromItems(args))
 		require.Error(t, err)
 	})
 	t.Run("good", func(t *testing.T) {
 		args := []stackitem.Item{stackitem.Make(int(noderoles.NeoFSAlphabet)), stackitem.Make(123)}
-		e, err := ParseDesignate(args)
+		e, err := ParseDesignate(createNotifyEventFromItems(args))
 		require.NoError(t, err)
 		require.Equal(t, noderoles.NeoFSAlphabet, e.(Designate).Role)
 	})
+}
+
+func createNotifyEventFromItems(items []stackitem.Item) *subscriptions.NotificationEvent {
+	return &subscriptions.NotificationEvent{
+		NotificationEvent: state.NotificationEvent{
+			Item: stackitem.NewArray(items),
+		},
+	}
 }

--- a/pkg/morph/event/utils.go
+++ b/pkg/morph/event/utils.go
@@ -1,8 +1,14 @@
 package event
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/nspcc-dev/neo-go/pkg/core/mempoolevent"
+	"github.com/nspcc-dev/neo-go/pkg/rpc/response/result/subscriptions"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	util2 "github.com/nspcc-dev/neofs-node/pkg/util"
 	"go.uber.org/zap"
 )
@@ -87,4 +93,19 @@ func WorkerPoolHandler(w util2.WorkerPool, h Handler, log *zap.Logger) Handler {
 			)
 		}
 	}
+}
+
+var errEmptyStackArray = errors.New("stack item array is empty")
+
+// ParseStackArray parses stack array from raw notification
+// event received from neo-go RPC node.
+func ParseStackArray(event *subscriptions.NotificationEvent) ([]stackitem.Item, error) {
+	arr, err := client.ArrayFromStackItem(event.Item)
+	if err != nil {
+		return nil, fmt.Errorf("stack item is not an array type: %w", err)
+	} else if len(arr) == 0 {
+		return nil, errEmptyStackArray
+	}
+
+	return arr, nil
 }


### PR DESCRIPTION
This PR refactors morph wrappers to group their call parameters. `InvokePrmOptional` is public in all level parameters to save us from too much useless copy-paste of `TxHash()` method. It will be considered to be private after moving to `neofs-sdk-go` and reducing the number of wrapper levels. 

`InvokePrmOptional` was also planned to store optional `transaction.Transaction` that is going to be signed by Alphabet. So after that PR, there will be another that deletes `NotarySignAndInvokeTX`and its usage.

Closes #844.