### PR TITLE
metabase: Copy BoltDB value returned by IsSmall

### DIFF
--- a/pkg/local_object_storage/metabase/small.go
+++ b/pkg/local_object_storage/metabase/small.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
@@ -69,5 +70,5 @@ func (db *DB) isSmall(tx *bbolt.Tx, addr *objectSDK.Address) (*blobovnicza.ID, e
 		return nil, nil
 	}
 
-	return blobovnicza.NewIDFromBytes(blobovniczaID), nil
+	return blobovnicza.NewIDFromBytes(slice.Copy(blobovniczaID)), nil
 }


### PR DESCRIPTION
According to BoltDB documentation bucket `value is only valid for the
life of the transaction`.

Make `DB.IsSmall` copy value slice in order to prevent potential memory
corruptions (e.g. `runtime.stringtobyteslice` cast).

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* Closes #1007