### PR TITLE
service/object: Don't override status of payload overtake

### DIFF
--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -160,10 +160,7 @@ func (exec *execCtx) overtakePayloadInReverse(prev *objectSDK.ID) bool {
 
 	exec.overtakePayloadDirectly(chain, rngs, false)
 
-	exec.status = statusOK
-	exec.err = nil
-
-	return true
+	return exec.status == statusOK
 }
 
 func (exec *execCtx) buildChainInReverse(prev *objectSDK.ID) ([]*objectSDK.ID, []*objectSDK.Range, bool) {


### PR DESCRIPTION
Closes #1077 

Reverse payload overtake triggers direct payload overtake that sets status and error. We should not override that.