### PR TITLE
Feat/Do not cut deploy args in `NNS`

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -99,9 +99,6 @@ func (c *initializeContext) deployNNS(method string) error {
 	}
 
 	params := getContractDeployParameters(cs.RawNEF, cs.RawManifest, nil)
-	if method == updateMethodName {
-		params = params[:len(params)-1] // update has only NEF and manifest args
-	}
 
 	signer := transaction.Signer{
 		Account: c.CommitteeAcc.Contract.ScriptHash(),


### PR DESCRIPTION
The updated version of the `NNS` contract now supports the third `data`
argument that may provide additional information.

Related to https://github.com/nspcc-dev/neofs-contract/issues/197