### PR TITLE
Allow to dump data from shard

### DIFF
--- a/pkg/local_object_storage/blobovnicza/iterate.go
+++ b/pkg/local_object_storage/blobovnicza/iterate.go
@@ -84,6 +84,8 @@ type IteratePrm struct {
 	withoutData bool
 
 	handler IterationHandler
+
+	ignoreErrors bool
 }
 
 // DecodeAddresses sets flag to unmarshal object addresses.
@@ -99,6 +101,11 @@ func (x *IteratePrm) WithoutData() {
 // SetHandler sets handler to be called iteratively.
 func (x *IteratePrm) SetHandler(h IterationHandler) {
 	x.handler = h
+}
+
+// IgnoreErrors makes all errors to be ignored.
+func (x *IteratePrm) IgnoreErrors() {
+	x.ignoreErrors = true
 }
 
 // IterateRes groups resulting values of Iterate operation.
@@ -124,6 +131,9 @@ func (b *Blobovnicza) Iterate(prm IteratePrm) (*IterateRes, error) {
 					}
 
 					if err := addressFromKey(elem.addr, k); err != nil {
+						if prm.ignoreErrors {
+							return nil
+						}
 						return fmt.Errorf("could not decode address key: %w", err)
 					}
 				}

--- a/pkg/local_object_storage/blobovnicza/iterate_test.go
+++ b/pkg/local_object_storage/blobovnicza/iterate_test.go
@@ -1,0 +1,57 @@
+package blobovnicza
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/util/slice"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func TestBlobovniczaIterate(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "blob")
+	b := New(WithPath(filename))
+	require.NoError(t, b.Open())
+	require.NoError(t, b.Init())
+
+	data := [][]byte{{0, 1, 2, 3}, {5, 6, 7, 8}}
+	addr := objecttest.Address()
+	_, err := b.Put(&PutPrm{addr: addr, objData: data[0]})
+	require.NoError(t, err)
+
+	require.NoError(t, b.boltDB.Update(func(tx *bbolt.Tx) error {
+		buck := tx.Bucket(bucketKeyFromBounds(firstBucketBound))
+		return buck.Put([]byte("invalid address"), data[1])
+	}))
+
+	seen := make([][]byte, 0, 2)
+	inc := func(e IterationElement) error {
+		seen = append(seen, slice.Copy(e.data))
+		return nil
+	}
+
+	_, err = b.Iterate(IteratePrm{handler: inc})
+	require.NoError(t, err)
+	require.ElementsMatch(t, seen, data)
+
+	seen = seen[:0]
+	_, err = b.Iterate(IteratePrm{handler: inc, decodeAddresses: true})
+	require.Error(t, err)
+
+	seen = seen[:0]
+	_, err = b.Iterate(IteratePrm{handler: inc, decodeAddresses: true, ignoreErrors: true})
+	require.NoError(t, err)
+	require.ElementsMatch(t, seen, data[:1])
+
+	seen = seen[:0]
+	expectedErr := errors.New("stop iteration")
+	_, err = b.Iterate(IteratePrm{
+		decodeAddresses: true,
+		handler:         func(IterationElement) error { return expectedErr },
+		ignoreErrors:    true,
+	})
+	require.True(t, errors.Is(err, expectedErr), "got: %v")
+}

--- a/pkg/local_object_storage/blobstor/blobovnicza.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza.go
@@ -631,10 +631,13 @@ func (b *blobovniczas) iterateLeaves(f func(string) (bool, error)) error {
 }
 
 // iterator over all blobovniczas in unsorted order. Break on f's error return.
