### PR TITLE
Fix/Panic in container estimation announcement

### DIFF
--- a/pkg/services/container/announcement/load/route/deps.go
+++ b/pkg/services/container/announcement/load/route/deps.go
@@ -29,6 +29,10 @@ type Builder interface {
 	// Empty passed list means being at the starting point of the route.
 	//
 	// Must return empty list and no error if the endpoint of the route is reached.
+	// If there are more than one point to go and the last passed point is included
+	// in that list (means that point is the last point in one of the route groups),
+	// returned route must contain nil point that should be interpreted as signal to,
+	// among sending to other route points, save the announcement in that point.
 	NextStage(a container.UsedSpaceAnnouncement, passed []ServerInfo) ([]ServerInfo, error)
 }
 

--- a/pkg/services/container/announcement/load/route/util.go
+++ b/pkg/services/container/announcement/load/route/util.go
@@ -24,6 +24,15 @@ func CheckRoute(builder Builder, a container.UsedSpaceAnnouncement, route []Serv
 		found := false
 
 		for j := range servers {
+			if servers[j] == nil {
+				// nil route point means that
+				// (i-1)-th node in the route
+				// must, among other things,
+				// save the announcement to its
+				// local memory
+				continue
+			}
+
 			if bytes.Equal(servers[j].PublicKey(), route[i].PublicKey()) {
 				found = true
 				break


### PR DESCRIPTION
Closes #1016.

After https://github.com/nspcc-dev/neofs-node/pull/872 route building was changed: it now could have `nil` routes to signal that the node also has to save announcements to its local storage. But this change was not adopted in the code that checks passed route in other nodes: they tried to check public keys of such route points but must just ignore them.