### PR TITLE
neofs-adm: update contracts in a single transaction

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -61,7 +61,7 @@ func initializeSideChainCmd(cmd *cobra.Command, args []string) error {
 
 	// 4. Deploy NeoFS contracts.
 	cmd.Println("Stage 4: deploy NeoFS contracts.")
-	if err := initCtx.deployContracts(deployMethodName); err != nil {
+	if err := initCtx.deployContracts(); err != nil {
 		return err
 	}
 

--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -104,6 +104,9 @@ func (c *initializeContext) deployNNS(method string) error {
 	}
 
 	params := getContractDeployParameters(cs.RawNEF, cs.RawManifest, nil)
+	if method == updateMethodName {
+		params = params[:len(params)-1] // update has only NEF and manifest args
+	}
 
 	signer := transaction.Signer{
 		Account: c.CommitteeAcc.Contract.ScriptHash(),

--- a/cmd/neofs-adm/internal/modules/morph/update.go
+++ b/cmd/neofs-adm/internal/modules/morph/update.go
@@ -17,5 +17,5 @@ func updateContracts(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return wCtx.deployContracts(updateMethodName)
+	return wCtx.updateContracts()
 }


### PR DESCRIPTION
Close #1035.

Same thing is desireable for deploy, but alphabet contracts have to be deployed from different senders to have different hash. Also contrary to `update` network starts to function only after all contracts were deployed, so there we won't end in an inconsistent state.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>