### PR TITLE
Fix/Printing config file in `verbose` mode

### DIFF
--- a/cmd/neofs-cli/modules/accounting.go
+++ b/cmd/neofs-cli/modules/accounting.go
@@ -28,7 +28,6 @@ var accountingCmd = &cobra.Command{
 		_ = viper.BindPFlag(wif, flags.Lookup(wif))
 		_ = viper.BindPFlag(address, flags.Lookup(address))
 		_ = viper.BindPFlag(rpc, flags.Lookup(rpc))
-		_ = viper.BindPFlag(verbose, flags.Lookup(verbose))
 	},
 }
 
@@ -73,7 +72,6 @@ func initAccountingBalanceCmd() {
 	ff.StringP(wif, wifShorthand, wifDefault, wifUsage)
 	ff.StringP(address, addressShorthand, addressDefault, addressUsage)
 	ff.StringP(rpc, rpcShorthand, rpcDefault, rpcUsage)
-	ff.BoolP(verbose, verboseShorthand, verboseDefault, verboseUsage)
 
 	accountingBalanceCmd.Flags().StringVar(&balanceOwner, "owner", "", "owner of balance account (omit to use owner from private key)")
 }

--- a/cmd/neofs-cli/modules/control.go
+++ b/cmd/neofs-cli/modules/control.go
@@ -30,7 +30,6 @@ var controlCmd = &cobra.Command{
 		_ = viper.BindPFlag(wif, ff.Lookup(wif))
 		_ = viper.BindPFlag(address, ff.Lookup(address))
 		_ = viper.BindPFlag(controlRPC, ff.Lookup(controlRPC))
-		_ = viper.BindPFlag(verbose, ff.Lookup(verbose))
 	},
 }
 

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -124,6 +124,9 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/neofs-cli/config.yaml)")
+	rootCmd.PersistentFlags().BoolP(verbose, verboseShorthand, verboseDefault, verboseUsage)
+
+	_ = viper.BindPFlag(verbose, rootCmd.PersistentFlags().Lookup(verbose))
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -399,7 +402,6 @@ func parseXHeaders() []*session.XHeader {
 // - WIF;
 // - address;
 // - RPC;
-// - verbose;
 func initCommonFlags(cmd *cobra.Command) {
 	ff := cmd.Flags()
 
@@ -409,7 +411,6 @@ func initCommonFlags(cmd *cobra.Command) {
 	ff.StringP(wif, wifShorthand, wifDefault, wifUsage)
 	ff.StringP(address, addressShorthand, addressDefault, addressUsage)
 	ff.StringP(rpc, rpcShorthand, rpcDefault, rpcUsage)
-	ff.BoolP(verbose, verboseShorthand, verboseDefault, verboseUsage)
 }
 
 // bind common command flags to the viper
@@ -422,7 +423,6 @@ func bindCommonFlags(cmd *cobra.Command) {
 	_ = viper.BindPFlag(wif, ff.Lookup(wif))
 	_ = viper.BindPFlag(address, ff.Lookup(address))
 	_ = viper.BindPFlag(rpc, ff.Lookup(rpc))
-	_ = viper.BindPFlag(verbose, ff.Lookup(verbose))
 }
 
 func bindAPIFlags(cmd *cobra.Command) {

--- a/cmd/neofs-cli/modules/util.go
+++ b/cmd/neofs-cli/modules/util.go
@@ -37,7 +37,6 @@ var (
 			_ = viper.BindPFlag(walletPath, flags.Lookup(walletPath))
 			_ = viper.BindPFlag(wif, flags.Lookup(wif))
 			_ = viper.BindPFlag(address, flags.Lookup(address))
-			_ = viper.BindPFlag(verbose, flags.Lookup(verbose))
 		},
 	}
 
@@ -198,7 +197,6 @@ func initCommonFlagsWithoutRPC(cmd *cobra.Command) {
 	flags.StringP(walletPath, walletPathShorthand, walletPathDefault, walletPathUsage)
 	flags.StringP(wif, wifShorthand, wifDefault, wifUsage)
 	flags.StringP(address, addressShorthand, addressDefault, addressUsage)
-	flags.BoolP(verbose, verboseShorthand, verboseDefault, verboseUsage)
 }
 
 func initUtilSignBearerCmd() {


### PR DESCRIPTION
Closes #1083.

It was broken since `initConfig` was made before every execution of the 
command and flags have not been read by cobra yet, so it was impossible to 
print config file path if `verbose` flag was set in command line not in 
config file.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>