### PR TITLE
neofs-adm: fixes for contract update

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
@@ -91,7 +91,7 @@ func (c *initializeContext) nnsRegisterDomain(nnsHash, expectedHash util.Uint160
 		if err != nil {
 			return err
 		}
-		if s != expectedHash {
+		if s == expectedHash {
 			return nil
 		}
 	}


### PR DESCRIPTION
1. Compare `NEF.Checksum` to check if contract is updated.
2. Replace `addRoot` with `register` in NNS.
3. Compare hashes written to NNS properly.