### PR TITLE
Do not cut `data` args in `NNS`

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -104,9 +104,6 @@ func (c *initializeContext) deployNNS(method string) error {
 	}
 
 	params := getContractDeployParameters(cs.RawNEF, cs.RawManifest, nil)
-	if method == updateMethodName {
-		params = params[:len(params)-1] // update has only NEF and manifest args
-	}
 
 	signer := transaction.Signer{
 		Account: c.CommitteeAcc.Contract.ScriptHash(),


### PR DESCRIPTION
Same as previously reverted #1038. Is actual for `v0.14.0` contract version.