### PR TITLE
Upd/Update `neofs-sdk-go`

### DIFF
--- a/cmd/neofs-cli/internal/client/client.go
+++ b/cmd/neofs-cli/internal/client/client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nspcc-dev/neofs-sdk-go/accounting"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
-	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
@@ -39,10 +38,6 @@ func BalanceOf(prm BalanceOfPrm) (res BalanceOfRes, err error) {
 	res.cliRes, err = prm.cli.GetBalance(context.Background(), prm.ownerID,
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -70,10 +65,6 @@ func ListContainers(prm ListContainersPrm) (res ListContainersRes, err error) {
 	res.cliRes, err = prm.cli.ListContainers(context.Background(), prm.ownerID,
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -114,10 +105,6 @@ func PutContainer(prm PutContainerPrm) (res PutContainerRes, err error) {
 		client.WithKey(prm.privKey),
 		client.WithSession(prm.sessionToken),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -145,10 +132,6 @@ func GetContainer(prm GetContainerPrm) (res GetContainerRes, err error) {
 	res.cliRes, err = prm.cli.GetContainer(context.Background(), prm.cnrID,
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -172,16 +155,10 @@ type DeleteContainerRes struct{}
 //
 // Returns any error prevented the operation from completing correctly in error return.
 func DeleteContainer(prm DeleteContainerPrm) (res DeleteContainerRes, err error) {
-	var cliRes *client.ContainerDeleteRes
-
-	cliRes, err = prm.cli.DeleteContainer(context.Background(), prm.cnrID,
+	_, err = prm.cli.DeleteContainer(context.Background(), prm.cnrID,
 		client.WithKey(prm.privKey),
 		client.WithSession(prm.sessionToken),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(cliRes.Status())
-	}
 
 	return
 }
@@ -209,10 +186,6 @@ func EACL(prm EACLPrm) (res EACLRes, err error) {
 	res.cliRes, err = prm.cli.EACL(context.Background(), prm.cnrID,
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -242,16 +215,10 @@ type SetEACLRes struct{}
 //
 // Returns any error prevented the operation from completing correctly in error return.
 func SetEACL(prm SetEACLPrm) (res SetEACLRes, err error) {
-	var cliRes *client.SetEACLRes
-
-	cliRes, err = prm.cli.SetEACL(context.Background(), prm.eaclTable,
+	_, err = prm.cli.SetEACL(context.Background(), prm.eaclTable,
 		client.WithKey(prm.privKey),
 		client.WithSession(prm.sessionToken),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(cliRes.Status())
-	}
 
 	return
 }
@@ -278,10 +245,6 @@ func NetworkInfo(prm NetworkInfoPrm) (res NetworkInfoRes, err error) {
 	res.cliRes, err = prm.cli.NetworkInfo(context.Background(),
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -313,10 +276,6 @@ func NodeInfo(prm NodeInfoPrm) (res NodeInfoRes, err error) {
 	res.cliRes, err = prm.cli.EndpointInfo(context.Background(),
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -348,10 +307,6 @@ func CreateSession(prm CreateSessionPrm) (res CreateSessionRes, err error) {
 	res.cliRes, err = prm.cli.CreateSession(context.Background(), math.MaxUint64,
 		client.WithKey(prm.privKey),
 	)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -399,10 +354,6 @@ func PutObject(prm PutObjectPrm) (res PutObjectRes, err error) {
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -436,10 +387,6 @@ func DeleteObject(prm DeleteObjectPrm) (res DeleteObjectRes, err error) {
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -457,7 +404,7 @@ type GetObjectRes struct {
 	cliRes *client.ObjectGetRes
 }
 
-// Object returns header of the request object.
+// Header returns header of the request object.
 func (x GetObjectRes) Header() *object.Object {
 	return x.cliRes.Object()
 }
@@ -480,10 +427,6 @@ func GetObject(prm GetObjectPrm) (res GetObjectRes, err error) {
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -533,10 +476,6 @@ func HeadObject(prm HeadObjectPrm) (res HeadObjectRes, err error) {
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -578,10 +517,6 @@ func SearchObjects(prm SearchObjectsPrm) (res SearchObjectsRes, err error) {
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -643,10 +578,6 @@ func HashPayloadRanges(prm HashPayloadRangesPrm) (res HashPayloadRangesRes, err 
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(res.cliRes.Status())
-	}
 
 	return
 }
@@ -683,17 +614,11 @@ func PayloadRange(prm PayloadRangePrm) (res PayloadRangeRes, err error) {
 	cliPrm.WithDataWriter(prm.wrt)
 	cliPrm.WithRange(prm.rng)
 
-	var cliRes *client.ObjectRangeRes
-
-	cliRes, err = prm.cli.ObjectPayloadRangeData(context.Background(), &cliPrm, append(prm.opts,
+	_, err = prm.cli.ObjectPayloadRangeData(context.Background(), &cliPrm, append(prm.opts,
 		client.WithKey(prm.privKey),
 		client.WithSession(prm.sessionToken),
 		client.WithBearer(prm.bearerToken),
 	)...)
-	if err == nil {
-		// pull out an error from status
-		err = apistatus.ErrFromStatus(cliRes.Status())
-	}
 
 	return
 }

--- a/cmd/neofs-cli/internal/client/prm.go
+++ b/cmd/neofs-cli/internal/client/prm.go
@@ -15,13 +15,13 @@ import (
 // here are small structures with public setters to share between parameter structures
 
 type commonPrm struct {
-	cli client.Client
+	cli *client.Client
 
 	privKey *ecdsa.PrivateKey
 }
 
 // SetClient sets base client for NeoFS API communication.
-func (x *commonPrm) SetClient(cli client.Client) {
+func (x *commonPrm) SetClient(cli *client.Client) {
 	x.cli = cli
 }
 

--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -46,7 +46,7 @@ const (
 	basicACLNoFinalAppend   = "eacl-public-append"
 )
 
-var wellKnownBasicACL = map[string]uint32{
+var wellKnownBasicACL = map[string]acl.BasicACL{
 	basicACLPublic:   acl.PublicBasicRule,
 	basicACLPrivate:  acl.PrivateBasicRule,
 	basicACLReadOnly: acl.ReadOnlyBasicRule,
@@ -668,7 +668,7 @@ func parseAttributes(attributes []string) ([]*container.Attribute, error) {
 	return result, nil
 }
 
-func parseBasicACL(basicACL string) (uint32, error) {
+func parseBasicACL(basicACL string) (acl.BasicACL, error) {
 	if value, ok := wellKnownBasicACL[basicACL]; ok {
 		return value, nil
 	}
@@ -680,7 +680,7 @@ func parseBasicACL(basicACL string) (uint32, error) {
 		return 0, fmt.Errorf("can't parse basic ACL: %s", basicACL)
 	}
 
-	return uint32(value), nil
+	return acl.BasicACL(value), nil
 }
 
 func parseNonce(nonce string) (uuid.UUID, error) {
@@ -744,7 +744,7 @@ func prettyPrintContainer(cmd *cobra.Command, cnr *container.Container, jsonEnco
 	cmd.Println("owner ID:", cnr.OwnerID())
 
 	basicACL := cnr.BasicACL()
-	prettyPrintBasicACL(cmd, basicACL)
+	prettyPrintBasicACL(cmd, acl.BasicACL(basicACL))
 
 	for _, attribute := range cnr.Attributes() {
 		if attribute.Key() == container.AttributeTimestamp {
@@ -825,7 +825,7 @@ func printJSONMarshaler(cmd *cobra.Command, j json.Marshaler, entity string) {
 	cmd.Println(buf)
 }
 
-func prettyPrintBasicACL(cmd *cobra.Command, basicACL uint32) {
+func prettyPrintBasicACL(cmd *cobra.Command, basicACL acl.BasicACL) {
 	cmd.Printf("basic ACL: %.8x", basicACL)
 	for k, v := range wellKnownBasicACL {
 		if v == basicACL {

--- a/cmd/neofs-cli/modules/control.go
+++ b/cmd/neofs-cli/modules/control.go
@@ -238,7 +238,7 @@ func healthCheck(cmd *cobra.Command, _ []string) {
 	cmd.Printf("Health status: %s\n", resp.GetBody().GetHealthStatus())
 }
 
-func healthCheckIR(cmd *cobra.Command, key *ecdsa.PrivateKey, c client.Client) {
+func healthCheckIR(cmd *cobra.Command, key *ecdsa.PrivateKey, c *client.Client) {
 	req := new(ircontrol.HealthCheckRequest)
 
 	req.SetBody(new(ircontrol.HealthCheckRequest_Body))
@@ -430,7 +430,7 @@ func listShards(cmd *cobra.Command, _ []string) {
 
 // getControlSDKClient is the same getSDKClient but with
 // another RPC endpoint flag.
-func getControlSDKClient(key *ecdsa.PrivateKey) (client.Client, error) {
+func getControlSDKClient(key *ecdsa.PrivateKey) (*client.Client, error) {
 	netAddr, err := getEndpointAddress(controlRPC)
 	if err != nil {
 		return nil, err

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -289,7 +289,7 @@ func getEndpointAddress(endpointFlag string) (addr network.Address, err error) {
 }
 
 type clientWithKey interface {
-	SetClient(client.Client)
+	SetClient(*client.Client)
 	SetKey(*ecdsa.PrivateKey)
 }
 
@@ -325,7 +325,7 @@ func prepareBearerPrm(cmd *cobra.Command, prm bearerPrm) {
 
 // getSDKClient returns default neofs-api-go sdk client. Consider using
 // opts... to provide TTL or other global configuration flags.
-func getSDKClient(key *ecdsa.PrivateKey) (client.Client, error) {
+func getSDKClient(key *ecdsa.PrivateKey) (*client.Client, error) {
 	netAddr, err := getEndpointAddress(rpc)
 	if err != nil {
 		return nil, err
@@ -334,6 +334,7 @@ func getSDKClient(key *ecdsa.PrivateKey) (client.Client, error) {
 	options := []client.Option{
 		client.WithAddress(netAddr.HostAddr()),
 		client.WithDefaultPrivateKey(key),
+		client.WithNeoFSErrorParsing(),
 	}
 
 	if netAddr.TLSEnabled() {

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -249,7 +249,7 @@ type remoteLoadAnnounceProvider struct {
 	netmapKeys netmapCore.AnnouncedKeys
 
 	clientCache interface {
-		Get(client.NodeInfo) (apiClient.Client, error)
+		Get(client.NodeInfo) (client.Client, error)
 	}
 
 	deadEndProvider loadcontroller.WriterProvider
@@ -284,7 +284,7 @@ func (r *remoteLoadAnnounceProvider) InitRemote(srv loadroute.ServerInfo) (loadc
 }
 
 type remoteLoadAnnounceWriterProvider struct {
-	client apiClient.Client
+	client client.Client
 	key    *ecdsa.PrivateKey
 }
 
@@ -299,7 +299,7 @@ func (p *remoteLoadAnnounceWriterProvider) InitWriter(ctx context.Context) (load
 type remoteLoadAnnounceWriter struct {
 	ctx context.Context
 
-	client apiClient.Client
+	client client.Client
 	key    *ecdsa.PrivateKey
 
 	buf []containerSDK.UsedSpaceAnnouncement

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -172,13 +172,13 @@ func (f *innerRingFetcherWithoutNotary) InnerRingKeys() ([][]byte, error) {
 
 type coreClientConstructor reputationClientConstructor
 
-func (x *coreClientConstructor) Get(info coreclient.NodeInfo) (coreclient.Client, error) {
+func (x *coreClientConstructor) Get(info coreclient.NodeInfo) (coreclient.MultiAddressClient, error) {
 	c, err := (*reputationClientConstructor)(x).Get(info)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.(coreclient.Client), nil
+	return c.(coreclient.MultiAddressClient), nil
 }
 
 func initObjectService(c *cfg) {
@@ -440,12 +440,12 @@ type reputationClientConstructor struct {
 	trustStorage *truststorage.Storage
 
 	basicConstructor interface {
-		Get(coreclient.NodeInfo) (client.Client, error)
+		Get(coreclient.NodeInfo) (coreclient.Client, error)
 	}
 }
 
 type reputationClient struct {
-	coreclient.Client
+	coreclient.MultiAddressClient
 
 	prm truststorage.UpdatePrm
 
@@ -461,7 +461,7 @@ func (c *reputationClient) submitResult(err error) {
 }
 
 func (c *reputationClient) PutObject(ctx context.Context, prm *client.PutObjectParams, opts ...client.CallOption) (*client.ObjectPutRes, error) {
-	res, err := c.Client.PutObject(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.PutObject(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -469,7 +469,7 @@ func (c *reputationClient) PutObject(ctx context.Context, prm *client.PutObjectP
 }
 
 func (c *reputationClient) DeleteObject(ctx context.Context, prm *client.DeleteObjectParams, opts ...client.CallOption) (*client.ObjectDeleteRes, error) {
-	res, err := c.Client.DeleteObject(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.DeleteObject(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -477,7 +477,7 @@ func (c *reputationClient) DeleteObject(ctx context.Context, prm *client.DeleteO
 }
 
 func (c *reputationClient) GetObject(ctx context.Context, prm *client.GetObjectParams, opts ...client.CallOption) (*client.ObjectGetRes, error) {
-	res, err := c.Client.GetObject(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.GetObject(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -485,7 +485,7 @@ func (c *reputationClient) GetObject(ctx context.Context, prm *client.GetObjectP
 }
 
 func (c *reputationClient) HeadObject(ctx context.Context, prm *client.ObjectHeaderParams, opts ...client.CallOption) (*client.ObjectHeadRes, error) {
-	res, err := c.Client.HeadObject(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.HeadObject(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -493,7 +493,7 @@ func (c *reputationClient) HeadObject(ctx context.Context, prm *client.ObjectHea
 }
 
 func (c *reputationClient) ObjectPayloadRangeData(ctx context.Context, prm *client.RangeDataParams, opts ...client.CallOption) (*client.ObjectRangeRes, error) {
-	res, err := c.Client.ObjectPayloadRangeData(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.ObjectPayloadRangeData(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -501,7 +501,7 @@ func (c *reputationClient) ObjectPayloadRangeData(ctx context.Context, prm *clie
 }
 
 func (c *reputationClient) HashObjectPayloadRanges(ctx context.Context, prm *client.RangeChecksumParams, opts ...client.CallOption) (*client.ObjectRangeHashRes, error) {
-	res, err := c.Client.HashObjectPayloadRanges(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.HashObjectPayloadRanges(ctx, prm, opts...)
 
 	c.submitResult(err)
 
@@ -509,14 +509,14 @@ func (c *reputationClient) HashObjectPayloadRanges(ctx context.Context, prm *cli
 }
 
 func (c *reputationClient) SearchObjects(ctx context.Context, prm *client.SearchObjectParams, opts ...client.CallOption) (*client.ObjectSearchRes, error) {
-	res, err := c.Client.SearchObjects(ctx, prm, opts...)
+	res, err := c.MultiAddressClient.SearchObjects(ctx, prm, opts...)
 
 	c.submitResult(err)
 
 	return res, err
 }
 
-func (c *reputationClientConstructor) Get(info coreclient.NodeInfo) (client.Client, error) {
+func (c *reputationClientConstructor) Get(info coreclient.NodeInfo) (coreclient.Client, error) {
 	cl, err := c.basicConstructor.Get(info)
 	if err != nil {
 		return nil, err
@@ -532,9 +532,9 @@ func (c *reputationClientConstructor) Get(info coreclient.NodeInfo) (client.Clie
 				prm.SetPeer(reputation.PeerIDFromBytes(nm.Nodes[i].PublicKey()))
 
 				return &reputationClient{
-					Client: cl.(coreclient.Client),
-					prm:    prm,
-					cons:   c,
+					MultiAddressClient: cl.(coreclient.MultiAddressClient),
+					prm:                prm,
+					cons:               c,
 				}, nil
 			}
 		}

--- a/cmd/neofs-node/reputation/common/remote.go
+++ b/cmd/neofs-node/reputation/common/remote.go
@@ -8,18 +8,17 @@ import (
 	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
 	reputationrouter "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common/router"
 	trustcontroller "github.com/nspcc-dev/neofs-node/pkg/services/reputation/local/controller"
-	apiClient "github.com/nspcc-dev/neofs-sdk-go/client"
 )
 
 type clientCache interface {
-	Get(client.NodeInfo) (apiClient.Client, error)
+	Get(client.NodeInfo) (client.Client, error)
 }
 
 // clientKeyRemoteProvider must provide remote writer and take into account
 // that requests must be sent via passed api client and must be signed with
 // passed private key.
 type clientKeyRemoteProvider interface {
-	WithClient(apiClient.Client) reputationcommon.WriterProvider
+	WithClient(client.Client) reputationcommon.WriterProvider
 }
 
 // remoteTrustProvider is implementation of reputation RemoteWriterProvider interface.

--- a/cmd/neofs-node/reputation/intermediate/remote.go
+++ b/cmd/neofs-node/reputation/intermediate/remote.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/reputation/common"
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-node/reputation/internal/client"
+	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
 	eigentrustcalc "github.com/nspcc-dev/neofs-node/pkg/services/reputation/eigentrust/calculator"
-	apiClient "github.com/nspcc-dev/neofs-sdk-go/client"
 	reputationapi "github.com/nspcc-dev/neofs-sdk-go/reputation"
 )
 
@@ -43,7 +43,7 @@ type RemoteProvider struct {
 	key *ecdsa.PrivateKey
 }
 
-func (rp RemoteProvider) WithClient(c apiClient.Client) reputationcommon.WriterProvider {
+func (rp RemoteProvider) WithClient(c coreclient.Client) reputationcommon.WriterProvider {
 	return &TrustWriterProvider{
 		client: c,
 		key:    rp.key,
@@ -51,7 +51,7 @@ func (rp RemoteProvider) WithClient(c apiClient.Client) reputationcommon.WriterP
 }
 
 type TrustWriterProvider struct {
-	client apiClient.Client
+	client coreclient.Client
 	key    *ecdsa.PrivateKey
 }
 
@@ -71,7 +71,7 @@ func (twp *TrustWriterProvider) InitWriter(ctx reputationcommon.Context) (reputa
 
 type RemoteTrustWriter struct {
 	eiCtx  eigentrustcalc.Context
-	client apiClient.Client
+	client coreclient.Client
 	key    *ecdsa.PrivateKey
 }
 

--- a/cmd/neofs-node/reputation/internal/client/client.go
+++ b/cmd/neofs-node/reputation/internal/client/client.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"crypto/ecdsa"
 
+	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/reputation"
 )
 
 type commonPrm struct {
-	cli client.Client
+	cli coreclient.Client
 
 	ctx context.Context
 
@@ -22,7 +23,7 @@ type commonPrm struct {
 // SetClient sets base client for NeoFS API communication.
 //
 // Required parameter.
-func (x *commonPrm) SetClient(cli client.Client) {
+func (x *commonPrm) SetClient(cli coreclient.Client) {
 	x.cli = cli
 }
 

--- a/cmd/neofs-node/reputation/local/remote.go
+++ b/cmd/neofs-node/reputation/local/remote.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/reputation/common"
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-node/reputation/internal/client"
+	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/reputation"
 	reputationcommon "github.com/nspcc-dev/neofs-node/pkg/services/reputation/common"
-	apiClient "github.com/nspcc-dev/neofs-sdk-go/client"
 	reputationapi "github.com/nspcc-dev/neofs-sdk-go/reputation"
 )
 
@@ -42,7 +42,7 @@ type RemoteProvider struct {
 	key *ecdsa.PrivateKey
 }
 
-func (rp RemoteProvider) WithClient(c apiClient.Client) reputationcommon.WriterProvider {
+func (rp RemoteProvider) WithClient(c coreclient.Client) reputationcommon.WriterProvider {
 	return &TrustWriterProvider{
 		client: c,
 		key:    rp.key,
@@ -50,7 +50,7 @@ func (rp RemoteProvider) WithClient(c apiClient.Client) reputationcommon.WriterP
 }
 
 type TrustWriterProvider struct {
-	client apiClient.Client
+	client coreclient.Client
 	key    *ecdsa.PrivateKey
 }
 
@@ -64,7 +64,7 @@ func (twp *TrustWriterProvider) InitWriter(ctx reputationcommon.Context) (reputa
 
 type RemoteTrustWriter struct {
 	ctx    reputationcommon.Context
-	client apiClient.Client
+	client coreclient.Client
 	key    *ecdsa.PrivateKey
 
 	buf []*reputationapi.Trust

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.98.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.11.1
-	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211230072947-1fe37df88f80
+	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659
 	github.com/nspcc-dev/tzhash v1.4.0
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BE
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
-github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211230072947-1fe37df88f80 h1:qM011x26c1Q74peWNpXHuE0IqbEwDF0ksqAwbh9xZn8=
-github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211230072947-1fe37df88f80/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
+github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659 h1:rpMCoRa7expLc9gMiOP724gz6YSykZzmMALR/CmiwnU=
+github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/core/client/client.go
+++ b/pkg/core/client/client.go
@@ -1,15 +1,58 @@
 package client
 
 import (
+	"context"
+	"io"
+
 	rawclient "github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
+	"github.com/nspcc-dev/neofs-sdk-go/container"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	"github.com/nspcc-dev/neofs-sdk-go/eacl"
+	"github.com/nspcc-dev/neofs-sdk-go/owner"
 )
 
 // Client is an interface of NeoFS storage
 // node's client.
 type Client interface {
-	client.Client
+	GetBalance(context.Context, *owner.ID, ...client.CallOption) (*client.BalanceOfRes, error)
+
+	PutContainer(context.Context, *container.Container, ...client.CallOption) (*client.ContainerPutRes, error)
+	GetContainer(context.Context, *cid.ID, ...client.CallOption) (*client.ContainerGetRes, error)
+	ListContainers(context.Context, *owner.ID, ...client.CallOption) (*client.ContainerListRes, error)
+	DeleteContainer(context.Context, *cid.ID, ...client.CallOption) (*client.ContainerDeleteRes, error)
+
+	EACL(context.Context, *cid.ID, ...client.CallOption) (*client.EACLRes, error)
+	SetEACL(context.Context, *eacl.Table, ...client.CallOption) (*client.SetEACLRes, error)
+
+	AnnounceContainerUsedSpace(context.Context, []container.UsedSpaceAnnouncement, ...client.CallOption) (*client.AnnounceSpaceRes, error)
+
+	EndpointInfo(context.Context, ...client.CallOption) (*client.EndpointInfoRes, error)
+	NetworkInfo(context.Context, ...client.CallOption) (*client.NetworkInfoRes, error)
+
+	PutObject(context.Context, *client.PutObjectParams, ...client.CallOption) (*client.ObjectPutRes, error)
+	DeleteObject(context.Context, *client.DeleteObjectParams, ...client.CallOption) (*client.ObjectDeleteRes, error)
+	GetObject(context.Context, *client.GetObjectParams, ...client.CallOption) (*client.ObjectGetRes, error)
+	HeadObject(context.Context, *client.ObjectHeaderParams, ...client.CallOption) (*client.ObjectHeadRes, error)
+	SearchObjects(context.Context, *client.SearchObjectParams, ...client.CallOption) (*client.ObjectSearchRes, error)
+	ObjectPayloadRangeData(context.Context, *client.RangeDataParams, ...client.CallOption) (*client.ObjectRangeRes, error)
+	HashObjectPayloadRanges(context.Context, *client.RangeChecksumParams, ...client.CallOption) (*client.ObjectRangeHashRes, error)
+
+	AnnounceLocalTrust(context.Context, client.AnnounceLocalTrustPrm, ...client.CallOption) (*client.AnnounceLocalTrustRes, error)
+	AnnounceIntermediateTrust(context.Context, client.AnnounceIntermediateTrustPrm, ...client.CallOption) (*client.AnnounceIntermediateTrustRes, error)
+
+	CreateSession(context.Context, uint64, ...client.CallOption) (*client.CreateSessionRes, error)
+
+	Raw() *rawclient.Client
+
+	Conn() io.Closer
+}
+
+// MultiAddressClient is an interface of the
+// Client that supports multihost work.
+type MultiAddressClient interface {
+	Client
 
 	// RawForAddress must return rawclient.Client
 	// for the passed network.Address.

--- a/pkg/innerring/internal/client/client.go
+++ b/pkg/innerring/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
+	clientcore "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/storagegroup"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
@@ -16,11 +17,11 @@ import (
 type Client struct {
 	key *ecdsa.PrivateKey
 
-	c client.Client
+	c clientcore.Client
 }
 
 // WrapBasicClient wraps client.Client instance to use it for NeoFS API RPC.
-func (x *Client) WrapBasicClient(c client.Client) {
+func (x *Client) WrapBasicClient(c clientcore.Client) {
 	x.c = c
 }
 

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -24,7 +24,7 @@ type (
 	ClientCache struct {
 		log   *zap.Logger
 		cache interface {
-			Get(clientcore.NodeInfo) (client.Client, error)
+			Get(clientcore.NodeInfo) (clientcore.Client, error)
 			CloseAll()
 		}
 		key *ecdsa.PrivateKey
@@ -51,7 +51,7 @@ func newClientCache(p *clientCacheParams) *ClientCache {
 	}
 }
 
-func (c *ClientCache) Get(info clientcore.NodeInfo) (client.Client, error) {
+func (c *ClientCache) Get(info clientcore.NodeInfo) (clientcore.Client, error) {
 	// Because cache is used by `ClientCache` exclusively,
 	// client will always have valid key.
 	return c.cache.Get(info)

--- a/pkg/network/cache/client.go
+++ b/pkg/network/cache/client.go
@@ -14,7 +14,7 @@ type (
 	// already created clients.
 	ClientCache struct {
 		mu      *sync.RWMutex
-		clients map[string]client.Client
+		clients map[string]clientcore.Client
 		opts    []client.Option
 	}
 )
@@ -24,13 +24,13 @@ type (
 func NewSDKClientCache(opts ...client.Option) *ClientCache {
 	return &ClientCache{
 		mu:      new(sync.RWMutex),
-		clients: make(map[string]client.Client),
+		clients: make(map[string]clientcore.Client),
 		opts:    opts,
 	}
 }
 
 // Get function returns existing client or creates a new one.
-func (c *ClientCache) Get(info clientcore.NodeInfo) (client.Client, error) {
+func (c *ClientCache) Get(info clientcore.NodeInfo) (clientcore.Client, error) {
 	netAddr := info.AddressGroup()
 
 	// multiaddr is used as a key in client cache since

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -32,7 +32,7 @@ type RangeHashPrm struct {
 	salt []byte
 }
 
-type RequestForwarder func(coreclient.NodeInfo, coreclient.Client) (*objectSDK.Object, error)
+type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) (*objectSDK.Object, error)
 
 // HeadPrm groups parameters of Head service call.
 type HeadPrm struct {

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -99,7 +99,7 @@ func WithLocalStorageEngine(e *engine.StorageEngine) Option {
 }
 
 type ClientConstructor interface {
-	Get(client.NodeInfo) (client.Client, error)
+	Get(client.NodeInfo) (client.MultiAddressClient, error)
 }
 
 // WithClientConstructor returns option to set constructor of remote node clients.

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -23,7 +23,7 @@ type clientCacheWrapper struct {
 }
 
 type clientWrapper struct {
-	client coreclient.Client
+	client coreclient.MultiAddressClient
 }
 
 type storageEngineWrapper struct {

--- a/pkg/services/object/get/v2/util.go
+++ b/pkg/services/object/get/v2/util.go
@@ -48,7 +48,7 @@ func (s *Service) toPrm(req *objectV2.GetRequest, stream objectSvc.GetObjectStre
 	if !commonPrm.LocalOnly() {
 		var onceResign sync.Once
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.Client, pubkey []byte) (*objectSDK.Object, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) (*objectSDK.Object, error) {
 			var err error
 
 			key, err := s.keyStorage.GetKey(nil)
@@ -178,7 +178,7 @@ func (s *Service) toRangePrm(req *objectV2.GetRangeRequest, stream objectSvc.Get
 			return nil, err
 		}
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.Client, pubkey []byte) (*objectSDK.Object, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) (*objectSDK.Object, error) {
 			var err error
 
 			// once compose and resign forwarding request
@@ -333,7 +333,7 @@ func (s *Service) toHeadPrm(ctx context.Context, req *objectV2.HeadRequest, resp
 	if !commonPrm.LocalOnly() {
 		var onceResign sync.Once
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.Client, pubkey []byte) (*objectSDK.Object, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) (*objectSDK.Object, error) {
 			var err error
 
 			key, err := s.keyStorage.GetKey(nil)
@@ -511,8 +511,8 @@ func toShortObjectHeader(hdr *object.Object) objectV2.GetHeaderPart {
 	return sh
 }
 
-func groupAddressRequestForwarder(f func(network.Address, client.Client, []byte) (*objectSDK.Object, error)) getsvc.RequestForwarder {
-	return func(info client.NodeInfo, c client.Client) (*objectSDK.Object, error) {
+func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) (*objectSDK.Object, error)) getsvc.RequestForwarder {
+	return func(info client.NodeInfo, c client.MultiAddressClient) (*objectSDK.Object, error) {
 		var (
 			firstErr error
 			res      *objectSDK.Object

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -9,13 +9,12 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	internalclient "github.com/nspcc-dev/neofs-node/pkg/services/object/internal/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
-	"github.com/nspcc-dev/neofs-sdk-go/client"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 )
 
 type ClientConstructor interface {
-	Get(clientcore.NodeInfo) (client.Client, error)
+	Get(clientcore.NodeInfo) (clientcore.Client, error)
 }
 
 // RemoteHeader represents utility for getting

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	session2 "github.com/nspcc-dev/neofs-api-go/v2/session"
+	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -15,7 +16,7 @@ import (
 )
 
 type commonPrm struct {
-	cli client.Client
+	cli coreclient.Client
 
 	ctx context.Context
 
@@ -25,7 +26,7 @@ type commonPrm struct {
 // SetClient sets base client for NeoFS API communication.
 //
 // Required parameter.
-func (x *commonPrm) SetClient(cli client.Client) {
+func (x *commonPrm) SetClient(cli coreclient.Client) {
 	x.cli = cli
 }
 

--- a/pkg/services/object/put/prm.go
+++ b/pkg/services/object/put/prm.go
@@ -14,7 +14,7 @@ type PutInitPrm struct {
 
 	traverseOpts []placement.Option
 
-	relay func(client.NodeInfo, client.Client) error
+	relay func(client.NodeInfo, client.MultiAddressClient) error
 }
 
 type PutChunkPrm struct {
@@ -45,7 +45,7 @@ func (p *PutInitPrm) WithObject(v *object.RawObject) *PutInitPrm {
 	return p
 }
 
-func (p *PutInitPrm) WithRelay(f func(client.NodeInfo, client.Client) error) *PutInitPrm {
+func (p *PutInitPrm) WithRelay(f func(client.NodeInfo, client.MultiAddressClient) error) *PutInitPrm {
 	if p != nil {
 		p.relay = f
 	}

--- a/pkg/services/object/put/service.go
+++ b/pkg/services/object/put/service.go
@@ -29,7 +29,7 @@ type Service struct {
 type Option func(*cfg)
 
 type ClientConstructor interface {
-	Get(client.NodeInfo) (client.Client, error)
+	Get(client.NodeInfo) (client.MultiAddressClient, error)
 }
 
 type cfg struct {

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -19,7 +19,7 @@ type Streamer struct {
 
 	target transformer.ObjectTarget
 
-	relay func(client.NodeInfo, client.Client) error
+	relay func(client.NodeInfo, client.MultiAddressClient) error
 
 	maxPayloadSz uint64 // network config
 }

--- a/pkg/services/object/put/v2/streamer.go
+++ b/pkg/services/object/put/v2/streamer.go
@@ -127,7 +127,7 @@ func (s *streamer) CloseAndRecv() (*object.PutResponse, error) {
 	return fromPutResponse(resp), nil
 }
 
-func (s *streamer) relayRequest(info client.NodeInfo, c client.Client) error {
+func (s *streamer) relayRequest(info client.NodeInfo, c client.MultiAddressClient) error {
 	// open stream
 	resp := new(object.PutResponse)
 

--- a/pkg/services/object/search/prm.go
+++ b/pkg/services/object/search/prm.go
@@ -28,7 +28,7 @@ type IDListWriter interface {
 
 // RequestForwarder is a callback for forwarding of the
 // original Search requests.
-type RequestForwarder func(coreclient.NodeInfo, coreclient.Client) ([]*objectSDK.ID, error)
+type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) ([]*objectSDK.ID, error)
 
 // SetCommonParameters sets common parameters of the operation.
 func (p *Prm) SetCommonParameters(common *util.CommonPrm) {

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -29,7 +29,7 @@ type searchClient interface {
 }
 
 type ClientConstructor interface {
-	Get(client.NodeInfo) (client.Client, error)
+	Get(client.NodeInfo) (client.MultiAddressClient, error)
 }
 
 type cfg struct {

--- a/pkg/services/object/search/util.go
+++ b/pkg/services/object/search/util.go
@@ -26,7 +26,7 @@ type clientConstructorWrapper struct {
 }
 
 type clientWrapper struct {
-	client client.Client
+	client client.MultiAddressClient
 }
 
 type storageEngineWrapper engine.StorageEngine

--- a/pkg/services/object/search/v2/util.go
+++ b/pkg/services/object/search/v2/util.go
@@ -44,7 +44,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 			return nil, err
 		}
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.Client, pubkey []byte) ([]*objectSDK.ID, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) ([]*objectSDK.ID, error) {
 			var err error
 
 			// once compose and resign forwarding request
@@ -114,8 +114,8 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 	return p, nil
 }
 
-func groupAddressRequestForwarder(f func(network.Address, client.Client, []byte) ([]*objectSDK.ID, error)) searchsvc.RequestForwarder {
-	return func(info client.NodeInfo, c client.Client) ([]*objectSDK.ID, error) {
+func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) ([]*objectSDK.ID, error)) searchsvc.RequestForwarder {
+	return func(info client.NodeInfo, c client.MultiAddressClient) ([]*objectSDK.ID, error) {
 		var (
 			firstErr error
 			res      []*objectSDK.ID


### PR DESCRIPTION
Update includes:
1. New simple client mode that parses erroneous status codes as error and
returns them from the calls of the client methods. (for `cli` only).
2. Client is struct now, not an interface. This leads to the new interfaces inside `pkg/client` package.