-func (b *blobovniczas) iterateBlobovniczas(f func(string, *blobovnicza.Blobovnicza) error) error {
+func (b *blobovniczas) iterateBlobovniczas(ignoreErrors bool, f func(string, *blobovnicza.Blobovnicza) error) error {
 	return b.iterateLeaves(func(p string) (bool, error) {
 		blz, err := b.openBlobovnicza(p)
 		if err != nil {
+			if ignoreErrors {
+				return false, nil
+			}
 			return false, fmt.Errorf("could not open blobovnicza %s: %w", p, err)
 		}
 
@@ -811,7 +814,7 @@ func (b *blobovniczas) init() error {
 		return zstdD(data)
 	}
 
-	return b.iterateBlobovniczas(func(p string, blz *blobovnicza.Blobovnicza) error {
+	return b.iterateBlobovniczas(false, func(p string, blz *blobovnicza.Blobovnicza) error {
 		if err := blz.Init(); err != nil {
 			return fmt.Errorf("could not initialize blobovnicza structure %s: %w", p, err)
 		}

--- a/pkg/local_object_storage/blobstor/iterate.go
+++ b/pkg/local_object_storage/blobstor/iterate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 )
 
@@ -78,7 +79,7 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 
 	elem.blzID = nil
 
-	err = b.fsTree.Iterate(func(_ *objectSDK.Address, data []byte) error {
+	err = b.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(_ *objectSDK.Address, data []byte) error {
 		// decompress the data
 		elem.data, err = b.decompressor(data)
 		if err != nil {
@@ -86,7 +87,7 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 		}
 
 		return prm.handler(elem)
-	})
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("fs tree iterator failure: %w", err)
 	}

--- a/pkg/local_object_storage/blobstor/iterate_test.go
+++ b/pkg/local_object_storage/blobstor/iterate_test.go
@@ -1,10 +1,15 @@
 package blobstor
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
@@ -88,4 +93,112 @@ func TestIterateObjects(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, mObjs)
+}
+
+func TestIterate_IgnoreErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	const (
+		smallSize = 512
+		objCount  = 5
+	)
+	bsOpts := []Option{
+		WithCompressObjects(true),
+		WithRootPath(dir),
+		WithSmallSizeLimit(smallSize * 2), // + header
+		WithBlobovniczaOpenedCacheSize(1),
+		WithBlobovniczaShallowWidth(1),
+		WithBlobovniczaShallowDepth(1)}
+	bs := New(bsOpts...)
+	require.NoError(t, bs.Open())
+	require.NoError(t, bs.Init())
+
+	addrs := make([]*object.Address, objCount)
+	for i := range addrs {
+		addrs[i] = objecttest.Address()
+		obj := object.NewRaw()
+		obj.SetContainerID(addrs[i].ContainerID())
+		obj.SetID(addrs[i].ObjectID())
+		obj.SetPayload(make([]byte, smallSize<<(i%2)))
+
+		objData, err := obj.Marshal()
+		require.NoError(t, err)
+
+		_, err = bs.PutRaw(addrs[i], objData, true)
+		require.NoError(t, err)
+	}
+
+	// Construct corrupted compressed object.
+	buf := bytes.NewBuffer(nil)
+	badObject := make([]byte, smallSize/2+1)
+	enc, err := zstd.NewWriter(buf)
+	require.NoError(t, err)
+	rawData := enc.EncodeAll(badObject, nil)
+	for i := 4; /* magic size */ i < len(rawData); i += 2 {
+		rawData[i] ^= 0xFF
+	}
+	// Will be put uncompressed but fetched as compressed because of magic.
+	_, err = bs.PutRaw(objecttest.Address(), rawData, false)
+	require.NoError(t, err)
+	require.NoError(t, bs.fsTree.Put(objecttest.Address(), rawData))
+
+	require.NoError(t, bs.Close())
+
+	// Increase width to have blobovnicza which is definitely empty.
+	b := New(append(bsOpts, WithBlobovniczaShallowWidth(2))...)
+	require.NoError(t, b.Open())
+	require.NoError(t, b.Init())
+
+	var p string
+	for i := 0; i < 2; i++ {
+		bp := filepath.Join(bs.blzRootPath, "1", strconv.FormatUint(uint64(i), 10))
+		if _, ok := bs.blobovniczas.opened.Get(bp); !ok {
+			p = bp
+			break
+		}
+	}
+	require.NotEqual(t, "", p, "expected to not have at least 1 blobovnicza in cache")
+	require.NoError(t, os.Chmod(p, 0))
+
+	var prm IteratePrm
+	prm.SetIterationHandler(func(e IterationElement) error {
+		return nil
+	})
+	_, err = bs.Iterate(prm)
+	require.Error(t, err)
+
+	prm.IgnoreErrors()
+
+	t.Run("skip invalid objects", func(t *testing.T) {
+		actual := make([]*object.Address, 0, len(addrs))
+		prm.SetIterationHandler(func(e IterationElement) error {
+			obj := object.New()
+			err := obj.Unmarshal(e.data)
+			if err != nil {
+				return err
+			}
+
+			addr := object.NewAddress()
+			addr.SetContainerID(obj.ContainerID())
+			addr.SetObjectID(obj.ID())
+			actual = append(actual, addr)
+			return nil
+		})
+
+		_, err := bs.Iterate(prm)
+		require.NoError(t, err)
+		require.ElementsMatch(t, addrs, actual)
+	})
+	t.Run("return errors from handler", func(t *testing.T) {
+		n := 0
+		expectedErr := errors.New("expected error")
+		prm.SetIterationHandler(func(e IterationElement) error {
+			if n++; n == objCount/2 {
+				return expectedErr
+			}
+			return nil
+		})
+		_, err := bs.Iterate(prm)
+		require.True(t, errors.Is(err, expectedErr), "got: %v")
+	})
 }

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -127,13 +127,13 @@ func (s *Shard) refillMetabase() error {
 
 // Close releases all Shard's components.
 func (s *Shard) Close() error {
-	components := []interface{ Close() error }{
-		s.blobStor, s.metaBase,
-	}
+	components := []interface{ Close() error }{}
 
 	if s.hasWriteCache() {
 		components = append(components, s.writeCache)
 	}
+
+	components = append(components, s.blobStor, s.metaBase)
 
 	for _, component := range components {
 		if err := component.Close(); err != nil {

--- a/pkg/local_object_storage/shard/dump.go
+++ b/pkg/local_object_storage/shard/dump.go
@@ -12,49 +12,49 @@ import (
 
 var dumpMagic = []byte("NEOF")
 
-// EvacuatePrm groups the parameters of Evacuate operation.
-type EvacuatePrm struct {
+// DumpPrm groups the parameters of Dump operation.
+type DumpPrm struct {
 	path         string
 	stream       io.Writer
 	ignoreErrors bool
 }
 
-// WithPath is an Evacuate option to set the destination path.
-func (p *EvacuatePrm) WithPath(path string) *EvacuatePrm {
+// WithPath is an Dump option to set the destination path.
+func (p *DumpPrm) WithPath(path string) *DumpPrm {
 	p.path = path
 	return p
 }
 
-// WithStream is an Evacuate option to set the destination stream.
+// WithStream is an Dump option to set the destination stream.
 // It takes priority over `path` option.
-func (p *EvacuatePrm) WithStream(r io.Writer) *EvacuatePrm {
+func (p *DumpPrm) WithStream(r io.Writer) *DumpPrm {
 	p.stream = r
 	return p
 }
 
-// WithIgnoreErrors is an Evacuate option to allow ignore all errors during iteration.
+// WithIgnoreErrors is an Dump option to allow ignore all errors during iteration.
 // This includes invalid blobovniczas as well as corrupted objects.
-func (p *EvacuatePrm) WithIgnoreErrors(ignore bool) *EvacuatePrm {
+func (p *DumpPrm) WithIgnoreErrors(ignore bool) *DumpPrm {
 	p.ignoreErrors = ignore
 	return p
 }
 
-// EvacuateRes groups the result fields of Evacuate operation.
-type EvacuateRes struct {
+// DumpRes groups the result fields of Dump operation.
+type DumpRes struct {
 	count int
 }
 
 // Count return amount of object written.
-func (r *EvacuateRes) Count() int {
+func (r *DumpRes) Count() int {
 	return r.count
 }
 
 var ErrMustBeReadOnly = errors.New("shard must be in read-only mode")
 
-// Evacuate dumps all objects from the shard to a file or stream.
+// Dump dumps all objects from the shard to a file or stream.
 //
 // Returns any error encountered.
-func (s *Shard) Evacuate(prm *EvacuatePrm) (*EvacuateRes, error) {
+func (s *Shard) Dump(prm *DumpPrm) (*DumpRes, error) {
 	s.m.RLock()
 	defer s.m.RUnlock()
 
@@ -126,5 +126,5 @@ func (s *Shard) Evacuate(prm *EvacuatePrm) (*EvacuateRes, error) {
 		return nil, err
 	}
 
-	return &EvacuateRes{count: count}, nil
+	return &DumpRes{count: count}, nil
 }

--- a/pkg/local_object_storage/shard/evacuate.go
+++ b/pkg/local_object_storage/shard/evacuate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 )
 
 var dumpMagic = []byte("NEOF")
@@ -72,7 +73,7 @@ func (s *Shard) Evacuate(prm *EvacuatePrm) (*EvacuateRes, error) {
 	var count int
 
 	if s.hasWriteCache() {
-		err := s.writeCache.Iterate(func(data []byte) error {
+		err := s.writeCache.Iterate(new(writecache.IterationPrm).WithHandler(func(data []byte) error {
 			var size [4]byte
 			binary.LittleEndian.PutUint32(size[:], uint32(len(data)))
 			if _, err := w.Write(size[:]); err != nil {
@@ -85,7 +86,7 @@ func (s *Shard) Evacuate(prm *EvacuatePrm) (*EvacuateRes, error) {
 
 			count++
 			return nil
-		})
+		}))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/local_object_storage/shard/evacuate.go
+++ b/pkg/local_object_storage/shard/evacuate.go
@@ -1,0 +1,102 @@
+package shard
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
+)
+
+var dumpMagic = []byte("NEOF")
+
+// EvacuatePrm groups the parameters of Evacuate operation.
+type EvacuatePrm struct {
+	path   string
+	stream io.Writer
+}
+
+// WithPath is an Evacuate option to set the destination path.
+func (p *EvacuatePrm) WithPath(path string) *EvacuatePrm {
+	p.path = path
+	return p
+}
+
+// WithStream is an Evacuate option to set the destination stream.
+// It takes priority over `path` option.
+func (p *EvacuatePrm) WithStream(r io.Writer) *EvacuatePrm {
+	p.stream = r
+	return p
+}
+
+// EvacuateRes groups the result fields of Evacuate operation.
+type EvacuateRes struct {
+	count int
+}
+
+// Count return amount of object written.
+func (r *EvacuateRes) Count() int {
+	return r.count
+}
+
+var ErrMustBeReadOnly = errors.New("shard must be in read-only mode")
+
+// Evacuate dumps all objects from the shard to a file or stream.
+//
+// Returns any error encountered.
+func (s *Shard) Evacuate(prm *EvacuatePrm) (*EvacuateRes, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	if s.info.Mode != ModeReadOnly {
+		return nil, ErrMustBeReadOnly
+	}
+
+	w := prm.stream
+	if w == nil {
+		f, err := os.OpenFile(prm.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		w = f
+	}
+
+	_, err := w.Write(dumpMagic)
+	if err != nil {
+		return nil, err
+	}
+
+	var count int
+
+	if s.hasWriteCache() {
+		// TODO evacuate objects from write cache
+	}
+
+	var pi blobstor.IteratePrm
+
+	pi.SetIterationHandler(func(elem blobstor.IterationElement) error {
+		data := elem.ObjectData()
+
+		var size [4]byte
+		binary.LittleEndian.PutUint32(size[:], uint32(len(data)))
+		if _, err := w.Write(size[:]); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+
+		count++
+		return nil
+	})
+
+	if _, err := s.blobStor.Iterate(pi); err != nil {
+		return nil, err
+	}
+
+	return &EvacuateRes{count: count}, nil
+}

--- a/pkg/local_object_storage/shard/evacuate_test.go
+++ b/pkg/local_object_storage/shard/evacuate_test.go
@@ -39,7 +39,7 @@ func testEvacuate(t *testing.T, objCount int, hasWriteCache bool) {
 	if !hasWriteCache {
 		sh = newShard(t, false)
 	} else {
-		sh = newCustomShard(t, true,
+		sh = newCustomShard(t, t.TempDir(), true,
 			writecache.WithSmallObjectSize(wcSmallObjectSize),
 			writecache.WithMaxObjectSize(wcBigObjectSize))
 	}

--- a/pkg/local_object_storage/shard/evacuate_test.go
+++ b/pkg/local_object_storage/shard/evacuate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,6 +78,7 @@ func testEvacuate(t *testing.T, objCount int, hasWriteCache bool) {
 			size = bsBigObjectSize - headerSize
 		}
 		data := make([]byte, size)
+		rand.Read(data)
 		obj := generateRawObjectWithPayload(cid, data)
 		objects[i] = obj.Object()
 
@@ -212,7 +214,8 @@ func checkRestore(t *testing.T, sh *shard.Shard, prm *shard.RestorePrm, objects 
 	require.Equal(t, len(objects), res.Count())
 
 	for i := range objects {
-		_, err := sh.Get(new(shard.GetPrm).WithAddress(objects[i].Address()))
+		res, err := sh.Get(new(shard.GetPrm).WithAddress(objects[i].Address()))
 		require.NoError(t, err)
+		require.Equal(t, objects[i], res.Object())
 	}
 }

--- a/pkg/local_object_storage/shard/evacuate_test.go
+++ b/pkg/local_object_storage/shard/evacuate_test.go
@@ -1,0 +1,182 @@
+package shard_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvacuate(t *testing.T) {
+	sh := newShard(t, false)
+	defer releaseShard(sh, t)
+
+	out := filepath.Join(t.TempDir(), "dump")
+	prm := new(shard.EvacuatePrm).WithPath(out)
+
+	t.Run("must be read-only", func(t *testing.T) {
+		_, err := sh.Evacuate(prm)
+		require.True(t, errors.Is(err, shard.ErrMustBeReadOnly), "got: %v", err)
+	})
+
+	require.NoError(t, sh.SetMode(shard.ModeReadOnly))
+	outEmpty := out + ".empty"
+	res, err := sh.Evacuate(new(shard.EvacuatePrm).WithPath(outEmpty))
+	require.NoError(t, err)
+	require.Equal(t, 0, res.Count())
+	require.NoError(t, sh.SetMode(shard.ModeReadWrite))
+
+	const objCount = 10
+	objects := make([]*object.Object, objCount)
+	for i := 0; i < objCount; i++ {
+		cid := cidtest.ID()
+		obj := generateRawObjectWithCID(t, cid)
+		addAttribute(obj, "foo", strconv.FormatUint(rand.Uint64(), 10))
+		objects[i] = obj.Object()
+
+		prm := new(shard.PutPrm).WithObject(objects[i])
+		_, err := sh.Put(prm)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, sh.SetMode(shard.ModeReadOnly))
+
+	t.Run("invalid path", func(t *testing.T) {
+		_, err := sh.Evacuate(new(shard.EvacuatePrm).WithPath("\x00"))
+		require.Error(t, err)
+	})
+
+	res, err = sh.Evacuate(prm)
+	require.NoError(t, err)
+	require.Equal(t, objCount, res.Count())
+
+	t.Run("restore", func(t *testing.T) {
+		sh := newShard(t, false)
+		defer releaseShard(sh, t)
+
+		t.Run("empty dump", func(t *testing.T) {
+			res, err := sh.Restore(new(shard.RestorePrm).WithPath(outEmpty))
+			require.NoError(t, err)
+			require.Equal(t, 0, res.Count())
+		})
+
+		t.Run("invalid path", func(t *testing.T) {
+			_, err := sh.Restore(new(shard.RestorePrm))
+			require.True(t, errors.Is(err, os.ErrNotExist), "got: %v", err)
+		})
+
+		t.Run("invalid file", func(t *testing.T) {
+			t.Run("invalid magic", func(t *testing.T) {
+				out := out + ".wrongmagic"
+				require.NoError(t, ioutil.WriteFile(out, []byte{0, 0, 0, 0}, os.ModePerm))
+
+				_, err := sh.Restore(new(shard.RestorePrm).WithPath(out))
+				require.True(t, errors.Is(err, shard.ErrInvalidMagic), "got: %v", err)
+			})
+
+			fileData, err := ioutil.ReadFile(out)
+			require.NoError(t, err)
+
+			t.Run("incomplete size", func(t *testing.T) {
+				out := out + ".wrongsize"
+				fileData := append(fileData, 1)
+				require.NoError(t, ioutil.WriteFile(out, fileData, os.ModePerm))
+
+				_, err := sh.Restore(new(shard.RestorePrm).WithPath(out))
+				require.True(t, errors.Is(err, io.ErrUnexpectedEOF), "got: %v", err)
+			})
+			t.Run("incomplete object data", func(t *testing.T) {
+				out := out + ".wrongsize"
+				fileData := append(fileData, 1, 0, 0, 0)
+				require.NoError(t, ioutil.WriteFile(out, fileData, os.ModePerm))
+
+				_, err := sh.Restore(new(shard.RestorePrm).WithPath(out))
+				require.True(t, errors.Is(err, io.EOF), "got: %v", err)
+			})
+			t.Run("invalid object", func(t *testing.T) {
+				out := out + ".wrongobj"
+				fileData := append(fileData, 1, 0, 0, 0, 0xFF)
+				require.NoError(t, ioutil.WriteFile(out, fileData, os.ModePerm))
+
+				_, err := sh.Restore(new(shard.RestorePrm).WithPath(out))
+				require.Error(t, err)
+			})
+		})
+
+		prm := new(shard.RestorePrm).WithPath(out)
+		t.Run("must allow write", func(t *testing.T) {
+			require.NoError(t, sh.SetMode(shard.ModeReadOnly))
+
+			_, err := sh.Restore(prm)
+			require.True(t, errors.Is(err, shard.ErrReadOnlyMode), "got: %v", err)
+		})
+
+		require.NoError(t, sh.SetMode(shard.ModeReadWrite))
+
+		checkRestore(t, sh, prm, objects)
+	})
+}
+
+func TestStream(t *testing.T) {
+	sh1 := newCustomShard(t, filepath.Join(t.TempDir(), "shard1"), false, nil, nil)
+	defer releaseShard(sh1, t)
+
+	sh2 := newCustomShard(t, filepath.Join(t.TempDir(), "shard2"), false, nil, nil)
+	defer releaseShard(sh2, t)
+
+	const objCount = 5
+	objects := make([]*object.Object, objCount)
+	for i := 0; i < objCount; i++ {
+		cid := cidtest.ID()
+		obj := generateRawObjectWithCID(t, cid)
+		objects[i] = obj.Object()
+
+		prm := new(shard.PutPrm).WithObject(objects[i])
+		_, err := sh1.Put(prm)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, sh1.SetMode(shard.ModeReadOnly))
+
+	r, w := io.Pipe()
+	finish := make(chan struct{})
+
+	go func() {
+		res, err := sh1.Evacuate(new(shard.EvacuatePrm).WithStream(w))
+		require.NoError(t, err)
+		require.Equal(t, objCount, res.Count())
+		require.NoError(t, w.Close())
+		close(finish)
+	}()
+
+	checkRestore(t, sh2, new(shard.RestorePrm).WithStream(r), objects)
+	require.Eventually(t, func() bool {
+		select {
+		case <-finish:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func checkRestore(t *testing.T, sh *shard.Shard, prm *shard.RestorePrm, objects []*object.Object) {
+	res, err := sh.Restore(prm)
+	require.NoError(t, err)
+	require.Equal(t, len(objects), res.Count())
+
+	for i := range objects {
+		_, err := sh.Get(new(shard.GetPrm).WithAddress(objects[i].Address()))
+		require.NoError(t, err)
+	}
+}

--- a/pkg/local_object_storage/shard/head_test.go
+++ b/pkg/local_object_storage/shard/head_test.go
@@ -42,7 +42,7 @@ func testShardHead(t *testing.T, hasWriteCache bool) {
 
 		res, err := testHead(t, sh, headPrm, hasWriteCache)
 		require.NoError(t, err)
-		require.Equal(t, obj.Object(), res.Object())
+		require.Equal(t, obj.CutPayload().Object(), res.Object())
 	})
 
 	t.Run("virtual object", func(t *testing.T) {
@@ -75,7 +75,7 @@ func testShardHead(t *testing.T, hasWriteCache bool) {
 
 		head, err := sh.Head(headPrm)
 		require.NoError(t, err)
-		require.Equal(t, parent.Object(), head.Object())
+		require.Equal(t, parent.CutPayload().Object(), head.Object())
 	})
 }
 

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -1,6 +1,10 @@
 package shard
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
+)
 
 // Mode represents enumeration of Shard work modes.
 type Mode uint32
@@ -39,6 +43,15 @@ func (m Mode) String() string {
 func (s *Shard) SetMode(m Mode) error {
 	s.m.Lock()
 	defer s.m.Unlock()
+
+	if s.hasWriteCache() {
+		switch m {
+		case ModeReadOnly:
+			s.writeCache.SetMode(writecache.ModeReadOnly)
+		case ModeReadWrite:
+			s.writeCache.SetMode(writecache.ModeReadWrite)
+		}
+	}
 
 	s.info.Mode = m
 

--- a/pkg/local_object_storage/shard/restore.go
+++ b/pkg/local_object_storage/shard/restore.go
@@ -56,7 +56,7 @@ func (r *RestoreRes) FailCount() int {
 	return r.failed
 }
 
-// Restore restores objects from the dump prepared by Evacuate.
+// Restore restores objects from the dump prepared by Dump.
 //
 // Returns any error encountered.
 func (s *Shard) Restore(prm *RestorePrm) (*RestoreRes, error) {

--- a/pkg/local_object_storage/shard/restore.go
+++ b/pkg/local_object_storage/shard/restore.go
@@ -1,0 +1,115 @@
+package shard
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+)
+
+// ErrInvalidMagic is returned when dump format is invalid.
+var ErrInvalidMagic = errors.New("invalid magic")
+
+// RestorePrm groups the parameters of Restore operation.
+type RestorePrm struct {
+	path   string
+	stream io.Reader
+}
+
+// WithPath is a Restore option to set the destination path.
+func (p *RestorePrm) WithPath(path string) *RestorePrm {
+	p.path = path
+	return p
+}
+
+// WithStream is a Restore option to set the stream to read objects from.
+// It takes priority over `WithPath` option.
+func (p *RestorePrm) WithStream(r io.Reader) *RestorePrm {
+	p.stream = r
+	return p
+}
+
+// RestoreRes groups the result fields of Restore operation.
+type RestoreRes struct {
+	count int
+}
+
+// Count return amount of object written.
+func (r *RestoreRes) Count() int {
+	return r.count
+}
+
+// Restore restores objects from the dump prepared by Evacuate.
+//
+// Returns any error encountered.
+func (s *Shard) Restore(prm *RestorePrm) (*RestoreRes, error) {
+	// Disallow changing mode during restore.
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	if s.info.Mode != ModeReadWrite {
+		return nil, ErrReadOnlyMode
+	}
+
+	r := prm.stream
+	if r == nil {
+		f, err := os.OpenFile(prm.path, os.O_RDONLY, os.ModeExclusive)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		r = f
+	}
+
+	var m [4]byte
+	_, _ = io.ReadFull(r, m[:])
+	if !bytes.Equal(m[:], dumpMagic) {
+		return nil, ErrInvalidMagic
+	}
+
+	var count int
+	var data []byte
+	var size [4]byte
+	for {
+		// If there are less than 4 bytes left, `Read` returns nil error instead of
+		// io.ErrUnexpectedEOF, thus `ReadFull` is used.
+		_, err := io.ReadFull(r, size[:])
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		sz := binary.LittleEndian.Uint32(size[:])
+		if uint32(cap(data)) < sz {
+			data = make([]byte, sz)
+		} else {
+			data = data[:sz]
+		}
+
+		_, err = r.Read(data)
+		if err != nil {
+			return nil, err
+		}
+
+		obj := object.New()
+		err = obj.Unmarshal(data)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = s.Put(new(PutPrm).WithObject(obj))
+		if err != nil {
+			return nil, err
+		}
+
+		count++
+	}
+
+	return &RestoreRes{count: count}, nil
+}

--- a/pkg/local_object_storage/shard/shard_test.go
+++ b/pkg/local_object_storage/shard/shard_test.go
@@ -27,11 +27,10 @@ import (
 )
 
 func newShard(t testing.TB, enableWriteCache bool) *shard.Shard {
-	return newCustomShard(t, enableWriteCache, writecache.WithMaxMemSize(0))
+	return newCustomShard(t, t.TempDir(), enableWriteCache, writecache.WithMaxMemSize(0))
 }
 
-func newCustomShard(t testing.TB, enableWriteCache bool, wcOpts ...writecache.Option) *shard.Shard {
-	rootPath := t.Name()
+func newCustomShard(t testing.TB, rootPath string, enableWriteCache bool, wcOpts ...writecache.Option) *shard.Shard {
 	if enableWriteCache {
 		rootPath = path.Join(rootPath, "wc")
 	} else {

--- a/pkg/local_object_storage/shard/shutdown_test.go
+++ b/pkg/local_object_storage/shard/shutdown_test.go
@@ -34,7 +34,7 @@ func TestWriteCacheObjectLoss(t *testing.T) {
 		writecache.WithSmallObjectSize(smallSize),
 		writecache.WithMaxObjectSize(smallSize * 2)}
 
-	sh := newCustomShard(t, dir, true, wcOpts...)
+	sh := newCustomShard(t, dir, true, wcOpts, nil)
 
 	for i := range objects {
 		_, err := sh.Put(new(shard.PutPrm).WithObject(objects[i]))
@@ -42,7 +42,7 @@ func TestWriteCacheObjectLoss(t *testing.T) {
 	}
 	require.NoError(t, sh.Close())
 
-	sh = newCustomShard(t, dir, true, wcOpts...)
+	sh = newCustomShard(t, dir, true, wcOpts, nil)
 	defer releaseShard(sh, t)
 
 	for i := range objects {

--- a/pkg/local_object_storage/shard/shutdown_test.go
+++ b/pkg/local_object_storage/shard/shutdown_test.go
@@ -1,0 +1,52 @@
+package shard_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteCacheObjectLoss(t *testing.T) {
+	const (
+		smallSize = 1024
+		objCount  = 100
+	)
+
+	objects := make([]*object.Object, objCount)
+	for i := range objects {
+		size := smallSize
+		//if i%2 == 0 {
+		size = smallSize / 2
+		//}
+		data := make([]byte, size)
+		rand.Read(data)
+
+		objects[i] = generateRawObjectWithPayload(cidtest.ID(), data).Object()
+	}
+
+	dir := t.TempDir()
+	wcOpts := []writecache.Option{
+		writecache.WithSmallObjectSize(smallSize),
+		writecache.WithMaxObjectSize(smallSize * 2)}
+
+	sh := newCustomShard(t, dir, true, wcOpts...)
+
+	for i := range objects {
+		_, err := sh.Put(new(shard.PutPrm).WithObject(objects[i]))
+		require.NoError(t, err)
+	}
+	require.NoError(t, sh.Close())
+
+	sh = newCustomShard(t, dir, true, wcOpts...)
+	defer releaseShard(sh, t)
+
+	for i := range objects {
+		_, err := sh.Get(new(shard.GetPrm).WithAddress(objects[i].Address()))
+		require.NoError(t, err, i)
+	}
+}

--- a/pkg/local_object_storage/writecache/delete.go
+++ b/pkg/local_object_storage/writecache/delete.go
@@ -12,6 +12,12 @@ import (
 
 // Delete removes object from write-cache.
 func (c *cache) Delete(addr *objectSDK.Address) error {
+	c.modeMtx.RLock()
+	defer c.modeMtx.RUnlock()
+	if c.mode == ModeReadOnly {
+		return ErrReadOnly
+	}
+
 	saddr := addr.String()
 
 	// Check memory cache.

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
@@ -132,7 +133,7 @@ func (c *cache) flushBigObjects() {
 			}
 
 			evictNum := 0
-			_ = c.fsTree.Iterate(func(addr *objectSDK.Address, data []byte) error {
+			_ = c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
 				sAddr := addr.String()
 
 				if _, ok := c.store.flushed.Peek(sAddr); ok {
@@ -160,7 +161,7 @@ func (c *cache) flushBigObjects() {
 				evictNum++
 
 				return nil
-			})
+			}))
 
 			// evict objects which were successfully written to BlobStor
 			c.evictObjects(evictNum)

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -175,6 +175,7 @@ func (c *cache) flushWorker(num int) {
 		// TODO(fyrchik): do this once in N iterations depending on load
 		select {
 		case obj = <-priorityCh:
+			metaOnly = num%3 == 1
 		default:
 			select {
 			case obj = <-c.directCh:

--- a/pkg/local_object_storage/writecache/iterate.go
+++ b/pkg/local_object_storage/writecache/iterate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.etcd.io/bbolt"
 )
@@ -34,12 +35,12 @@ func (c *cache) Iterate(f func([]byte) error) error {
 		return err
 	}
 
-	return c.fsTree.Iterate(func(addr *object.Address, data []byte) error {
+	return c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *object.Address, data []byte) error {
 		if _, ok := c.flushed.Peek(addr.String()); ok {
 			return nil
 		}
 		return f(data)
-	})
+	}))
 }
 
 // IterateDB iterates over all objects stored in bbolt.DB instance and passes them to f until error return.

--- a/pkg/local_object_storage/writecache/iterate.go
+++ b/pkg/local_object_storage/writecache/iterate.go
@@ -12,10 +12,28 @@ import (
 // ErrNoDefaultBucket is returned by IterateDB when default bucket for objects is missing.
 var ErrNoDefaultBucket = errors.New("no default bucket")
 
+// IterationPrm contains iteration parameters.
+type IterationPrm struct {
+	handler      func([]byte) error
+	ignoreErrors bool
+}
+
+// WithHandler sets a callback to be executed on every object.
+func (p *IterationPrm) WithHandler(f func([]byte) error) *IterationPrm {
+	p.handler = f
+	return p
+}
+
+// WithIgnoreErrors sets a flag indicating that errors should be ignored.
+func (p *IterationPrm) WithIgnoreErrors(ignore bool) *IterationPrm {
+	p.ignoreErrors = ignore
+	return p
+}
+
 // Iterate iterates over all objects present in write cache.
 // This is very difficult to do correctly unless write-cache is put in read-only mode.
 // Thus we silently fail if shard is not in read-only mode to avoid reporting misleading results.
-func (c *cache) Iterate(f func([]byte) error) error {
+func (c *cache) Iterate(prm *IterationPrm) error {
 	c.modeMtx.RLock()
 	defer c.modeMtx.RUnlock()
 	if c.mode != ModeReadOnly {
@@ -28,7 +46,7 @@ func (c *cache) Iterate(f func([]byte) error) error {
 			if _, ok := c.flushed.Peek(string(k)); ok {
 				return nil
 			}
-			return f(data)
+			return prm.handler(data)
 		})
 	})
 	if err != nil {
@@ -39,8 +57,8 @@ func (c *cache) Iterate(f func([]byte) error) error {
 		if _, ok := c.flushed.Peek(addr.String()); ok {
 			return nil
 		}
-		return f(data)
-	}))
+		return prm.handler(data)
+	}).WithIgnoreErrors(prm.ignoreErrors))
 }
 
 // IterateDB iterates over all objects stored in bbolt.DB instance and passes them to f until error return.

--- a/pkg/local_object_storage/writecache/mode.go
+++ b/pkg/local_object_storage/writecache/mode.go
@@ -1,0 +1,52 @@
+package writecache
+
+import (
+	"errors"
+	"time"
+)
+
+// Mode represents write-cache mode of operation.
+type Mode uint32
+
+const (
+	// ModeReadWrite is a default mode allowing objects to be flushed.
+	ModeReadWrite Mode = iota
+
+	// ModeReadOnly is a mode in which write-cache doesn't flush anything to a metabase.
+	ModeReadOnly
+)
+
+// ErrReadOnly is returned when Put/Write is performed in a read-only mode.
+var ErrReadOnly = errors.New("write-cache is in read-only mode")
+
+// SetMode sets write-cache mode of operation.
+// When shard is put in read-only mode all objects in memory are flushed to disk
+// and all background jobs are suspended.
+func (c *cache) SetMode(m Mode) {
+	c.modeMtx.Lock()
+	defer c.modeMtx.Unlock()
+	if c.mode == m {
+		return
+	}
+
+	c.mode = m
+	if m == ModeReadWrite {
+		return
+	}
+
+	// Because modeMtx is taken no new objects will arrive an all other modifying
+	// operations are completed.
+	// 1. Persist objects already in memory on disk.
+	c.persistMemoryCache()
+
+	// 2. Suspend producers to ensure there are channel send operations in fly.
+	// metaCh and directCh can be populated either during Put or in background memory persist thread.
+	// Former possibility is eliminated by taking `modeMtx` mutex and
+	// latter by explicit persist in the previous step.
+	// flushCh is populated by `flush` with `modeMtx` is also taken.
+	// Thus all producers are shutdown and we only need to wait until all channels are empty.
+	for len(c.metaCh) != 0 || len(c.directCh) != 0 || len(c.flushCh) != 0 {
+		c.log.Info("waiting for channels to flush")
+		time.Sleep(time.Second)
+	}
+}

--- a/pkg/local_object_storage/writecache/put.go
+++ b/pkg/local_object_storage/writecache/put.go
@@ -12,6 +12,12 @@ var ErrBigObject = errors.New("too big object")
 
 // Put puts object to write-cache.
 func (c *cache) Put(o *object.Object) error {
+	c.modeMtx.RLock()
+	defer c.modeMtx.RUnlock()
+	if c.mode == ModeReadOnly {
+		return ErrReadOnly
+	}
+
 	sz := uint64(o.ToV2().StableSize())
 	if sz > c.maxObjectSize {
 		return ErrBigObject

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -140,6 +140,9 @@ func (c *cache) Init() error {
 
 // Close closes db connection and stops services. Executes ObjectCounters.FlushAndClose op.
 func (c *cache) Close() error {
+	// Finish all in-progress operations.
+	c.SetMode(ModeReadOnly)
+
 	close(c.closeCh)
 	c.objCounters.FlushAndClose()
 	return c.db.Close()

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -20,6 +20,7 @@ type Cache interface {
 	Get(*objectSDK.Address) (*object.Object, error)
 	Head(*objectSDK.Address) (*object.Object, error)
 	Delete(*objectSDK.Address) error
+	Iterate(func(data []byte) error) error
 	Put(*object.Object) error
 	SetMode(Mode)
 	DumpInfo() Info

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -20,7 +20,7 @@ type Cache interface {
 	Get(*objectSDK.Address) (*object.Object, error)
 	Head(*objectSDK.Address) (*object.Object, error)
 	Delete(*objectSDK.Address) error
-	Iterate(func(data []byte) error) error
+	Iterate(*IterationPrm) error
 	Put(*object.Object) error
 	SetMode(Mode)
 	DumpInfo() Info

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -21,6 +21,7 @@ type Cache interface {
 	Head(*objectSDK.Address) (*object.Object, error)
 	Delete(*objectSDK.Address) error
 	Put(*object.Object) error
+	SetMode(Mode)
 	DumpInfo() Info
 
 	Init() error
@@ -34,6 +35,9 @@ type cache struct {
 	// mtx protects mem field, statistics, counters and compressFlags.
 	mtx sync.RWMutex
 	mem []objectInfo
+
+	mode    Mode
+	modeMtx sync.RWMutex
 
 	// compressFlags maps address of a big object to boolean value indicating
 	// whether object should be compressed.
@@ -83,6 +87,7 @@ func New(opts ...Option) Cache {
 		metaCh:   make(chan *object.Object),
 		closeCh:  make(chan struct{}),
 		evictCh:  make(chan []byte),
+		mode:     ModeReadWrite,
 
 		compressFlags: make(map[string]struct{}),
 		options: options{


### PR DESCRIPTION
Close #1085 . Related #1057 . Depends on #1088 .

Proto-marshaled list is not an option because it requires (let's be realistic) having the slice in memory.
I decided to not use TAR archives because of 512-byte header overhead for each object. It is noticeable only when lot's of small objects without attributes are present, though.