### PR TITLE
Makefile: use `go install` instead of `go get`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ dep:
 protoc:
 	@GOPRIVATE=github.com/nspcc-dev go mod vendor
 	# Install specific version for protobuf lib
-	@go list -f '{{.Path}}/...@{{.Version}}' -m  github.com/golang/protobuf | xargs go get -v
+	@go list -f '{{.Path}}/...@{{.Version}}' -m  github.com/golang/protobuf | xargs go install -v
 	# Protoc generate
 	@for f in `find . -type f -name '*.proto' -not -path './vendor/*'`; do \
 		echo "⇒ Processing $$f "; \


### PR DESCRIPTION
Remove warning and prevent `go.mod` updates when building `protoc` target.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>