### PR TITLE
[#878] neofs-node: default to secure TLS settings

### DIFF
--- a/cmd/neofs-node/config/grpc/config.go
+++ b/cmd/neofs-node/config/grpc/config.go
@@ -78,6 +78,11 @@ func (tls TLSConfig) CertificateFile() string {
 	return v
 }
 
+// UseInsecureCrypto returns true if TLS 1.2 cipher suite should not be restricted.
+func (tls TLSConfig) UseInsecureCrypto() bool {
+	return config.BoolSafe(tls.cfg, "use_insecure_crypto")
+}
+
 // IterateEndpoints iterates over subsections ["0":"N") (N - "num" value)
 // of "grpc" section of c, wrap them into Config and passes to f.
 //

--- a/cmd/neofs-node/config/grpc/config_test.go
+++ b/cmd/neofs-node/config/grpc/config_test.go
@@ -31,12 +31,17 @@ func TestGRPCSection(t *testing.T) {
 			case 0:
 				require.Equal(t, "s01.neofs.devenv:8080", sc.Endpoint())
 
+				require.NotNil(t, tls)
 				require.Equal(t, "/path/to/cert", tls.CertificateFile())
 				require.Equal(t, "/path/to/key", tls.KeyFile())
+				require.False(t, tls.UseInsecureCrypto())
 			case 1:
 				require.Equal(t, "s02.neofs.devenv:8080", sc.Endpoint())
-
 				require.Nil(t, tls)
+			case 2:
+				require.Equal(t, "s03.neofs.devenv:8080", sc.Endpoint())
+				require.NotNil(t, tls)
+				require.True(t, tls.UseInsecureCrypto())
 			}
 		})
 	}

--- a/config/example/node.json
+++ b/config/example/node.json
@@ -53,6 +53,13 @@
       "tls": {
         "enabled": false
       }
+    },
+    "2": {
+      "endpoint": "s03.neofs.devenv:8080",
+      "tls": {
+        "enabled": true,
+        "use_insecure_crypto": true
+      }
     }
   },
   "control": {

--- a/config/example/node.yaml
+++ b/config/example/node.yaml
@@ -37,7 +37,7 @@ grpc:
   0:
     endpoint: s01.neofs.devenv:8080  # endpoint for gRPC server
     tls:
-      enabled: true  # use TLS for a gRPC connection
+      enabled: true  # use TLS for a gRPC connection (min version is TLS 1.2)
       certificate: /path/to/cert  # path to TLS certificate
       key: /path/to/key  # path to TLS key
 
@@ -45,6 +45,11 @@ grpc:
     endpoint: s02.neofs.devenv:8080  # endpoint for gRPC server
     tls:
       enabled: false  # use TLS for a gRPC connection
+  2:
+    endpoint: s03.neofs.devenv:8080
+    tls:
+      enabled: true
+      use_insecure_crypto: true # allow using insecure ciphers with TLS 1.2
 
 control:
   authorized_keys:  # list of hex-encoded public keys that have rights to use the Control Service


### PR DESCRIPTION
Close #878 .

Support TLS >=1.2 only and strong cipher suites.
I have also checked NIST recommendations (
https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf), but they are less strict and include ciphers considered insecure by go stdlib.

I don't think allowing user to precisely specify cipher suites is worth it.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>