### PR TITLE
Feat/Add read-only shard mode

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -404,6 +404,7 @@ func initShardOptions(c *cfg) {
 		opts = append(opts, []shard.Option{
 			shard.WithLogger(c.log),
 			shard.WithRefillMetabase(sc.RefillMetabase()),
+			shard.WithMode(sc.Mode()),
 			shard.WithBlobStorOptions(
 				blobstor.WithRootPath(blobStorCfg.Path()),
 				blobstor.WithCompressObjects(blobStorCfg.Compress()),

--- a/cmd/neofs-node/config/engine/config_test.go
+++ b/cmd/neofs-node/config/engine/config_test.go
@@ -9,6 +9,7 @@ import (
 	engineconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine"
 	shardconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine/shard"
 	configtest "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/test"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +32,7 @@ func TestEngineSection(t *testing.T) {
 		require.False(t, handlerCalled)
 
 		require.EqualValues(t, engineconfig.ShardPoolSizeDefault, engineconfig.ShardPoolSize(empty))
+		require.EqualValues(t, shard.ModeReadWrite, shardconfig.From(empty).Mode())
 	})
 
 	const path = "../../../../config/example/node"
@@ -80,6 +82,7 @@ func TestEngineSection(t *testing.T) {
 				require.Equal(t, 2*time.Minute, gc.RemoverSleepInterval())
 
 				require.Equal(t, false, sc.RefillMetabase())
+				require.Equal(t, shard.ModeReadOnly, sc.Mode())
 			case 1:
 				require.Equal(t, true, sc.UseWriteCache())
 
@@ -108,6 +111,7 @@ func TestEngineSection(t *testing.T) {
 				require.Equal(t, 5*time.Minute, gc.RemoverSleepInterval())
 
 				require.Equal(t, true, sc.RefillMetabase())
+				require.Equal(t, shard.ModeReadWrite, sc.Mode())
 			}
 		})
 

--- a/cmd/neofs-node/config/engine/shard/config.go
+++ b/cmd/neofs-node/config/engine/shard/config.go
@@ -1,11 +1,14 @@
 package shardconfig
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/config"
 	blobstorconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine/shard/blobstor"
 	gcconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine/shard/gc"
 	metabaseconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine/shard/metabase"
 	writecacheconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine/shard/writecache"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 )
 
 // Config is a wrapper over the config section
@@ -67,4 +70,26 @@ func (x *Config) RefillMetabase() bool {
 		(*config.Config)(x),
 		"resync_metabase",
 	)
+}
+
+// Mode return value of "mode" config parameter.
+//
+// Panics if read value is not one of predefined
+// shard modes.
+func (x *Config) Mode() (m shard.Mode) {
+	s := config.StringSafe(
+		(*config.Config)(x),
+		"mode",
+	)
+
+	switch s {
+	case "read-write", "":
+		m = shard.ModeReadWrite
+	case "read-only":
+		m = shard.ModeReadOnly
+	default:
+		panic(fmt.Sprintf("unknown shard mode: %s", s))
+	}
+
+	return
 }

--- a/config/example/node.env
+++ b/config/example/node.env
@@ -73,6 +73,8 @@ NEOFS_STORAGE_SHARD_NUM=2
 ## 0 shard
 ### Flag to refill Metabase from BlobStor
 NEOFS_STORAGE_SHARD_0_RESYNC_METABASE=false
+### Flag to set shard mode
+NEOFS_STORAGE_SHARD_0_MODE=read-only
 ### Write cache config
 NEOFS_STORAGE_SHARD_0_USE_WRITE_CACHE=false
 NEOFS_STORAGE_SHARD_0_WRITECACHE_PATH=tmp/0/cache
@@ -104,6 +106,8 @@ NEOFS_STORAGE_SHARD_0_GC_REMOVER_SLEEP_INTERVAL=2m
 ## 1 shard
 ### Flag to refill Metabase from BlobStor
 NEOFS_STORAGE_SHARD_1_RESYNC_METABASE=true
+### Flag to set shard mode
+NEOFS_STORAGE_SHARD_1_MODE=read-write
 ### Write cache config
 NEOFS_STORAGE_SHARD_1_USE_WRITE_CACHE=true
 NEOFS_STORAGE_SHARD_1_WRITECACHE_PATH=tmp/1/cache

--- a/config/example/node.json
+++ b/config/example/node.json
@@ -117,6 +117,7 @@
     "shard_num": 2,
     "shard": {
       "0": {
+        "mode": "read-only",
         "resync_metabase": false,
         "use_write_cache": false,
         "writecache": {
@@ -150,6 +151,7 @@
         }
       },
       "1": {
+        "mode": "read-write",
         "resync_metabase": true,
         "use_write_cache": true,
         "writecache": {

--- a/config/example/node.yaml
+++ b/config/example/node.yaml
@@ -131,6 +131,7 @@ storage:
 
   shard:
     0:
+      mode: "read-only"  # mode of the shard, must be one of the: "read-write" (default), "read-only"
       resync_metabase: false  # sync metabase with blobstor on start, expensive, leave false until complete understanding
 
       use_write_cache: false  # use write-cache

--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -33,6 +33,10 @@ func (p *DeletePrm) WithAddresses(addr ...*objectSDK.Address) *DeletePrm {
 // Delete removes data from the shard's writeCache, metaBase and
 // blobStor.
 func (s *Shard) Delete(prm *DeletePrm) (*DeleteRes, error) {
+	if s.getMode() == ModeReadOnly {
+		return nil, ErrReadOnlyMode
+	}
+
 	ln := len(prm.addr)
 	delSmallPrm := new(blobstor.DeleteSmallPrm)
 	delBigPrm := new(blobstor.DeleteBigPrm)

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -171,7 +171,12 @@ func (gc *gc) stop() {
 
 // iterates over metabase graveyard and deletes objects
 // with GC-marked graves.
+// Does nothing if shard is in "read-only" mode.
 func (s *Shard) removeGarbage() {
+	if s.getMode() == ModeReadOnly {
+		return
+	}
+
 	buf := make([]*object.Address, 0, s.rmBatchSize)
 
 	// iterate over metabase graveyard and accumulate

--- a/pkg/local_object_storage/shard/inhume.go
+++ b/pkg/local_object_storage/shard/inhume.go
@@ -43,7 +43,13 @@ func (p *InhumePrm) MarkAsGarbage(addr ...*objectSDK.Address) *InhumePrm {
 
 // Inhume calls metabase. Inhume method to mark object as removed. It won't be
 // removed physically from blobStor and metabase until `Delete` operation.
+//
+// Returns ErrReadOnlyMode error if shard is in "read-only" mode.
 func (s *Shard) Inhume(prm *InhumePrm) (*InhumeRes, error) {
+	if s.getMode() == ModeReadOnly {
+		return nil, ErrReadOnlyMode
+	}
+
 	if s.hasWriteCache() {
 		for i := range prm.target {
 			_ = s.writeCache.Delete(prm.target[i])

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -1,50 +1,41 @@
 package shard
 
+import "errors"
+
 // Mode represents enumeration of Shard work modes.
 type Mode uint32
+
+// ErrReadOnlyMode is returned when it is impossible to apply operation
+// that changes shard's memory due to the "read-only" shard's mode.
+var ErrReadOnlyMode = errors.New("shard is in read-only mode")
 
 // TODO: more detailed description of shard modes.
 
 const (
-	_ Mode = iota
+	// ModeReadWrite is a Mode value for shard that is available
+	// for read and write operations. Default shard mode.
+	ModeReadWrite Mode = iota
 
-	// ModeActive is a Mode value for active shard.
-	ModeActive
-
-	// ModeInactive is a Mode value for inactive shard.
-	ModeInactive
-
-	// ModeReadOnly is a Mode value for read-only shard.
+	// ModeReadOnly is a Mode value for shard that does not
+	// accept write operation but is readable.
 	ModeReadOnly
-
-	// ModeFault is a Mode value for faulty shard.
-	ModeFault
-
-	// ModeEvacuate is a Mode value for evacuating shard.
-	ModeEvacuate
 )
 
 func (m Mode) String() string {
 	switch m {
 	default:
 		return "UNDEFINED"
-	case ModeActive:
-		return "ACTIVE"
-	case ModeInactive:
-		return "INACTIVE"
+	case ModeReadWrite:
+		return "READ_WRITE"
 	case ModeReadOnly:
 		return "READ_ONLY"
-	case ModeFault:
-		return "FAULT"
-	case ModeEvacuate:
-		return "EVACUATE"
 	}
 }
 
 // SetMode sets mode of the shard.
 //
 // Returns any error encountered that did not allow
-// to set shard mode.
+// setting shard mode.
 func (s *Shard) SetMode(m Mode) error {
 	s.mode.Store(uint32(m))
 

--- a/pkg/local_object_storage/shard/move.go
+++ b/pkg/local_object_storage/shard/move.go
@@ -27,6 +27,10 @@ func (p *ToMoveItPrm) WithAddress(addr *objectSDK.Address) *ToMoveItPrm {
 // ToMoveIt calls metabase.ToMoveIt method to mark object as relocatable to
 // another shard.
 func (s *Shard) ToMoveIt(prm *ToMoveItPrm) (*ToMoveItRes, error) {
+	if s.getMode() == ModeReadOnly {
+		return nil, ErrReadOnlyMode
+	}
+
 	err := meta.ToMoveIt(s.metaBase, prm.addr)
 	if err != nil {
 		s.log.Debug("could not mark object for shard relocation in metabase",

--- a/pkg/local_object_storage/shard/put.go
+++ b/pkg/local_object_storage/shard/put.go
@@ -30,7 +30,13 @@ func (p *PutPrm) WithObject(obj *object.Object) *PutPrm {
 //
 // Returns any error encountered that
 // did not allow to completely save the object.
+//
+// Returns ErrReadOnlyMode error if shard is in "read-only" mode.
 func (s *Shard) Put(prm *PutPrm) (*PutRes, error) {
+	if s.getMode() == ModeReadOnly {
+		return nil, ErrReadOnlyMode
+	}
+
 	putPrm := new(blobstor.PutPrm) // form Put parameters
 	putPrm.SetObject(prm.obj)
 


### PR DESCRIPTION
Related to #1044. Deleted unused shard modes and suggest adding them when needed. Do not know if shard should be able to tick its `GC` (and remove objects) and accept `Inhume()` calls when it's in `read-only` mode or not.