### PR TITLE
policer: Check context before job selection

### DIFF
--- a/pkg/services/policer/process.go
+++ b/pkg/services/policer/process.go
@@ -27,6 +27,12 @@ func (p *Policer) shardPolicyWorker(ctx context.Context) {
 	)
 
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		addrs, cursor, err = p.jobQueue.Select(cursor, p.batchSize)
 		if err != nil {
 			if errors.Is(err, engine.ErrEndOfListing) {


### PR DESCRIPTION
When application is being terminated, replicator routine might be on the object picking phase. Storage is terminated asynchronously, thus `Select()` may return corresponding error. If we don't process `context.Done()` in this case, then application freezes on shutdown.

Related to #1042