### PR TITLE
object/search: Fix error loss in `SignService.Search`

### DIFF
--- a/pkg/services/object/sign.go
+++ b/pkg/services/object/sign.go
@@ -150,7 +150,7 @@ func (s *SignService) Search(req *object.SearchRequest, stream SearchStream) err
 				return stream.Send(new(object.SearchResponse))
 			}
 
-			return nil
+			return err
 		},
 	)
 }


### PR DESCRIPTION
* closes #1098