### PR TITLE
Upd/Adopt SDK changes: `Address` and `ID` was moved to the separate pkgs

### DIFF
--- a/cmd/neofs-cli/internal/client/client.go
+++ b/cmd/neofs-cli/internal/client/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
 
@@ -305,7 +307,7 @@ type PutObjectRes struct {
 }
 
 // ID returns identifier of the created object.
-func (x PutObjectRes) ID() *object.ID {
+func (x PutObjectRes) ID() *oidSDK.ID {
 	return x.cliRes.ID()
 }
 
@@ -338,7 +340,7 @@ type DeleteObjectRes struct {
 }
 
 // TombstoneAddress returns address of the created object with tombstone.
-func (x DeleteObjectRes) TombstoneAddress() *object.Address {
+func (x DeleteObjectRes) TombstoneAddress() *addressSDK.Address {
 	return x.cliRes.TombstoneAddress()
 }
 
@@ -464,7 +466,7 @@ type SearchObjectsRes struct {
 }
 
 // IDList returns identifiers of the matched objects.
-func (x SearchObjectsRes) IDList() []*object.ID {
+func (x SearchObjectsRes) IDList() []*oidSDK.ID {
 	return x.cliRes.IDList()
 }
 

--- a/cmd/neofs-cli/internal/client/prm.go
+++ b/cmd/neofs-cli/internal/client/prm.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/token"
 )
@@ -49,10 +49,10 @@ func (x *bearerTokenPrm) SetBearerToken(tok *token.BearerToken) {
 }
 
 type objectAddressPrm struct {
-	objAddr *object.Address
+	objAddr *addressSDK.Address
 }
 
-func (x *objectAddressPrm) SetAddress(addr *object.Address) {
+func (x *objectAddressPrm) SetAddress(addr *addressSDK.Address) {
 	x.objAddr = addr
 }
 

--- a/cmd/neofs-cli/modules/control.go
+++ b/cmd/neofs-cli/modules/control.go
@@ -11,7 +11,7 @@ import (
 	ircontrolsrv "github.com/nspcc-dev/neofs-node/pkg/services/control/ir/server"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/util/signature"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -325,7 +325,7 @@ var dropObjectsCmd = &cobra.Command{
 		binAddrList := make([][]byte, 0, len(dropObjectsList))
 
 		for i := range dropObjectsList {
-			a := object.NewAddress()
+			a := addressSDK.NewAddress()
 
 			err := a.Parse(dropObjectsList[i])
 			if err != nil {

--- a/cmd/neofs-cli/modules/object.go
+++ b/cmd/neofs-cli/modules/object.go
@@ -17,6 +17,8 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/token"
@@ -669,7 +671,7 @@ func parseSearchFilters(cmd *cobra.Command) (object.SearchFilters, error) {
 
 	oid, _ := cmd.Flags().GetString(searchOIDFlag)
 	if oid != "" {
-		id := object.NewID()
+		id := oidSDK.NewID()
 		if err := id.Parse(oid); err != nil {
 			return nil, fmt.Errorf("could not parse object ID: %w", err)
 		}
@@ -731,8 +733,8 @@ func getCID(cmd *cobra.Command) (*cid.ID, error) {
 	return id, nil
 }
 
-func getOID(cmd *cobra.Command) (*object.ID, error) {
-	oid := object.NewID()
+func getOID(cmd *cobra.Command) (*oidSDK.ID, error) {
+	oid := oidSDK.NewID()
 
 	err := oid.Parse(cmd.Flag("oid").Value.String())
 	if err != nil {
@@ -742,7 +744,7 @@ func getOID(cmd *cobra.Command) (*object.ID, error) {
 	return oid, nil
 }
 
-func getObjectAddress(cmd *cobra.Command) (*object.Address, error) {
+func getObjectAddress(cmd *cobra.Command) (*addressSDK.Address, error) {
 	cid, err := getCID(cmd)
 	if err != nil {
 		return nil, err
@@ -752,7 +754,7 @@ func getObjectAddress(cmd *cobra.Command) (*object.Address, error) {
 		return nil, err
 	}
 
-	objAddr := object.NewAddress()
+	objAddr := addressSDK.NewAddress()
 	objAddr.SetContainerID(cid)
 	objAddr.SetObjectID(oid)
 	return objAddr, nil

--- a/cmd/neofs-cli/modules/storagegroup.go
+++ b/cmd/neofs-cli/modules/storagegroup.go
@@ -9,6 +9,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/storagegroup"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	storagegroupAPI "github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"github.com/spf13/cobra"
 )
@@ -136,7 +138,7 @@ type sgHeadReceiver struct {
 	prm internalclient.HeadObjectPrm
 }
 
-func (c sgHeadReceiver) Head(addr *objectSDK.Address) (interface{}, error) {
+func (c sgHeadReceiver) Head(addr *addressSDK.Address) (interface{}, error) {
 	c.prm.SetAddress(addr)
 
 	res, err := internalclient.HeadObject(c.prm)
@@ -163,10 +165,10 @@ func putSG(cmd *cobra.Command, _ []string) {
 	cid, err := getCID(cmd)
 	exitOnErr(cmd, err)
 
-	members := make([]*objectSDK.ID, 0, len(sgMembers))
+	members := make([]*oidSDK.ID, 0, len(sgMembers))
 
 	for i := range sgMembers {
-		id := objectSDK.NewID()
+		id := oidSDK.NewID()
 
 		err = id.Parse(sgMembers[i])
 		exitOnErr(cmd, errf("could not parse object ID: %w", err))
@@ -207,8 +209,8 @@ func putSG(cmd *cobra.Command, _ []string) {
 	cmd.Printf("  ID: %s\n  CID: %s\n", res.ID(), cid)
 }
 
-func getSGID() (*objectSDK.ID, error) {
-	oid := objectSDK.NewID()
+func getSGID() (*oidSDK.ID, error) {
+	oid := oidSDK.NewID()
 	err := oid.Parse(sgID)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse storage group ID: %w", err)
@@ -224,7 +226,7 @@ func getSG(cmd *cobra.Command, _ []string) {
 	id, err := getSGID()
 	exitOnErr(cmd, err)
 
-	addr := objectSDK.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetContainerID(cid)
 	addr.SetObjectID(id)
 
@@ -288,7 +290,7 @@ func delSG(cmd *cobra.Command, _ []string) {
 	id, err := getSGID()
 	exitOnErr(cmd, err)
 
-	addr := objectSDK.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetContainerID(cid)
 	addr.SetObjectID(id)
 

--- a/cmd/neofs-lens/internal/commands/inspect/inspect.go
+++ b/cmd/neofs-lens/internal/commands/inspect/inspect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +55,7 @@ func init() {
 }
 
 func objectInspectCmd(cmd *cobra.Command, _ []string) {
-	addr := object.NewAddress()
+	addr := addressSDK.NewAddress()
 	err := addr.Parse(vAddress)
 	common.ExitOnErr(cmd, common.Errf("invalid address argument: %w", err))
 

--- a/cmd/neofs-lens/internal/commands/list/list.go
+++ b/cmd/neofs-lens/internal/commands/list/list.go
@@ -6,7 +6,7 @@ import (
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +40,7 @@ var Command = &cobra.Command{
 		// other targets can be supported
 		w := cmd.OutOrStderr()
 
-		wAddr := func(addr *object.Address) error {
+		wAddr := func(addr *addressSDK.Address) error {
 			_, err := io.WriteString(w, addr.String()+"\n")
 			return err
 		}

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"google.golang.org/grpc"
 )
 
@@ -33,7 +33,7 @@ func initControlService(c *cfg) {
 		controlSvc.WithHealthChecker(c),
 		controlSvc.WithNetMapSource(c.cfgNetmap.wrapper),
 		controlSvc.WithNodeState(c),
-		controlSvc.WithDeletedObjectHandler(func(addrList []*object.Address) error {
+		controlSvc.WithDeletedObjectHandler(func(addrList []*addressSDK.Address) error {
 			prm := new(engine.DeletePrm).WithAddresses(addrList...)
 
 			_, err := c.cfgObject.cfgLocalStorage.localStorage.Delete(prm)

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -38,7 +38,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/util/signature"
 	"go.uber.org/zap"
@@ -99,7 +99,7 @@ type localObjectInhumer struct {
 	log *logger.Logger
 }
 
-func (r *localObjectInhumer) DeleteObjects(ts *objectSDK.Address, addr ...*objectSDK.Address) {
+func (r *localObjectInhumer) DeleteObjects(ts *addressSDK.Address, addr ...*addressSDK.Address) {
 	prm := new(engine.InhumePrm)
 
 	for _, a := range addr {
@@ -238,7 +238,7 @@ func initObjectService(c *cfg) {
 			policerconfig.HeadTimeout(c.appCfg),
 		),
 		policer.WithReplicator(repl),
-		policer.WithRedundantCopyCallback(func(addr *objectSDK.Address) {
+		policer.WithRedundantCopyCallback(func(addr *addressSDK.Address) {
 			_, err := ls.Inhume(new(engine.InhumePrm).MarkAsGarbage(addr))
 			if err != nil {
 				c.log.Warn("could not inhume mark redundant copy as garbage",

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.98.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.11.2-0.20220127135316-32dd0bb3f9c5
-	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201140258-9414f42aa349
+	github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201141054-6a7ba33b59ef
 	github.com/nspcc-dev/tzhash v1.5.1
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BE
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
-github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201140258-9414f42aa349 h1:dnaLvUnqt1LUKDepsH0knjAQ92I4L+CxuW44XeVl9J8=
-github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201140258-9414f42aa349/go.mod h1:dPvrJlIgoF1hLJlOWgbNmxQwANsQI/8dTe/wfjxwy04=
+github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201141054-6a7ba33b59ef h1:0DuR21CIuOIPfVIyThWATulCkemdqHmmEqKdt22EHXk=
+github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220201141054-6a7ba33b59ef/go.mod h1:dPvrJlIgoF1hLJlOWgbNmxQwANsQI/8dTe/wfjxwy04=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -12,6 +12,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 )
@@ -32,7 +33,7 @@ type cfg struct {
 
 // DeleteHandler is an interface of delete queue processor.
 type DeleteHandler interface {
-	DeleteObjects(*object.Address, ...*object.Address)
+	DeleteObjects(*addressSDK.Address, ...*addressSDK.Address)
 }
 
 var errNilObject = errors.New("object is nil")
@@ -158,14 +159,14 @@ func (v *FormatValidator) ValidateContent(o *Object) error {
 		// mark all objects from tombstone body as removed in storage engine
 		cid := o.ContainerID()
 		idList := tombstone.Members()
-		addrList := make([]*object.Address, 0, len(idList))
+		addrList := make([]*addressSDK.Address, 0, len(idList))
 
 		for _, id := range idList {
 			if id == nil {
 				return fmt.Errorf("(%T) empty member in tombstone", v)
 			}
 
-			a := object.NewAddress()
+			a := addressSDK.NewAddress()
 			a.SetContainerID(cid)
 			a.SetObjectID(id)
 

--- a/pkg/core/object/fmt_test.go
+++ b/pkg/core/object/fmt_test.go
@@ -12,6 +12,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
@@ -27,8 +28,8 @@ func testSHA(t *testing.T) [sha256.Size]byte {
 	return cs
 }
 
-func testObjectID(t *testing.T) *object.ID {
-	id := object.NewID()
+func testObjectID(t *testing.T) *oidSDK.ID {
+	id := oidSDK.NewID()
 	id.SetSHA256(testSHA(t))
 
 	return id
@@ -118,7 +119,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 		require.Error(t, v.ValidateContent(obj.Object())) // no tombstone content
 
 		content := object.NewTombstone()
-		content.SetMembers([]*object.ID{nil})
+		content.SetMembers([]*oidSDK.ID{nil})
 
 		data, err := content.Marshal()
 		require.NoError(t, err)
@@ -127,7 +128,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		require.Error(t, v.ValidateContent(obj.Object())) // no members in tombstone
 
-		content.SetMembers([]*object.ID{testObjectID(t)})
+		content.SetMembers([]*oidSDK.ID{testObjectID(t)})
 
 		data, err = content.Marshal()
 		require.NoError(t, err)
@@ -160,7 +161,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 		require.Error(t, v.ValidateContent(obj.Object()))
 
 		content := storagegroup.New()
-		content.SetMembers([]*object.ID{nil})
+		content.SetMembers([]*oidSDK.ID{nil})
 
 		data, err := content.Marshal()
 		require.NoError(t, err)
@@ -169,7 +170,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		require.Error(t, v.ValidateContent(obj.Object()))
 
-		content.SetMembers([]*object.ID{testObjectID(t)})
+		content.SetMembers([]*oidSDK.ID{testObjectID(t)})
 
 		data, err = content.Marshal()
 		require.NoError(t, err)

--- a/pkg/core/object/object.go
+++ b/pkg/core/object/object.go
@@ -4,6 +4,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // Object represents the NeoFS object.
@@ -16,13 +17,13 @@ type Object struct {
 }
 
 // Address returns address of the object.
-func (o *Object) Address() *object.Address {
+func (o *Object) Address() *addressSDK.Address {
 	if o != nil {
 		aV2 := new(refs.Address)
 		aV2.SetObjectID(o.ID().ToV2())
 		aV2.SetContainerID(o.ContainerID().ToV2())
 
-		return object.NewAddressFromV2(aV2)
+		return addressSDK.NewAddressFromV2(aV2)
 	}
 
 	return nil

--- a/pkg/innerring/internal/client/client.go
+++ b/pkg/innerring/internal/client/client.go
@@ -11,6 +11,8 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Client represents NeoFS API client cut down to the needs of a purely IR application.
@@ -48,7 +50,7 @@ type SearchSGRes struct {
 }
 
 // IDList returns list of IDs of storage groups in container.
-func (x SearchSGRes) IDList() []*object.ID {
+func (x SearchSGRes) IDList() []*oid.ID {
 	return x.cliRes.IDList()
 }
 
@@ -163,7 +165,7 @@ func (x Client) HeadObject(prm HeadObjectPrm) (res HeadObjectRes, err error) {
 // GetObjectPayload reads object by address from NeoFS via Client and returns its payload.
 //
 // Returns any error prevented the operation from completing correctly in error return.
-func GetObjectPayload(ctx context.Context, c Client, addr *object.Address) ([]byte, error) {
+func GetObjectPayload(ctx context.Context, c Client, addr *addressSDK.Address) ([]byte, error) {
 	var prm GetObjectPrm
 
 	prm.SetContext(ctx)
@@ -177,7 +179,7 @@ func GetObjectPayload(ctx context.Context, c Client, addr *object.Address) ([]by
 	return obj.Object().Payload(), nil
 }
 
-func headObject(ctx context.Context, c Client, addr *object.Address, raw bool, ttl uint32) (*object.Object, error) {
+func headObject(ctx context.Context, c Client, addr *addressSDK.Address, raw bool, ttl uint32) (*object.Object, error) {
 	var prm HeadObjectPrm
 
 	prm.SetContext(ctx)
@@ -197,13 +199,13 @@ func headObject(ctx context.Context, c Client, addr *object.Address, raw bool, t
 }
 
 // GetRawObjectHeaderLocally reads raw short object header from server's local storage by address via Client.
-func GetRawObjectHeaderLocally(ctx context.Context, c Client, addr *object.Address) (*object.Object, error) {
+func GetRawObjectHeaderLocally(ctx context.Context, c Client, addr *addressSDK.Address) (*object.Object, error) {
 	return headObject(ctx, c, addr, true, 1)
 }
 
 // GetObjectHeaderFromContainer reads short object header by address via Client with TTL = 10
 // for deep traversal of the container.
-func GetObjectHeaderFromContainer(ctx context.Context, c Client, addr *object.Address) (*object.Object, error) {
+func GetObjectHeaderFromContainer(ctx context.Context, c Client, addr *addressSDK.Address) (*object.Object, error) {
 	return headObject(ctx, c, addr, false, 10)
 }
 
@@ -265,7 +267,7 @@ func (x Client) HashPayloadRange(prm HashPayloadRangePrm) (res HashPayloadRangeR
 // from the remote server's local storage via Client.
 //
 // Returns any error prevented the operation from completing correctly in error return.
-func HashObjectRange(ctx context.Context, c Client, addr *object.Address, rng *object.Range) ([]byte, error) {
+func HashObjectRange(ctx context.Context, c Client, addr *addressSDK.Address, rng *object.Range) ([]byte, error) {
 	var prm HashPayloadRangePrm
 
 	prm.SetContext(ctx)

--- a/pkg/innerring/internal/client/prm.go
+++ b/pkg/innerring/internal/client/prm.go
@@ -3,7 +3,7 @@ package neofsapiclient
 import (
 	"context"
 
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type contextPrm struct {
@@ -16,11 +16,11 @@ func (x *contextPrm) SetContext(ctx context.Context) {
 }
 
 type objectAddressPrm struct {
-	objAddr *object.Address
+	objAddr *addressSDK.Address
 }
 
 // SetAddress sets address of the object.
-func (x *objectAddressPrm) SetAddress(addr *object.Address) {
+func (x *objectAddressPrm) SetAddress(addr *addressSDK.Address) {
 	x.objAddr = addr
 }
 

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -107,8 +107,8 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 	}
 }
 
-func (ap *Processor) findStorageGroups(cid *cid.ID, shuffled netmap.Nodes) []*object.ID {
-	var sg []*object.ID
+func (ap *Processor) findStorageGroups(cid *cid.ID, shuffled netmap.Nodes) []*oidSDK.ID {
+	var sg []*oidSDK.ID
 
 	ln := len(shuffled)
 

--- a/pkg/innerring/processors/audit/processor.go
+++ b/pkg/innerring/processors/audit/processor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/services/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
 )
@@ -89,11 +89,11 @@ func (x SearchSGPrm) NodeInfo() client.NodeInfo {
 
 // SearchSGDst groups target values which Processor expects from SG searching to process.
 type SearchSGDst struct {
-	ids []*object.ID
+	ids []*oidSDK.ID
 }
 
 // WriteIDList writes list of identifiers of storage group objects stored in the container.
-func (x *SearchSGDst) WriteIDList(ids []*object.ID) {
+func (x *SearchSGDst) WriteIDList(ids []*oidSDK.ID) {
 	x.ids = ids
 }
 

--- a/pkg/innerring/processors/settlement/audit/calculate.go
+++ b/pkg/innerring/processors/settlement/audit/calculate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"go.uber.org/zap"
 )
@@ -213,7 +213,7 @@ func (c *Calculator) sumSGSizes(ctx *singleResultCtx) bool {
 
 	sumPassSGSize := uint64(0)
 
-	addr := object.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetContainerID(ctx.containerID())
 
 	for _, sgID := range ctx.auditResult.PassSG() {

--- a/pkg/innerring/processors/settlement/audit/prm.go
+++ b/pkg/innerring/processors/settlement/audit/prm.go
@@ -3,7 +3,7 @@ package audit
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement/common"
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // CalculatorPrm groups the parameters of Calculator's constructor.
@@ -39,7 +39,7 @@ type SGInfo interface {
 // SGStorage is an interface of storage of the storage groups.
 type SGStorage interface {
 	// Must return information about the storage group by address.
-	SGInfo(*object.Address) (SGInfo, error)
+	SGInfo(*addressSDK.Address) (SGInfo, error)
 }
 
 // FeeFetcher wraps AuditFee method that returns audit fee price from

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -16,6 +16,8 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"go.uber.org/zap"
 )
@@ -59,15 +61,15 @@ func (c *ClientCache) Get(info clientcore.NodeInfo) (clientcore.Client, error) {
 
 // GetSG polls the container from audit task to get the object by id.
 // Returns storage groups structure from received object.
-func (c *ClientCache) GetSG(task *audit.Task, id *object.ID) (*storagegroup.StorageGroup, error) {
-	sgAddress := new(object.Address)
+func (c *ClientCache) GetSG(task *audit.Task, id *oidSDK.ID) (*storagegroup.StorageGroup, error) {
+	sgAddress := new(addressSDK.Address)
 	sgAddress.SetContainerID(task.ContainerID())
 	sgAddress.SetObjectID(id)
 
 	return c.getSG(task.AuditContext(), sgAddress, task.NetworkMap(), task.ContainerNodes())
 }
 
-func (c *ClientCache) getSG(ctx context.Context, addr *object.Address, nm *netmap.Netmap, cn netmap.ContainerNodes) (*storagegroup.StorageGroup, error) {
+func (c *ClientCache) getSG(ctx context.Context, addr *addressSDK.Address, nm *netmap.Netmap, cn netmap.ContainerNodes) (*storagegroup.StorageGroup, error) {
 	nodes, err := placement.BuildObjectPlacement(nm, cn, addr.ObjectID())
 	if err != nil {
 		return nil, fmt.Errorf("can't build object placement: %w", err)
@@ -121,8 +123,8 @@ func (c *ClientCache) getSG(ctx context.Context, addr *object.Address, nm *netma
 }
 
 // GetHeader requests node from the container under audit to return object header by id.
-func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.ID, relay bool) (*object.Object, error) {
-	objAddress := new(object.Address)
+func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *oidSDK.ID, relay bool) (*object.Object, error) {
+	objAddress := new(addressSDK.Address)
 	objAddress.SetContainerID(task.ContainerID())
 	objAddress.SetObjectID(id)
 
@@ -160,8 +162,8 @@ func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *object.
 
 // GetRangeHash requests node from the container under audit to return Tillich-Zemor hash of the
 // payload range of the object with specified identifier.
-func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id *object.ID, rng *object.Range) ([]byte, error) {
-	objAddress := new(object.Address)
+func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id *oidSDK.ID, rng *object.Range) ([]byte, error) {
+	objAddress := new(addressSDK.Address)
 	objAddress.SetContainerID(task.ContainerID())
 	objAddress.SetObjectID(id)
 

--- a/pkg/innerring/settlement.go
+++ b/pkg/innerring/settlement.go
@@ -22,7 +22,7 @@ import (
 	containerAPI "github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	netmapAPI "github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"go.uber.org/zap"
@@ -167,7 +167,7 @@ func (s settlementDeps) ContainerNodes(e uint64, cid *cid.ID) ([]common.NodeInfo
 	return res, nil
 }
 
-func (s settlementDeps) SGInfo(addr *object.Address) (audit.SGInfo, error) {
+func (s settlementDeps) SGInfo(addr *addressSDK.Address) (audit.SGInfo, error) {
 	cn, nm, err := s.buildContainer(0, addr.ContainerID())
 	if err != nil {
 		return nil, err

--- a/pkg/local_object_storage/blobovnicza/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobovnicza/blobovnicza_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,18 +23,18 @@ func testSHA256() (h [sha256.Size]byte) {
 	return h
 }
 
-func testAddress() *objectSDK.Address {
-	oid := objectSDK.NewID()
+func testAddress() *addressSDK.Address {
+	oid := oidSDK.NewID()
 	oid.SetSHA256(testSHA256())
 
-	addr := objectSDK.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetObjectID(oid)
 	addr.SetContainerID(cidtest.ID())
 
 	return addr
 }
 
-func testPutGet(t *testing.T, blz *Blobovnicza, sz uint64, expPut, expGet error) *objectSDK.Address {
+func testPutGet(t *testing.T, blz *Blobovnicza, sz uint64, expPut, expGet error) *addressSDK.Address {
 	// create binary object
 	data := make([]byte, sz)
 
@@ -55,7 +56,7 @@ func testPutGet(t *testing.T, blz *Blobovnicza, sz uint64, expPut, expGet error)
 	return addr
 }
 
-func testGet(t *testing.T, blz *Blobovnicza, addr *objectSDK.Address, expObj []byte, expErr error) {
+func testGet(t *testing.T, blz *Blobovnicza, addr *addressSDK.Address, expObj []byte, expErr error) {
 	pGet := new(GetPrm)
 	pGet.SetAddress(addr)
 

--- a/pkg/local_object_storage/blobovnicza/delete.go
+++ b/pkg/local_object_storage/blobovnicza/delete.go
@@ -2,14 +2,14 @@ package blobovnicza
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // DeleteRes groups resulting values of Delete operation.
@@ -17,7 +17,7 @@ type DeleteRes struct {
 }
 
 // SetAddress sets address of the requested object.
-func (p *DeletePrm) SetAddress(addr *objectSDK.Address) {
+func (p *DeletePrm) SetAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 

--- a/pkg/local_object_storage/blobovnicza/get.go
+++ b/pkg/local_object_storage/blobovnicza/get.go
@@ -2,14 +2,14 @@ package blobovnicza
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // GetRes groups resulting values of Get operation.
@@ -18,7 +18,7 @@ type GetRes struct {
 }
 
 // SetAddress sets address of the requested object.
-func (p *GetPrm) SetAddress(addr *objectSDK.Address) {
+func (p *GetPrm) SetAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 

--- a/pkg/local_object_storage/blobovnicza/get_range.go
+++ b/pkg/local_object_storage/blobovnicza/get_range.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // GetRangePrm groups the parameters of GetRange operation.
 type GetRangePrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 
 	rng *objectSDK.Range
 }
@@ -20,7 +21,7 @@ type GetRangeRes struct {
 }
 
 // SetAddress sets address of the requested object.
-func (p *GetRangePrm) SetAddress(addr *objectSDK.Address) {
+func (p *GetRangePrm) SetAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 

--- a/pkg/local_object_storage/blobovnicza/iterate.go
+++ b/pkg/local_object_storage/blobovnicza/iterate.go
@@ -3,7 +3,7 @@ package blobovnicza
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
@@ -57,7 +57,7 @@ func max(a, b uint64) uint64 {
 
 // IterationElement represents a unit of elements through which Iterate operation passes.
 type IterationElement struct {
-	addr *object.Address
+	addr *addressSDK.Address
 
 	data []byte
 }
@@ -68,7 +68,7 @@ func (x IterationElement) ObjectData() []byte {
 }
 
 // Address returns address of the stored object.
-func (x IterationElement) Address() *object.Address {
+func (x IterationElement) Address() *addressSDK.Address {
 	return x.addr
 }
 
@@ -125,7 +125,7 @@ func (b *Blobovnicza) Iterate(prm IteratePrm) (*IterateRes, error) {
 			return buck.ForEach(func(k, v []byte) error {
 				if prm.decodeAddresses {
 					if elem.addr == nil {
-						elem.addr = object.NewAddress()
+						elem.addr = addressSDK.NewAddress()
 					}
 
 					if err := addressFromKey(elem.addr, k); err != nil {
@@ -164,7 +164,7 @@ func IterateObjects(blz *Blobovnicza, f func([]byte) error) error {
 }
 
 // IterateAddresses is a helper function which iterates over Blobovnicza and passes addresses of the objects to f.
-func IterateAddresses(blz *Blobovnicza, f func(*object.Address) error) error {
+func IterateAddresses(blz *Blobovnicza, f func(*addressSDK.Address) error) error {
 	var prm IteratePrm
 
 	prm.DecodeAddresses()

--- a/pkg/local_object_storage/blobovnicza/iterate_test.go
+++ b/pkg/local_object_storage/blobovnicza/iterate_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )

--- a/pkg/local_object_storage/blobovnicza/put.go
+++ b/pkg/local_object_storage/blobovnicza/put.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // PutPrm groups the parameters of Put operation.
 type PutPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 
 	objData []byte
 }
@@ -26,7 +26,7 @@ var ErrFull = errors.New("blobovnicza is full")
 var errNilAddress = errors.New("object address is nil")
 
 // SetAddress sets address of saving object.
-func (p *PutPrm) SetAddress(addr *objectSDK.Address) {
+func (p *PutPrm) SetAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 
@@ -86,10 +86,10 @@ func (b *Blobovnicza) Put(prm *PutPrm) (*PutRes, error) {
 	return nil, err
 }
 
-func addressKey(addr *objectSDK.Address) []byte {
+func addressKey(addr *addressSDK.Address) []byte {
 	return []byte(addr.String())
 }
 
-func addressFromKey(dst *objectSDK.Address, data []byte) error {
+func addressFromKey(dst *addressSDK.Address, data []byte) error {
 	return dst.Parse(string(data))
 }

--- a/pkg/local_object_storage/blobstor/blobovnicza.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -132,7 +132,7 @@ func indexSlice(number uint64) []uint64 {
 // save object in the maximum weight blobobnicza.
 //
 // returns error if could not save object in any blobovnicza.
-func (b *blobovniczas) put(addr *objectSDK.Address, data []byte) (*blobovnicza.ID, error) {
+func (b *blobovniczas) put(addr *addressSDK.Address, data []byte) (*blobovnicza.ID, error) {
 	prm := new(blobovnicza.PutPrm)
 	prm.SetAddress(addr)
 	prm.SetMarshaledObject(data)
@@ -648,7 +648,7 @@ func (b *blobovniczas) iterateBlobovniczas(ignoreErrors bool, f func(string, *bl
 }
 
 // iterator over the paths of blobovniczas sorted by weight.
-func (b *blobovniczas) iterateSortedLeaves(addr *objectSDK.Address, f func(string) (bool, error)) error {
+func (b *blobovniczas) iterateSortedLeaves(addr *addressSDK.Address, f func(string) (bool, error)) error {
 	_, err := b.iterateSorted(
 		addr,
 		make([]string, 0, b.blzShallowDepth),
@@ -660,7 +660,7 @@ func (b *blobovniczas) iterateSortedLeaves(addr *objectSDK.Address, f func(strin
 }
 
 // iterator over directories with blobovniczas sorted by weight.
-func (b *blobovniczas) iterateDeepest(addr *objectSDK.Address, f func(string) (bool, error)) error {
+func (b *blobovniczas) iterateDeepest(addr *addressSDK.Address, f func(string) (bool, error)) error {
 	depth := b.blzShallowDepth
 	if depth > 0 {
 		depth--
@@ -677,7 +677,7 @@ func (b *blobovniczas) iterateDeepest(addr *objectSDK.Address, f func(string) (b
 }
 
 // iterator over particular level of directories.
-func (b *blobovniczas) iterateSorted(addr *objectSDK.Address, curPath []string, execDepth uint64, f func([]string) (bool, error)) (bool, error) {
+func (b *blobovniczas) iterateSorted(addr *addressSDK.Address, curPath []string, execDepth uint64, f func([]string) (bool, error)) (bool, error) {
 	indices := indexSlice(b.blzShallowWidth)
 
 	hrw.SortSliceByValue(indices, addressHash(addr, filepath.Join(curPath...)))
@@ -906,7 +906,7 @@ func (b *blobovniczas) openBlobovnicza(p string) (*blobovnicza.Blobovnicza, erro
 }
 
 // returns hash of the object address.
-func addressHash(addr *objectSDK.Address, path string) uint64 {
+func addressHash(addr *addressSDK.Address, path string) uint64 {
 	var a string
 
 	if addr != nil {

--- a/pkg/local_object_storage/blobstor/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,11 +22,11 @@ func testSHA256() (h [sha256.Size]byte) {
 	return h
 }
 
-func testAddress() *objectSDK.Address {
-	oid := objectSDK.NewID()
+func testAddress() *addressSDK.Address {
+	oid := oidSDK.NewID()
 	oid.SetSHA256(testSHA256())
 
-	addr := objectSDK.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetObjectID(oid)
 	addr.SetContainerID(cidtest.ID())
 
@@ -84,7 +86,7 @@ func TestBlobovniczas(t *testing.T) {
 
 	objSz := uint64(szLim / 2)
 
-	addrList := make([]*objectSDK.Address, 0)
+	addrList := make([]*addressSDK.Address, 0)
 	minFitObjNum := width * depth * szLim / objSz
 
 	for i := uint64(0); i < minFitObjNum; i++ {

--- a/pkg/local_object_storage/blobstor/exists.go
+++ b/pkg/local_object_storage/blobstor/exists.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // ExistsPrm groups the parameters of Exists operation.
@@ -46,7 +46,7 @@ func (b *BlobStor) Exists(prm *ExistsPrm) (*ExistsRes, error) {
 }
 
 // checks if object is presented in shallow dir.
-func (b *BlobStor) existsBig(addr *object.Address) (bool, error) {
+func (b *BlobStor) existsBig(addr *addressSDK.Address) (bool, error) {
 	_, err := b.fsTree.Exists(addr)
 	if errors.Is(err, fstree.ErrFileNotFound) {
 		return false, nil
@@ -56,7 +56,7 @@ func (b *BlobStor) existsBig(addr *object.Address) (bool, error) {
 }
 
 // checks if object is presented in blobovnicza.
-func (b *BlobStor) existsSmall(addr *object.Address) (bool, error) {
+func (b *BlobStor) existsSmall(_ *addressSDK.Address) (bool, error) {
 	// TODO: implement
 	return false, nil
 }

--- a/pkg/local_object_storage/blobstor/fstree/fstree_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree_test.go
@@ -10,23 +10,24 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
-func testOID() *objectSDK.ID {
+func testOID() *oidSDK.ID {
 	cs := [sha256.Size]byte{}
 	_, _ = rand.Read(cs[:])
 
-	id := objectSDK.NewID()
+	id := oidSDK.NewID()
 	id.SetSHA256(cs)
 
 	return id
 }
 
-func testAddress() *objectSDK.Address {
-	a := objectSDK.NewAddress()
+func testAddress() *addressSDK.Address {
+	a := addressSDK.NewAddress()
 	a.SetObjectID(testOID())
 	a.SetContainerID(cidtest.ID())
 
@@ -56,7 +57,7 @@ func TestFSTree(t *testing.T) {
 	}
 
 	const count = 3
-	var addrs []*objectSDK.Address
+	var addrs []*addressSDK.Address
 
 	store := map[string][]byte{}
 
@@ -93,7 +94,7 @@ func TestFSTree(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		n := 0
-		err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
+		err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 			n++
 			expected, ok := store[addr.String()]
 			require.True(t, ok, "object %s was not found", addr.String())
@@ -107,7 +108,7 @@ func TestFSTree(t *testing.T) {
 		t.Run("leave early", func(t *testing.T) {
 			n := 0
 			errStop := errors.New("stop")
-			err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
+			err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 				if n++; n == count-1 {
 					return errStop
 				}
@@ -134,7 +135,7 @@ func TestFSTree(t *testing.T) {
 			require.NoError(t, util.MkdirAllX(filepath.Dir(p), fs.Permissions))
 			require.NoError(t, os.WriteFile(p, []byte{1, 2, 3}, fs.Permissions))
 
-			err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
+			err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 				n++
 				return nil
 			}).WithIgnoreErrors(true))
@@ -144,7 +145,7 @@ func TestFSTree(t *testing.T) {
 			t.Run("error from handler is returned", func(t *testing.T) {
 				expectedErr := errors.New("expected error")
 				n := 0
-				err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
+				err := fs.Iterate(new(IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 					n++
 					if n == count/2 { // process some iterations
 						return expectedErr

--- a/pkg/local_object_storage/blobstor/iterate.go
+++ b/pkg/local_object_storage/blobstor/iterate.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // IterationElement represents a unit of elements through which Iterate operation passes.
@@ -88,7 +88,7 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 
 	elem.blzID = nil
 
-	err = b.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(_ *objectSDK.Address, data []byte) error {
+	err = b.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(_ *addressSDK.Address, data []byte) error {
 		// decompress the data
 		elem.data, err = b.decompressor(data)
 		if err != nil {

--- a/pkg/local_object_storage/blobstor/iterate_test.go
+++ b/pkg/local_object_storage/blobstor/iterate_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +45,7 @@ func TestIterateObjects(t *testing.T) {
 
 	type addrData struct {
 		big  bool
-		addr *object.Address
+		addr *addressSDK.Address
 		data []byte
 	}
 
@@ -113,7 +114,7 @@ func TestIterate_IgnoreErrors(t *testing.T) {
 	require.NoError(t, bs.Open())
 	require.NoError(t, bs.Init())
 
-	addrs := make([]*object.Address, objCount)
+	addrs := make([]*addressSDK.Address, objCount)
 	for i := range addrs {
 		addrs[i] = objecttest.Address()
 		obj := object.NewRaw()
@@ -170,7 +171,7 @@ func TestIterate_IgnoreErrors(t *testing.T) {
 	prm.IgnoreErrors()
 
 	t.Run("skip invalid objects", func(t *testing.T) {
-		actual := make([]*object.Address, 0, len(addrs))
+		actual := make([]*addressSDK.Address, 0, len(addrs))
 		prm.SetIterationHandler(func(e IterationElement) error {
 			obj := object.New()
 			err := obj.Unmarshal(e.data)
@@ -178,7 +179,7 @@ func TestIterate_IgnoreErrors(t *testing.T) {
 				return err
 			}
 
-			addr := object.NewAddress()
+			addr := addressSDK.NewAddress()
 			addr.SetContainerID(obj.ContainerID())
 			addr.SetObjectID(obj.ID())
 			actual = append(actual, addr)

--- a/pkg/local_object_storage/blobstor/put.go
+++ b/pkg/local_object_storage/blobstor/put.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // PutPrm groups the parameters of Put operation.
@@ -69,7 +70,7 @@ func (b *BlobStor) NeedsCompression(obj *object.Object) bool {
 }
 
 // PutRaw saves already marshaled object in BLOB storage.
-func (b *BlobStor) PutRaw(addr *objectSDK.Address, data []byte, compress bool) (*PutRes, error) {
+func (b *BlobStor) PutRaw(addr *addressSDK.Address, data []byte, compress bool) (*PutRes, error) {
 	big := b.isBig(data)
 
 	if compress {

--- a/pkg/local_object_storage/blobstor/util.go
+++ b/pkg/local_object_storage/blobstor/util.go
@@ -4,14 +4,15 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type address struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // SetAddress sets the address of the requested object.
-func (a *address) SetAddress(addr *objectSDK.Address) {
+func (a *address) SetAddress(addr *addressSDK.Address) {
 	a.addr = addr
 }
 

--- a/pkg/local_object_storage/engine/delete.go
+++ b/pkg/local_object_storage/engine/delete.go
@@ -2,12 +2,12 @@ package engine
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr []*objectSDK.Address
+	addr []*addressSDK.Address
 }
 
 // DeleteRes groups resulting values of Delete operation.
@@ -16,7 +16,7 @@ type DeleteRes struct{}
 // WithAddresses is a Delete option to set the addresses of the objects to delete.
 //
 // Option is required.
-func (p *DeletePrm) WithAddresses(addr ...*objectSDK.Address) *DeletePrm {
+func (p *DeletePrm) WithAddresses(addr ...*addressSDK.Address) *DeletePrm {
 	if p != nil {
 		p.addr = append(p.addr, addr...)
 	}

--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -77,11 +78,11 @@ func testNewShard(t *testing.T, id int) *shard.Shard {
 	return s
 }
 
-func testOID() *objectSDK.ID {
+func testOID() *oidSDK.ID {
 	cs := [sha256.Size]byte{}
 	_, _ = rand.Read(cs[:])
 
-	id := objectSDK.NewID()
+	id := oidSDK.NewID()
 	id.SetSHA256(cs)
 
 	return id

--- a/pkg/local_object_storage/engine/exists.go
+++ b/pkg/local_object_storage/engine/exists.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
-func (e *StorageEngine) exists(addr *objectSDK.Address) (bool, error) {
+func (e *StorageEngine) exists(addr *addressSDK.Address) (bool, error) {
 	shPrm := new(shard.ExistsPrm).WithAddress(addr)
 	alreadyRemoved := false
 	exists := false

--- a/pkg/local_object_storage/engine/get.go
+++ b/pkg/local_object_storage/engine/get.go
@@ -7,11 +7,12 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // GetRes groups resulting values of Get operation.
@@ -22,7 +23,7 @@ type GetRes struct {
 // WithAddress is a Get option to set the address of the requested object.
 //
 // Option is required.
-func (p *GetPrm) WithAddress(addr *objectSDK.Address) *GetPrm {
+func (p *GetPrm) WithAddress(addr *addressSDK.Address) *GetPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -118,7 +119,7 @@ func (e *StorageEngine) get(prm *GetPrm) (*GetRes, error) {
 }
 
 // Get reads object from local storage by provided address.
-func Get(storage *StorageEngine, addr *objectSDK.Address) (*object.Object, error) {
+func Get(storage *StorageEngine, addr *addressSDK.Address) (*object.Object, error) {
 	res, err := storage.Get(new(GetPrm).
 		WithAddress(addr),
 	)

--- a/pkg/local_object_storage/engine/head.go
+++ b/pkg/local_object_storage/engine/head.go
@@ -7,11 +7,12 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // HeadPrm groups the parameters of Head operation.
 type HeadPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 	raw  bool
 }
 
@@ -23,7 +24,7 @@ type HeadRes struct {
 // WithAddress is a Head option to set the address of the requested object.
 //
 // Option is required.
-func (p *HeadPrm) WithAddress(addr *objectSDK.Address) *HeadPrm {
+func (p *HeadPrm) WithAddress(addr *addressSDK.Address) *HeadPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -134,7 +135,7 @@ func (e *StorageEngine) head(prm *HeadPrm) (*HeadRes, error) {
 }
 
 // Head reads object header from local storage by provided address.
-func Head(storage *StorageEngine, addr *objectSDK.Address) (*object.Object, error) {
+func Head(storage *StorageEngine, addr *addressSDK.Address) (*object.Object, error) {
 	res, err := storage.Head(new(HeadPrm).
 		WithAddress(addr),
 	)
@@ -147,7 +148,7 @@ func Head(storage *StorageEngine, addr *objectSDK.Address) (*object.Object, erro
 
 // HeadRaw reads object header from local storage by provided address and raw
 // flag.
-func HeadRaw(storage *StorageEngine, addr *objectSDK.Address, raw bool) (*object.Object, error) {
+func HeadRaw(storage *StorageEngine, addr *addressSDK.Address, raw bool) (*object.Object, error) {
 	res, err := storage.Head(new(HeadPrm).
 		WithAddress(addr).
 		WithRaw(raw),

--- a/pkg/local_object_storage/engine/head_test.go
+++ b/pkg/local_object_storage/engine/head_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func TestHeadRaw(t *testing.T) {
 	parent := generateRawObjectWithCID(t, cid)
 	addAttribute(parent, "foo", "bar")
 
-	parentAddr := objectSDK.NewAddress()
+	parentAddr := addressSDK.NewAddress()
 	parentAddr.SetContainerID(cid)
 	parentAddr.SetObjectID(parent.ID())
 

--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -7,12 +7,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // InhumePrm encapsulates parameters for inhume operation.
 type InhumePrm struct {
-	tombstone *objectSDK.Address
-	addrs     []*objectSDK.Address
+	tombstone *addressSDK.Address
+	addrs     []*addressSDK.Address
 }
 
 // InhumeRes encapsulates results of inhume operation.
@@ -23,7 +24,7 @@ type InhumeRes struct{}
 //
 // tombstone should not be nil, addr should not be empty.
 // Should not be called along with MarkAsGarbage.
-func (p *InhumePrm) WithTarget(tombstone *objectSDK.Address, addrs ...*objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) WithTarget(tombstone *addressSDK.Address, addrs ...*addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.addrs = addrs
 		p.tombstone = tombstone
@@ -35,7 +36,7 @@ func (p *InhumePrm) WithTarget(tombstone *objectSDK.Address, addrs ...*objectSDK
 // MarkAsGarbage marks object to be physically removed from local storage.
 //
 // Should not be called along with WithTarget.
-func (p *InhumePrm) MarkAsGarbage(addrs ...*objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) MarkAsGarbage(addrs ...*addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.addrs = addrs
 		p.tombstone = nil
@@ -85,7 +86,7 @@ func (e *StorageEngine) inhume(prm *InhumePrm) (*InhumeRes, error) {
 	return new(InhumeRes), nil
 }
 
-func (e *StorageEngine) inhumeAddr(addr *objectSDK.Address, prm *shard.InhumePrm, checkExists bool) (ok bool) {
+func (e *StorageEngine) inhumeAddr(addr *addressSDK.Address, prm *shard.InhumePrm, checkExists bool) (ok bool) {
 	root := false
 
 	e.iterateOverSortedShards(addr, func(_ int, sh hashedShard) (stop bool) {
@@ -133,7 +134,7 @@ func (e *StorageEngine) inhumeAddr(addr *objectSDK.Address, prm *shard.InhumePrm
 	return
 }
 
-func (e *StorageEngine) processExpiredTombstones(ctx context.Context, addrs []*objectSDK.Address) {
+func (e *StorageEngine) processExpiredTombstones(ctx context.Context, addrs []*addressSDK.Address) {
 	tss := make(map[string]struct{}, len(addrs))
 
 	for i := range addrs {

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // ErrEndOfListing is returned from object listing with cursor
@@ -40,12 +40,12 @@ func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 
 // ListWithCursorRes contains values returned from ListWithCursor operation.
 type ListWithCursorRes struct {
-	addrList []*object.Address
+	addrList []*addressSDK.Address
 	cursor   *Cursor
 }
 
 // AddressList returns addresses selected by ListWithCursor operation.
-func (l ListWithCursorRes) AddressList() []*object.Address {
+func (l ListWithCursorRes) AddressList() []*addressSDK.Address {
 	return l.addrList
 }
 
@@ -62,7 +62,7 @@ func (l ListWithCursorRes) Cursor() *Cursor {
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
 func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
-	result := make([]*object.Address, 0, prm.count)
+	result := make([]*addressSDK.Address, 0, prm.count)
 
 	// 1. Get available shards and sort them.
 	e.mtx.RLock()

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,8 +23,8 @@ func TestListWithCursor(t *testing.T) {
 
 	const total = 20
 
-	expected := make([]*object.Address, 0, total)
-	got := make([]*object.Address, 0, total)
+	expected := make([]*addressSDK.Address, 0, total)
+	got := make([]*addressSDK.Address, 0, total)
 
 	for i := 0; i < total; i++ {
 		containerID := cidtest.ID()
@@ -58,7 +58,7 @@ func TestListWithCursor(t *testing.T) {
 	require.Equal(t, expected, got)
 }
 
-func sortAddresses(addr []*object.Address) []*object.Address {
+func sortAddresses(addr []*addressSDK.Address) []*addressSDK.Address {
 	sort.Slice(addr, func(i, j int) bool {
 		return addr[i].String() < addr[j].String()
 	})

--- a/pkg/local_object_storage/engine/range.go
+++ b/pkg/local_object_storage/engine/range.go
@@ -7,13 +7,14 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // RngPrm groups the parameters of GetRange operation.
 type RngPrm struct {
 	off, ln uint64
 
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // RngRes groups resulting values of GetRange operation.
@@ -24,7 +25,7 @@ type RngRes struct {
 // WithAddress is a GetRng option to set the address of the requested object.
 //
 // Option is required.
-func (p *RngPrm) WithAddress(addr *objectSDK.Address) *RngPrm {
+func (p *RngPrm) WithAddress(addr *addressSDK.Address) *RngPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -139,7 +140,7 @@ func (e *StorageEngine) getRange(prm *RngPrm) (*RngRes, error) {
 }
 
 // GetRange reads object payload range from local storage by provided address.
-func GetRange(storage *StorageEngine, addr *objectSDK.Address, rng *objectSDK.Range) ([]byte, error) {
+func GetRange(storage *StorageEngine, addr *addressSDK.Address, rng *objectSDK.Range) ([]byte, error) {
 	res, err := storage.GetRange(new(RngPrm).
 		WithAddress(addr).
 		WithPayloadRange(rng),

--- a/pkg/local_object_storage/engine/select.go
+++ b/pkg/local_object_storage/engine/select.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // SelectPrm groups the parameters of Select operation.
@@ -17,7 +18,7 @@ type SelectPrm struct {
 
 // SelectRes groups resulting values of Select operation.
 type SelectRes struct {
-	addrList []*object.Address
+	addrList []*addressSDK.Address
 }
 
 // WithContainerID is a Select option to set the container id to search in.
@@ -39,7 +40,7 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) *SelectPrm {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []*object.Address {
+func (r *SelectRes) AddressList() []*addressSDK.Address {
 	return r.addrList
 }
 
@@ -62,7 +63,7 @@ func (e *StorageEngine) _select(prm *SelectPrm) (*SelectRes, error) {
 		defer elapsed(e.metrics.AddSearchDuration)()
 	}
 
-	addrList := make([]*object.Address, 0)
+	addrList := make([]*addressSDK.Address, 0)
 	uniqueMap := make(map[string]struct{})
 
 	var outError error
@@ -119,7 +120,7 @@ func (e *StorageEngine) list(limit uint64) (*SelectRes, error) {
 		defer elapsed(e.metrics.AddListObjectsDuration)()
 	}
 
-	addrList := make([]*object.Address, 0, limit)
+	addrList := make([]*addressSDK.Address, 0, limit)
 	uniqueMap := make(map[string]struct{})
 	ln := uint64(0)
 
@@ -151,7 +152,7 @@ func (e *StorageEngine) list(limit uint64) (*SelectRes, error) {
 }
 
 // Select selects objects from local storage using provided filters.
-func Select(storage *StorageEngine, cid *cid.ID, fs object.SearchFilters) ([]*object.Address, error) {
+func Select(storage *StorageEngine, cid *cid.ID, fs object.SearchFilters) ([]*addressSDK.Address, error) {
 	res, err := storage.Select(new(SelectPrm).
 		WithContainerID(cid).
 		WithFilters(fs),
@@ -165,7 +166,7 @@ func Select(storage *StorageEngine, cid *cid.ID, fs object.SearchFilters) ([]*ob
 
 // List returns `limit` available physically storage object addresses in
 // engine. If limit is zero, then returns all available object addresses.
-func List(storage *StorageEngine, limit uint64) ([]*object.Address, error) {
+func List(storage *StorageEngine, limit uint64) ([]*addressSDK.Address, error) {
 	res, err := storage.List(limit)
 	if err != nil {
 		return nil, err

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nspcc-dev/hrw"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/atomic"
 )
@@ -99,7 +99,7 @@ func (e *StorageEngine) unsortedShards() []hashedShard {
 	return shards
 }
 
-func (e *StorageEngine) iterateOverSortedShards(addr *object.Address, handler func(int, hashedShard) (stop bool)) {
+func (e *StorageEngine) iterateOverSortedShards(addr *addressSDK.Address, handler func(int, hashedShard) (stop bool)) {
 	for i, sh := range e.sortShardsByWeight(addr) {
 		if handler(i, sh) {
 			break

--- a/pkg/local_object_storage/metabase/control_test.go
+++ b/pkg/local_object_storage/metabase/control_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +20,7 @@ func TestReset(t *testing.T) {
 
 	addrToInhume := generateAddress()
 
-	assertExists := func(addr *objectSDK.Address, expExists bool, expErr error) {
+	assertExists := func(addr *addressSDK.Address, expExists bool, expErr error) {
 		exists, err := meta.Exists(db, addr)
 		require.ErrorIs(t, err, expErr)
 		require.Equal(t, expExists, exists)

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -13,6 +13,8 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -25,7 +27,7 @@ func putBig(db *meta.DB, obj *object.Object) error {
 	return meta.Put(db, obj, nil)
 }
 
-func testSelect(t *testing.T, db *meta.DB, cid *cid.ID, fs objectSDK.SearchFilters, exp ...*objectSDK.Address) {
+func testSelect(t *testing.T, db *meta.DB, cid *cid.ID, fs objectSDK.SearchFilters, exp ...*addressSDK.Address) {
 	res, err := meta.Select(db, cid, fs)
 	require.NoError(t, err)
 	require.Len(t, res, len(exp))
@@ -35,11 +37,11 @@ func testSelect(t *testing.T, db *meta.DB, cid *cid.ID, fs objectSDK.SearchFilte
 	}
 }
 
-func testOID() *objectSDK.ID {
+func testOID() *oidSDK.ID {
 	cs := [sha256.Size]byte{}
 	_, _ = rand.Read(cs[:])
 
-	id := objectSDK.NewID()
+	id := oidSDK.NewID()
 	id.SetSHA256(cs)
 
 	return id
@@ -87,8 +89,8 @@ func generateRawObjectWithCID(t *testing.T, cid *cid.ID) *object.RawObject {
 	return obj
 }
 
-func generateAddress() *objectSDK.Address {
-	addr := objectSDK.NewAddress()
+func generateAddress() *addressSDK.Address {
+	addr := addressSDK.NewAddress()
 	addr.SetContainerID(cidtest.ID())
 	addr.SetObjectID(testOID())
 

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addrs []*objectSDK.Address
+	addrs []*addressSDK.Address
 }
 
 // DeleteRes groups resulting values of Delete operation.
@@ -21,7 +22,7 @@ type DeleteRes struct{}
 // WithAddresses is a Delete option to set the addresses of the objects to delete.
 //
 // Option is required.
-func (p *DeletePrm) WithAddresses(addrs ...*objectSDK.Address) *DeletePrm {
+func (p *DeletePrm) WithAddresses(addrs ...*addressSDK.Address) *DeletePrm {
 	if p != nil {
 		p.addrs = addrs
 	}
@@ -30,7 +31,7 @@ func (p *DeletePrm) WithAddresses(addrs ...*objectSDK.Address) *DeletePrm {
 }
 
 // Delete removes objects from DB.
-func Delete(db *DB, addrs ...*objectSDK.Address) error {
+func Delete(db *DB, addrs ...*addressSDK.Address) error {
 	_, err := db.Delete(new(DeletePrm).WithAddresses(addrs...))
 	return err
 }
@@ -38,7 +39,7 @@ func Delete(db *DB, addrs ...*objectSDK.Address) error {
 type referenceNumber struct {
 	all, cur int
 
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 
 	obj *object.Object
 }
@@ -52,7 +53,7 @@ func (db *DB) Delete(prm *DeletePrm) (*DeleteRes, error) {
 	})
 }
 
-func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []*objectSDK.Address) error {
+func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []*addressSDK.Address) error {
 	refCounter := make(referenceCounter, len(addrs))
 
 	for i := range addrs {
@@ -74,7 +75,7 @@ func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []*objectSDK.Address) error {
 	return nil
 }
 
-func (db *DB) delete(tx *bbolt.Tx, addr *objectSDK.Address, refCounter referenceCounter) error {
+func (db *DB) delete(tx *bbolt.Tx, addr *addressSDK.Address, refCounter referenceCounter) error {
 	// remove record from graveyard
 	graveyard := tx.Bucket(graveyardBucketName)
 	if graveyard != nil {
@@ -158,7 +159,7 @@ func (db *DB) deleteObject(
 }
 
 // parentLength returns amount of available children from parentid index.
-func parentLength(tx *bbolt.Tx, addr *objectSDK.Address) int {
+func parentLength(tx *bbolt.Tx, addr *addressSDK.Address) int {
 	bkt := tx.Bucket(parentBucketName(addr.ContainerID()))
 	if bkt == nil {
 		return 0

--- a/pkg/local_object_storage/metabase/exists.go
+++ b/pkg/local_object_storage/metabase/exists.go
@@ -8,12 +8,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // ExistsPrm groups the parameters of Exists operation.
 type ExistsPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // ExistsRes groups resulting values of Exists operation.
@@ -24,7 +25,7 @@ type ExistsRes struct {
 var ErrLackSplitInfo = errors.New("no split info on parent object")
 
 // WithAddress is an Exists option to set object checked for existence.
-func (p *ExistsPrm) WithAddress(addr *objectSDK.Address) *ExistsPrm {
+func (p *ExistsPrm) WithAddress(addr *addressSDK.Address) *ExistsPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -38,7 +39,7 @@ func (p *ExistsRes) Exists() bool {
 }
 
 // Exists checks if object is presented in DB.
-func Exists(db *DB, addr *objectSDK.Address) (bool, error) {
+func Exists(db *DB, addr *addressSDK.Address) (bool, error) {
 	r, err := db.Exists(new(ExistsPrm).WithAddress(addr))
 	if err != nil {
 		return false, err
@@ -61,7 +62,7 @@ func (db *DB) Exists(prm *ExistsPrm) (res *ExistsRes, err error) {
 	return
 }
 
-func (db *DB) exists(tx *bbolt.Tx, addr *objectSDK.Address) (exists bool, err error) {
+func (db *DB) exists(tx *bbolt.Tx, addr *addressSDK.Address) (exists bool, err error) {
 	// check graveyard first
 	switch inGraveyard(tx, addr) {
 	case 1:
@@ -100,7 +101,7 @@ func (db *DB) exists(tx *bbolt.Tx, addr *objectSDK.Address) (exists bool, err er
 //  * 0 if object is not in graveyard;
 //  * 1 if object is in graveyard with GC mark;
 //  * 2 if object is in graveyard with tombstone.
-func inGraveyard(tx *bbolt.Tx, addr *objectSDK.Address) uint8 {
+func inGraveyard(tx *bbolt.Tx, addr *addressSDK.Address) uint8 {
 	graveyard := tx.Bucket(graveyardBucketName)
 	if graveyard == nil {
 		return 0

--- a/pkg/local_object_storage/metabase/get.go
+++ b/pkg/local_object_storage/metabase/get.go
@@ -6,12 +6,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 	raw  bool
 }
 
@@ -23,7 +24,7 @@ type GetRes struct {
 // WithAddress is a Get option to set the address of the requested object.
 //
 // Option is required.
-func (p *GetPrm) WithAddress(addr *objectSDK.Address) *GetPrm {
+func (p *GetPrm) WithAddress(addr *addressSDK.Address) *GetPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -48,7 +49,7 @@ func (r *GetRes) Header() *object.Object {
 }
 
 // Get reads the object from DB.
-func Get(db *DB, addr *objectSDK.Address) (*object.Object, error) {
+func Get(db *DB, addr *addressSDK.Address) (*object.Object, error) {
 	r, err := db.Get(new(GetPrm).WithAddress(addr))
 	if err != nil {
 		return nil, err
@@ -58,7 +59,7 @@ func Get(db *DB, addr *objectSDK.Address) (*object.Object, error) {
 }
 
 // GetRaw reads physically stored object from DB.
-func GetRaw(db *DB, addr *objectSDK.Address, raw bool) (*object.Object, error) {
+func GetRaw(db *DB, addr *addressSDK.Address, raw bool) (*object.Object, error) {
 	r, err := db.Get(new(GetPrm).WithAddress(addr).WithRaw(raw))
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func (db *DB) Get(prm *GetPrm) (res *GetRes, err error) {
 	return
 }
 
-func (db *DB) get(tx *bbolt.Tx, addr *objectSDK.Address, checkGraveyard, raw bool) (*object.Object, error) {
+func (db *DB) get(tx *bbolt.Tx, addr *addressSDK.Address, checkGraveyard, raw bool) (*object.Object, error) {
 	obj := object.New()
 	key := objectKey(addr.ObjectID())
 	cid := addr.ContainerID()

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
@@ -13,7 +13,7 @@ import (
 type Grave struct {
 	gcMark bool
 
-	addr *object.Address
+	addr *addressSDK.Address
 }
 
 // WithGCMark returns true if grave marked for GC to be removed.
@@ -22,7 +22,7 @@ func (g *Grave) WithGCMark() bool {
 }
 
 // Address returns buried object address.
-func (g *Grave) Address() *object.Address {
+func (g *Grave) Address() *addressSDK.Address {
 	return g.addr
 }
 

--- a/pkg/local_object_storage/metabase/graveyard_test.go
+++ b/pkg/local_object_storage/metabase/graveyard_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +42,7 @@ func TestDB_IterateOverGraveyard(t *testing.T) {
 
 	var (
 		counterAll         int
-		buriedTS, buriedGC []*object.Address
+		buriedTS, buriedGC []*addressSDK.Address
 	)
 
 	err = db.IterateOverGraveyard(func(g *meta.Grave) error {
@@ -60,6 +60,6 @@ func TestDB_IterateOverGraveyard(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, counterAll)
-	require.Equal(t, []*object.Address{obj1.Object().Address()}, buriedTS)
-	require.Equal(t, []*object.Address{obj2.Object().Address()}, buriedGC)
+	require.Equal(t, []*addressSDK.Address{obj1.Object().Address()}, buriedTS)
+	require.Equal(t, []*addressSDK.Address{obj2.Object().Address()}, buriedGC)
 }

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -6,21 +6,22 @@ import (
 	"fmt"
 
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // InhumePrm encapsulates parameters for Inhume operation.
 type InhumePrm struct {
-	tomb *objectSDK.Address
+	tomb *addressSDK.Address
 
-	target []*objectSDK.Address
+	target []*addressSDK.Address
 }
 
 // InhumeRes encapsulates results of Inhume operation.
 type InhumeRes struct{}
 
 // WithAddresses sets list of object addresses that should be inhumed.
-func (p *InhumePrm) WithAddresses(addrs ...*objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) WithAddresses(addrs ...*addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.target = addrs
 	}
@@ -32,7 +33,7 @@ func (p *InhumePrm) WithAddresses(addrs ...*objectSDK.Address) *InhumePrm {
 //
 // addr should not be nil.
 // Should not be called along with WithGCMark.
-func (p *InhumePrm) WithTombstoneAddress(addr *objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) WithTombstoneAddress(addr *addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.tomb = addr
 	}
@@ -54,7 +55,7 @@ func (p *InhumePrm) WithGCMark() *InhumePrm {
 // Inhume inhumes the object by specified address.
 //
 // tomb should not be nil.
-func Inhume(db *DB, target, tomb *objectSDK.Address) error {
+func Inhume(db *DB, target, tomb *addressSDK.Address) error {
 	_, err := db.Inhume(new(InhumePrm).
 		WithAddresses(target).
 		WithTombstoneAddress(tomb),

--- a/pkg/local_object_storage/metabase/iterators_test.go
+++ b/pkg/local_object_storage/metabase/iterators_test.go
@@ -7,6 +7,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,8 +16,8 @@ func TestDB_IterateExpired(t *testing.T) {
 
 	const epoch = 13
 
-	mAlive := map[object.Type]*object.Address{}
-	mExpired := map[object.Type]*object.Address{}
+	mAlive := map[object.Type]*addressSDK.Address{}
+	mExpired := map[object.Type]*addressSDK.Address{}
 
 	for _, typ := range []object.Type{
 		object.TypeRegular,
@@ -45,7 +46,7 @@ func TestDB_IterateExpired(t *testing.T) {
 	require.Empty(t, mExpired)
 }
 
-func putWithExpiration(t *testing.T, db *meta.DB, typ object.Type, expiresAt uint64) *object.Address {
+func putWithExpiration(t *testing.T, db *meta.DB, typ object.Type, expiresAt uint64) *addressSDK.Address {
 	raw := generateRawObject(t)
 	raw.SetType(typ)
 	addAttribute(raw, objectV2.SysAttributeExpEpoch, strconv.FormatUint(expiresAt, 10))
@@ -79,13 +80,13 @@ func TestDB_IterateCoveredByTombstones(t *testing.T) {
 		WithGCMark(),
 	)
 
-	var handled []*object.Address
+	var handled []*addressSDK.Address
 
 	tss := map[string]struct{}{
 		ts.String(): {},
 	}
 
-	err = db.IterateCoveredByTombstones(tss, func(addr *object.Address) error {
+	err = db.IterateCoveredByTombstones(tss, func(addr *addressSDK.Address) error {
 		handled = append(handled, addr)
 		return nil
 	})

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
@@ -42,12 +42,12 @@ func (l *ListPrm) WithCursor(cursor *Cursor) *ListPrm {
 
 // ListRes contains values returned from ListWithCursor operation.
 type ListRes struct {
-	addrList []*object.Address
+	addrList []*addressSDK.Address
 	cursor   *Cursor
 }
 
 // AddressList returns addresses selected by ListWithCursor operation.
-func (l ListRes) AddressList() []*object.Address {
+func (l ListRes) AddressList() []*addressSDK.Address {
 	return l.addrList
 }
 
@@ -62,7 +62,7 @@ func (l ListRes) Cursor() *Cursor {
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func ListWithCursor(db *DB, count uint32, cursor *Cursor) ([]*object.Address, *Cursor, error) {
+func ListWithCursor(db *DB, count uint32, cursor *Cursor) ([]*addressSDK.Address, *Cursor, error) {
 	r, err := db.ListWithCursor(new(ListPrm).WithCount(count).WithCursor(cursor))
 	if err != nil {
 		return nil, nil, err
@@ -87,9 +87,9 @@ func (db *DB) ListWithCursor(prm *ListPrm) (res *ListRes, err error) {
 	return res, err
 }
 
-func (db *DB) listWithCursor(tx *bbolt.Tx, count int, cursor *Cursor) ([]*object.Address, *Cursor, error) {
+func (db *DB) listWithCursor(tx *bbolt.Tx, count int, cursor *Cursor) ([]*addressSDK.Address, *Cursor, error) {
 	threshold := cursor == nil // threshold is a flag to ignore cursor
-	result := make([]*object.Address, 0, count)
+	result := make([]*addressSDK.Address, 0, count)
 	var bucketName []byte
 
 	c := tx.Cursor()
@@ -142,11 +142,11 @@ loop:
 func selectNFromBucket(tx *bbolt.Tx,
 	name []byte, // bucket name
 	prefix string, // string of CID, optimization
-	to []*object.Address, // listing result
+	to []*addressSDK.Address, // listing result
 	limit int, // stop listing at `limit` items in result
 	cursor *Cursor, // start from cursor object
 	threshold bool, // ignore cursor and start immediately
-) ([]*object.Address, *Cursor) {
+) ([]*addressSDK.Address, *Cursor) {
 	bkt := tx.Bucket(name)
 	if bkt == nil {
 		return to, cursor
@@ -171,7 +171,7 @@ func selectNFromBucket(tx *bbolt.Tx,
 		if count >= limit {
 			break
 		}
-		a := object.NewAddress()
+		a := addressSDK.NewAddress()
 		if err := a.Parse(prefix + string(k)); err != nil {
 			break
 		}

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -8,6 +8,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 		total      = containers * 4 // regular + ts + sg + child
 	)
 
-	expected := make([]*objectSDK.Address, 0, total)
+	expected := make([]*addressSDK.Address, 0, total)
 
 	// fill metabase with objects
 	for i := 0; i < containers; i++ {
@@ -72,7 +73,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 
 	t.Run("success with various count", func(t *testing.T) {
 		for countPerReq := 1; countPerReq <= total; countPerReq++ {
-			got := make([]*objectSDK.Address, 0, total)
+			got := make([]*addressSDK.Address, 0, total)
 
 			res, cursor, err := meta.ListWithCursor(db, uint32(countPerReq), nil)
 			require.NoError(t, err, "count:%d", countPerReq)
@@ -154,7 +155,7 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 
 }
 
-func sortAddresses(addr []*objectSDK.Address) []*objectSDK.Address {
+func sortAddresses(addr []*addressSDK.Address) []*addressSDK.Address {
 	sort.Slice(addr, func(i, j int) bool {
 		return addr[i].String() < addr[j].String()
 	})

--- a/pkg/local_object_storage/metabase/movable.go
+++ b/pkg/local_object_storage/metabase/movable.go
@@ -3,20 +3,20 @@ package meta
 import (
 	"fmt"
 
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // ToMoveItPrm groups the parameters of ToMoveIt operation.
 type ToMoveItPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // ToMoveItRes groups resulting values of ToMoveIt operation.
 type ToMoveItRes struct{}
 
 // WithAddress sets address of the object to move into another shard.
-func (p *ToMoveItPrm) WithAddress(addr *objectSDK.Address) *ToMoveItPrm {
+func (p *ToMoveItPrm) WithAddress(addr *addressSDK.Address) *ToMoveItPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -26,14 +26,14 @@ func (p *ToMoveItPrm) WithAddress(addr *objectSDK.Address) *ToMoveItPrm {
 
 // DoNotMovePrm groups the parameters of DoNotMove operation.
 type DoNotMovePrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // DoNotMoveRes groups resulting values of DoNotMove operation.
 type DoNotMoveRes struct{}
 
 // WithAddress sets address of the object to prevent moving into another shard.
-func (p *DoNotMovePrm) WithAddress(addr *objectSDK.Address) *DoNotMovePrm {
+func (p *DoNotMovePrm) WithAddress(addr *addressSDK.Address) *DoNotMovePrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -46,16 +46,16 @@ type MovablePrm struct{}
 
 // MovableRes groups resulting values of Movable operation.
 type MovableRes struct {
-	addrList []*objectSDK.Address
+	addrList []*addressSDK.Address
 }
 
 // AddressList returns resulting addresses of Movable operation.
-func (p *MovableRes) AddressList() []*objectSDK.Address {
+func (p *MovableRes) AddressList() []*addressSDK.Address {
 	return p.addrList
 }
 
 // ToMoveIt marks object to move it into another shard.
-func ToMoveIt(db *DB, addr *objectSDK.Address) error {
+func ToMoveIt(db *DB, addr *addressSDK.Address) error {
 	_, err := db.ToMoveIt(new(ToMoveItPrm).WithAddress(addr))
 	return err
 }
@@ -76,7 +76,7 @@ func (db *DB) ToMoveIt(prm *ToMoveItPrm) (res *ToMoveItRes, err error) {
 }
 
 // DoNotMove prevents the object to be moved into another shard.
-func DoNotMove(db *DB, addr *objectSDK.Address) error {
+func DoNotMove(db *DB, addr *addressSDK.Address) error {
 	_, err := db.DoNotMove(new(DoNotMovePrm).WithAddress(addr))
 	return err
 }
@@ -96,7 +96,7 @@ func (db *DB) DoNotMove(prm *DoNotMovePrm) (res *DoNotMoveRes, err error) {
 }
 
 // Movable returns all movable objects of DB.
-func Movable(db *DB) ([]*objectSDK.Address, error) {
+func Movable(db *DB) ([]*addressSDK.Address, error) {
 	r, err := db.Movable(new(MovablePrm))
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (db *DB) Movable(prm *MovablePrm) (*MovableRes, error) {
 	// we can parse strings to structures in-place, but probably it seems
 	// more efficient to keep bolt db TX code smaller because it might be
 	// bottleneck.
-	addrs := make([]*objectSDK.Address, 0, len(strAddrs))
+	addrs := make([]*addressSDK.Address, 0, len(strAddrs))
 
 	for i := range strAddrs {
 		addr, err := addressFromKey([]byte(strAddrs[i]))

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
@@ -377,7 +378,7 @@ func decodeList(data []byte) (lst [][]byte, err error) {
 
 // updateBlobovniczaID for existing objects if they were moved from from
 // one blobovnicza to another.
-func updateBlobovniczaID(tx *bbolt.Tx, addr *objectSDK.Address, id *blobovnicza.ID) error {
+func updateBlobovniczaID(tx *bbolt.Tx, addr *addressSDK.Address, id *blobovnicza.ID) error {
 	bkt, err := tx.CreateBucketIfNotExists(smallBucketName(addr.ContainerID()))
 	if err != nil {
 		return err
@@ -388,7 +389,7 @@ func updateBlobovniczaID(tx *bbolt.Tx, addr *objectSDK.Address, id *blobovnicza.
 
 // updateSpliInfo for existing objects if storage filled with extra information
 // about last object in split hierarchy or linking object.
-func updateSplitInfo(tx *bbolt.Tx, addr *objectSDK.Address, from *objectSDK.SplitInfo) error {
+func updateSplitInfo(tx *bbolt.Tx, addr *addressSDK.Address, from *objectSDK.SplitInfo) error {
 	bkt := tx.Bucket(rootBucketName(addr.ContainerID()))
 	if bkt == nil {
 		// if object doesn't exists and we want to update split info on it

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -9,6 +9,7 @@ import (
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
@@ -33,7 +34,7 @@ type SelectPrm struct {
 
 // SelectRes groups resulting values of Select operation.
 type SelectRes struct {
-	addrList []*object.Address
+	addrList []*addressSDK.Address
 }
 
 // WithContainerID is a Select option to set the container id to search in.
@@ -55,14 +56,14 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) *SelectPrm {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []*object.Address {
+func (r *SelectRes) AddressList() []*addressSDK.Address {
 	return r.addrList
 }
 
 var ErrMissingContainerID = errors.New("missing container id field")
 
 // Select selects the objects from DB with filtering.
-func Select(db *DB, cid *cid.ID, fs object.SearchFilters) ([]*object.Address, error) {
+func Select(db *DB, cid *cid.ID, fs object.SearchFilters) ([]*addressSDK.Address, error) {
 	r, err := db.Select(new(SelectPrm).WithFilters(fs).WithContainerID(cid))
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ func (db *DB) Select(prm *SelectPrm) (res *SelectRes, err error) {
 	})
 }
 
-func (db *DB) selectObjects(tx *bbolt.Tx, cid *cid.ID, fs object.SearchFilters) ([]*object.Address, error) {
+func (db *DB) selectObjects(tx *bbolt.Tx, cid *cid.ID, fs object.SearchFilters) ([]*addressSDK.Address, error) {
 	if cid == nil {
 		return nil, ErrMissingContainerID
 	}
@@ -118,7 +119,7 @@ func (db *DB) selectObjects(tx *bbolt.Tx, cid *cid.ID, fs object.SearchFilters) 
 		}
 	}
 
-	res := make([]*object.Address, 0, len(mAddr))
+	res := make([]*addressSDK.Address, 0, len(mAddr))
 
 	for a, ind := range mAddr {
 		if ind != expLen {
@@ -490,7 +491,7 @@ func (db *DB) selectObjectID(
 }
 
 // matchSlowFilters return true if object header is matched by all slow filters.
-func (db *DB) matchSlowFilters(tx *bbolt.Tx, addr *object.Address, f object.SearchFilters) bool {
+func (db *DB) matchSlowFilters(tx *bbolt.Tx, addr *addressSDK.Address, f object.SearchFilters) bool {
 	if len(f) == 0 {
 		return true
 	}

--- a/pkg/local_object_storage/metabase/select_test.go
+++ b/pkg/local_object_storage/metabase/select_test.go
@@ -8,6 +8,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
 )
@@ -320,7 +321,7 @@ func TestDB_SelectInhume(t *testing.T) {
 		raw2.Object().Address(),
 	)
 
-	tombstone := objectSDK.NewAddress()
+	tombstone := addressSDK.NewAddress()
 	tombstone.SetContainerID(cid)
 	tombstone.SetObjectID(testOID())
 

--- a/pkg/local_object_storage/metabase/small.go
+++ b/pkg/local_object_storage/metabase/small.go
@@ -3,13 +3,13 @@ package meta
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // IsSmallPrm groups the parameters of IsSmall operation.
 type IsSmallPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // IsSmallRes groups resulting values of IsSmall operation.
@@ -18,7 +18,7 @@ type IsSmallRes struct {
 }
 
 // WithAddress is a IsSmall option to set the object address to check.
-func (p *IsSmallPrm) WithAddress(addr *objectSDK.Address) *IsSmallPrm {
+func (p *IsSmallPrm) WithAddress(addr *addressSDK.Address) *IsSmallPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -34,7 +34,7 @@ func (r *IsSmallRes) BlobovniczaID() *blobovnicza.ID {
 // IsSmall wraps work with DB.IsSmall method with specified
 // address and other parameters by default. Returns only
 // the blobovnicza identifier.
-func IsSmall(db *DB, addr *objectSDK.Address) (*blobovnicza.ID, error) {
+func IsSmall(db *DB, addr *addressSDK.Address) (*blobovnicza.ID, error) {
 	r, err := db.IsSmall(new(IsSmallPrm).WithAddress(addr))
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (db *DB) IsSmall(prm *IsSmallPrm) (res *IsSmallRes, err error) {
 	return
 }
 
-func (db *DB) isSmall(tx *bbolt.Tx, addr *objectSDK.Address) (*blobovnicza.ID, error) {
+func (db *DB) isSmall(tx *bbolt.Tx, addr *addressSDK.Address) (*blobovnicza.ID, error) {
 	smallBucket := tx.Bucket(smallBucketName(addr.ContainerID()))
 	if smallBucket == nil {
 		return nil, nil

--- a/pkg/local_object_storage/metabase/util.go
+++ b/pkg/local_object_storage/metabase/util.go
@@ -6,6 +6,8 @@ import (
 
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
@@ -105,18 +107,18 @@ func splitBucketName(cid *cid.ID) []byte {
 }
 
 // addressKey returns key for K-V tables when key is a whole address.
-func addressKey(addr *object.Address) []byte {
+func addressKey(addr *addressSDK.Address) []byte {
 	return []byte(addr.String())
 }
 
 // parses object address formed by addressKey.
-func addressFromKey(k []byte) (*object.Address, error) {
-	a := object.NewAddress()
+func addressFromKey(k []byte) (*addressSDK.Address, error) {
+	a := addressSDK.NewAddress()
 	return a, a.Parse(string(k))
 }
 
 // objectKey returns key for K-V tables when key is an object id.
-func objectKey(oid *object.ID) []byte {
+func objectKey(oid *oidSDK.ID) []byte {
 	return []byte(oid.String())
 }
 

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // Open opens all Shard's components.
@@ -91,14 +92,14 @@ func (s *Shard) refillMetabase() error {
 			tombAddr := obj.Address()
 			cid := tombAddr.ContainerID()
 			memberIDs := tombstone.Members()
-			tombMembers := make([]*objectSDK.Address, 0, len(memberIDs))
+			tombMembers := make([]*addressSDK.Address, 0, len(memberIDs))
 
 			for _, id := range memberIDs {
 				if id == nil {
 					return errors.New("empty member in tombstone")
 				}
 
-				a := objectSDK.NewAddress()
+				a := addressSDK.NewAddress()
 				a.SetContainerID(cid)
 				a.SetObjectID(id)
 

--- a/pkg/local_object_storage/shard/control_test.go
+++ b/pkg/local_object_storage/shard/control_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestRefillMetabase(t *testing.T) {
 
 	type objAddr struct {
 		obj  *object.Object
-		addr *objectSDK.Address
+		addr *addressSDK.Address
 	}
 
 	mObjs := make(map[string]objAddr)
@@ -72,10 +73,10 @@ func TestRefillMetabase(t *testing.T) {
 
 	tombObj := tombObjRaw.Object()
 
-	tombMembers := make([]*objectSDK.Address, 0, len(tombstone.Members()))
+	tombMembers := make([]*addressSDK.Address, 0, len(tombstone.Members()))
 
 	for _, member := range tombstone.Members() {
-		a := objectSDK.NewAddress()
+		a := addressSDK.NewAddress()
 		a.SetObjectID(member)
 		a.SetContainerID(tombObj.ContainerID())
 
@@ -97,7 +98,7 @@ func TestRefillMetabase(t *testing.T) {
 
 	var headPrm HeadPrm
 
-	checkObj := func(addr *objectSDK.Address, expObj *object.Object) {
+	checkObj := func(addr *addressSDK.Address, expObj *object.Object) {
 		res, err := sh.Head(headPrm.WithAddress(addr))
 
 		if expObj == nil {

--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -7,13 +7,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr []*objectSDK.Address
+	addr []*addressSDK.Address
 }
 
 // DeleteRes groups resulting values of Delete operation.
@@ -22,7 +22,7 @@ type DeleteRes struct{}
 // WithAddresses is a Delete option to set the addresses of the objects to delete.
 //
 // Option is required.
-func (p *DeletePrm) WithAddresses(addr ...*objectSDK.Address) *DeletePrm {
+func (p *DeletePrm) WithAddresses(addr ...*addressSDK.Address) *DeletePrm {
 	if p != nil {
 		p.addr = append(p.addr, addr...)
 	}
@@ -41,7 +41,7 @@ func (s *Shard) Delete(prm *DeletePrm) (*DeleteRes, error) {
 	delSmallPrm := new(blobstor.DeleteSmallPrm)
 	delBigPrm := new(blobstor.DeleteBigPrm)
 
-	smalls := make(map[*objectSDK.Address]*blobovnicza.ID, ln)
+	smalls := make(map[*addressSDK.Address]*blobovnicza.ID, ln)
 
 	for i := range prm.addr {
 		if s.hasWriteCache() {

--- a/pkg/local_object_storage/shard/dump_test.go
+++ b/pkg/local_object_storage/shard/dump_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -327,7 +327,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 
 		// 2.2. Invalid object in valid blobovnicza.
 		prm := new(blobovnicza.PutPrm)
-		prm.SetAddress(objectSDK.NewAddress())
+		prm.SetAddress(addressSDK.NewAddress())
 		prm.SetMarshaledObject(corruptedData)
 		b := blobovnicza.New(blobovnicza.WithPath(filepath.Join(bTree, "1", "2")))
 		require.NoError(t, b.Open())

--- a/pkg/local_object_storage/shard/exists.go
+++ b/pkg/local_object_storage/shard/exists.go
@@ -2,12 +2,12 @@ package shard
 
 import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // ExistsPrm groups the parameters of Exists operation.
 type ExistsPrm struct {
-	addr *object.Address
+	addr *addressSDK.Address
 }
 
 // ExistsRes groups resulting values of Exists operation.
@@ -16,7 +16,7 @@ type ExistsRes struct {
 }
 
 // WithAddress is an Exists option to set object checked for existence.
-func (p *ExistsPrm) WithAddress(addr *object.Address) *ExistsPrm {
+func (p *ExistsPrm) WithAddress(addr *addressSDK.Address) *ExistsPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -41,6 +41,6 @@ func (s *Shard) Exists(prm *ExistsPrm) (*ExistsRes, error) {
 	}, err
 }
 
-func (s *Shard) objectExists(addr *object.Address) (bool, error) {
+func (s *Shard) objectExists(addr *addressSDK.Address) (bool, error) {
 	return meta.Exists(s.metaBase, addr)
 }

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -177,7 +178,7 @@ func (s *Shard) removeGarbage() {
 		return
 	}
 
-	buf := make([]*object.Address, 0, s.rmBatchSize)
+	buf := make([]*addressSDK.Address, 0, s.rmBatchSize)
 
 	// iterate over metabase graveyard and accumulate
 	// objects with GC mark (no more the s.rmBatchSize objects)
@@ -250,8 +251,8 @@ func (s *Shard) collectExpiredTombstones(ctx context.Context, e Event) {
 	s.expiredTombstonesCallback(ctx, expired)
 }
 
-func (s *Shard) getExpiredObjects(ctx context.Context, epoch uint64, collectTombstones bool) ([]*object.Address, error) {
-	var expired []*object.Address
+func (s *Shard) getExpiredObjects(ctx context.Context, epoch uint64, collectTombstones bool) ([]*addressSDK.Address, error) {
+	var expired []*addressSDK.Address
 
 	err := s.metaBase.IterateExpired(epoch, func(expiredObject *meta.ExpiredObject) error {
 		select {
@@ -276,11 +277,11 @@ func (s *Shard) getExpiredObjects(ctx context.Context, epoch uint64, collectTomb
 //
 // Does not modify tss.
 func (s *Shard) HandleExpiredTombstones(tss map[string]struct{}) {
-	inhume := make([]*object.Address, 0, len(tss))
+	inhume := make([]*addressSDK.Address, 0, len(tss))
 
 	// Collect all objects covered by the tombstones.
 
-	err := s.metaBase.IterateCoveredByTombstones(tss, func(addr *object.Address) error {
+	err := s.metaBase.IterateCoveredByTombstones(tss, func(addr *addressSDK.Address) error {
 		inhume = append(inhume, addr)
 		return nil
 	})
@@ -319,7 +320,7 @@ func (s *Shard) HandleExpiredTombstones(tss map[string]struct{}) {
 	for strAddr := range tss {
 		// parse address
 		// TODO: make type of map values *object.Address since keys are calculated from addresses
-		addr := object.NewAddress()
+		addr := addressSDK.NewAddress()
 
 		err = addr.Parse(strAddr)
 		if err != nil {

--- a/pkg/local_object_storage/shard/get.go
+++ b/pkg/local_object_storage/shard/get.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -18,7 +18,7 @@ type storFetcher = func(stor *blobstor.BlobStor, id *blobovnicza.ID) (*object.Ob
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // GetRes groups resulting values of Get operation.
@@ -29,7 +29,7 @@ type GetRes struct {
 // WithAddress is a Get option to set the address of the requested object.
 //
 // Option is required.
-func (p *GetPrm) WithAddress(addr *objectSDK.Address) *GetPrm {
+func (p *GetPrm) WithAddress(addr *addressSDK.Address) *GetPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -84,7 +84,7 @@ func (s *Shard) Get(prm *GetPrm) (*GetRes, error) {
 }
 
 // fetchObjectData looks through writeCache and blobStor to find object.
-func (s *Shard) fetchObjectData(addr *objectSDK.Address, big, small storFetcher) (*object.Object, error) {
+func (s *Shard) fetchObjectData(addr *addressSDK.Address, big, small storFetcher) (*object.Object, error) {
 	var (
 		err error
 		res *object.Object

--- a/pkg/local_object_storage/shard/head.go
+++ b/pkg/local_object_storage/shard/head.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // HeadPrm groups the parameters of Head operation.
 type HeadPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 	raw  bool
 }
 
@@ -23,7 +23,7 @@ type HeadRes struct {
 // WithAddress is a Head option to set the address of the requested object.
 //
 // Option is required.
-func (p *HeadPrm) WithAddress(addr *objectSDK.Address) *HeadPrm {
+func (p *HeadPrm) WithAddress(addr *addressSDK.Address) *HeadPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/inhume.go
+++ b/pkg/local_object_storage/shard/inhume.go
@@ -2,14 +2,14 @@ package shard
 
 import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
 // InhumePrm encapsulates parameters for inhume operation.
 type InhumePrm struct {
-	target    []*objectSDK.Address
-	tombstone *objectSDK.Address
+	target    []*addressSDK.Address
+	tombstone *addressSDK.Address
 }
 
 // InhumeRes encapsulates results of inhume operation.
@@ -20,7 +20,7 @@ type InhumeRes struct{}
 //
 // tombstone should not be nil, addr should not be empty.
 // Should not be called along with MarkAsGarbage.
-func (p *InhumePrm) WithTarget(tombstone *objectSDK.Address, addrs ...*objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) WithTarget(tombstone *addressSDK.Address, addrs ...*addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.target = addrs
 		p.tombstone = tombstone
@@ -32,7 +32,7 @@ func (p *InhumePrm) WithTarget(tombstone *objectSDK.Address, addrs ...*objectSDK
 // MarkAsGarbage marks object to be physically removed from shard.
 //
 // Should not be called along with WithTarget.
-func (p *InhumePrm) MarkAsGarbage(addr ...*objectSDK.Address) *InhumePrm {
+func (p *InhumePrm) MarkAsGarbage(addr ...*addressSDK.Address) *InhumePrm {
 	if p != nil {
 		p.target = addr
 		p.tombstone = nil

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -6,6 +6,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -35,7 +36,7 @@ type ListWithCursorPrm struct {
 
 // ListWithCursorRes contains values returned from ListWithCursor operation.
 type ListWithCursorRes struct {
-	addrList []*object.Address
+	addrList []*addressSDK.Address
 	cursor   *Cursor
 }
 
@@ -54,7 +55,7 @@ func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 }
 
 // AddressList returns addresses selected by ListWithCursor operation.
-func (r ListWithCursorRes) AddressList() []*object.Address {
+func (r ListWithCursorRes) AddressList() []*addressSDK.Address {
 	return r.addrList
 }
 
@@ -135,7 +136,7 @@ func (s *Shard) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, erro
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]*object.Address, *Cursor, error) {
+func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]*addressSDK.Address, *Cursor, error) {
 	prm := new(ListWithCursorPrm).WithCount(count).WithCursor(cursor)
 	res, err := s.ListWithCursor(prm)
 	if err != nil {

--- a/pkg/local_object_storage/shard/move.go
+++ b/pkg/local_object_storage/shard/move.go
@@ -2,13 +2,13 @@ package shard
 
 import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
 // ToMoveItPrm encapsulates parameters for ToMoveIt operation.
 type ToMoveItPrm struct {
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // ToMoveItRes encapsulates results of ToMoveIt operation.
@@ -16,7 +16,7 @@ type ToMoveItRes struct{}
 
 // WithAddress sets object address that should be marked to move into another
 // shard.
-func (p *ToMoveItPrm) WithAddress(addr *objectSDK.Address) *ToMoveItPrm {
+func (p *ToMoveItPrm) WithAddress(addr *addressSDK.Address) *ToMoveItPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/range.go
+++ b/pkg/local_object_storage/shard/range.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // RngPrm groups the parameters of GetRange operation.
@@ -13,7 +14,7 @@ type RngPrm struct {
 
 	off uint64
 
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 }
 
 // RngRes groups resulting values of GetRange operation.
@@ -24,7 +25,7 @@ type RngRes struct {
 // WithAddress is a Rng option to set the address of the requested object.
 //
 // Option is required.
-func (p *RngPrm) WithAddress(addr *objectSDK.Address) *RngPrm {
+func (p *RngPrm) WithAddress(addr *addressSDK.Address) *RngPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/select.go
+++ b/pkg/local_object_storage/shard/select.go
@@ -6,6 +6,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // SelectPrm groups the parameters of Select operation.
@@ -16,7 +17,7 @@ type SelectPrm struct {
 
 // SelectRes groups resulting values of Select operation.
 type SelectRes struct {
-	addrList []*objectSDK.Address
+	addrList []*addressSDK.Address
 }
 
 // WithContainerID is a Select option to set the container id to search in.
@@ -38,7 +39,7 @@ func (p *SelectPrm) WithFilters(fs objectSDK.SearchFilters) *SelectPrm {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []*objectSDK.Address {
+func (r *SelectRes) AddressList() []*addressSDK.Address {
 	return r.addrList
 }
 

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -31,7 +31,7 @@ type Shard struct {
 type Option func(*cfg)
 
 // ExpiredObjectsCallback is a callback handling list of expired objects.
-type ExpiredObjectsCallback func(context.Context, []*object.Address)
+type ExpiredObjectsCallback func(context.Context, []*addressSDK.Address)
 
 type cfg struct {
 	m sync.RWMutex

--- a/pkg/local_object_storage/shard/shard_test.go
+++ b/pkg/local_object_storage/shard/shard_test.go
@@ -18,6 +18,7 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -122,11 +123,11 @@ func addPayload(obj *object.RawObject, size int) {
 	obj.SetPayloadSize(uint64(size))
 }
 
-func generateOID() *objectSDK.ID {
+func generateOID() *oidSDK.ID {
 	cs := [sha256.Size]byte{}
 	_, _ = rand.Read(cs[:])
 
-	id := objectSDK.NewID()
+	id := oidSDK.NewID()
 	id.SetSHA256(cs)
 
 	return id

--- a/pkg/local_object_storage/util/splitinfo_test.go
+++ b/pkg/local_object_storage/util/splitinfo_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,8 +19,8 @@ func TestMergeSplitInfo(t *testing.T) {
 	splitID.SetUUID(uid)
 
 	var rawLinkID, rawLastID [32]byte
-	linkID := object.NewID()
-	lastID := object.NewID()
+	linkID := oidSDK.NewID()
+	lastID := oidSDK.NewID()
 
 	_, err = rand.Read(rawLinkID[:])
 	require.NoError(t, err)

--- a/pkg/local_object_storage/writecache/delete.go
+++ b/pkg/local_object_storage/writecache/delete.go
@@ -6,12 +6,12 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // Delete removes object from write-cache.
-func (c *cache) Delete(addr *objectSDK.Address) error {
+func (c *cache) Delete(addr *addressSDK.Address) error {
 	c.modeMtx.RLock()
 	defer c.modeMtx.RUnlock()
 	if c.mode == ModeReadOnly {

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
@@ -133,7 +133,7 @@ func (c *cache) flushBigObjects() {
 			}
 
 			evictNum := 0
-			_ = c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *objectSDK.Address, data []byte) error {
+			_ = c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 				sAddr := addr.String()
 
 				if _, ok := c.store.flushed.Peek(sAddr); ok {

--- a/pkg/local_object_storage/writecache/get.go
+++ b/pkg/local_object_storage/writecache/get.go
@@ -2,12 +2,12 @@ package writecache
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
 // Get returns object from write-cache.
-func (c *cache) Get(addr *objectSDK.Address) (*object.Object, error) {
+func (c *cache) Get(addr *addressSDK.Address) (*object.Object, error) {
 	saddr := addr.String()
 
 	c.mtx.RLock()
@@ -42,7 +42,7 @@ func (c *cache) Get(addr *objectSDK.Address) (*object.Object, error) {
 }
 
 // Head returns object header from write-cache.
-func (c *cache) Head(addr *objectSDK.Address) (*object.Object, error) {
+func (c *cache) Head(addr *addressSDK.Address) (*object.Object, error) {
 	// TODO: easiest to implement solution is presented here, consider more efficient way, e.g.:
 	//  - provide header as common object.Object to Put, but marked to prevent correlation with full object
 	//    (all write-cache logic will automatically spread to headers, except flushing)

--- a/pkg/local_object_storage/writecache/iterate.go
+++ b/pkg/local_object_storage/writecache/iterate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 )
 
@@ -53,7 +53,7 @@ func (c *cache) Iterate(prm *IterationPrm) error {
 		return err
 	}
 
-	return c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *object.Address, data []byte) error {
+	return c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
 		if _, ok := c.flushed.Peek(addr.String()); ok {
 			return nil
 		}
@@ -67,18 +67,18 @@ func (c *cache) Iterate(prm *IterationPrm) error {
 // Returns ErrNoDefaultBucket if there is no default bucket in db.
 //
 // DB must not be nil and should be opened.
-func IterateDB(db *bbolt.DB, f func(*object.Address) error) error {
+func IterateDB(db *bbolt.DB, f func(*addressSDK.Address) error) error {
 	return db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(defaultBucket)
 		if b == nil {
 			return ErrNoDefaultBucket
 		}
 
-		var addr *object.Address
+		var addr *addressSDK.Address
 
 		return b.ForEach(func(k, v []byte) error {
 			if addr == nil {
-				addr = object.NewAddress()
+				addr = addressSDK.NewAddress()
 			}
 
 			err := addr.Parse(string(k))

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
@@ -125,7 +125,7 @@ func (c *cache) deleteFromDisk(keys [][]byte) error {
 	var lastErr error
 
 	for i := range keys {
-		addr := objectSDK.NewAddress()
+		addr := addressSDK.NewAddress()
 		addrStr := string(keys[i])
 
 		if err := addr.Parse(addrStr); err != nil {

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -17,9 +17,9 @@ type Info struct {
 
 // Cache represents write-cache for objects.
 type Cache interface {
-	Get(*objectSDK.Address) (*object.Object, error)
-	Head(*objectSDK.Address) (*object.Object, error)
-	Delete(*objectSDK.Address) error
+	Get(*addressSDK.Address) (*object.Object, error)
+	Head(*addressSDK.Address) (*object.Object, error)
+	Delete(*addressSDK.Address) error
 	Iterate(*IterationPrm) error
 	Put(*object.Object) error
 	SetMode(Mode)

--- a/pkg/services/audit/auditor/pdp.go
+++ b/pkg/services/audit/auditor/pdp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 	"go.uber.org/zap"
 )
@@ -81,7 +82,7 @@ func (c *Context) distributeRanges(p *gamePair) {
 	}
 }
 
-func (c *Context) splitPayload(id *object.ID) []uint64 {
+func (c *Context) splitPayload(id *oidSDK.ID) []uint64 {
 	var (
 		prev    uint64
 		size    = c.objectSize(id)

--- a/pkg/services/audit/auditor/pop.go
+++ b/pkg/services/audit/auditor/pop.go
@@ -3,7 +3,7 @@ package auditor
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -27,7 +27,7 @@ func (c *Context) buildCoverage() {
 
 	// select random member from another storage group
 	// and process all placement vectors
-	c.iterateSGMembersPlacementRand(func(id *object.ID, ind int, nodes netmap.Nodes) bool {
+	c.iterateSGMembersPlacementRand(func(id *oidSDK.ID, ind int, nodes netmap.Nodes) bool {
 		c.processObjectPlacement(id, nodes, replicas[ind].Count())
 		return c.containerCovered()
 	})
@@ -38,7 +38,7 @@ func (c *Context) containerCovered() bool {
 	return c.cnrNodesNum <= len(c.pairedNodes)
 }
 
-func (c *Context) processObjectPlacement(id *object.ID, nodes netmap.Nodes, replicas uint32) {
+func (c *Context) processObjectPlacement(id *oidSDK.ID, nodes netmap.Nodes, replicas uint32) {
 	var (
 		ok      uint32
 		optimal bool
@@ -102,7 +102,7 @@ func (c *Context) processObjectPlacement(id *object.ID, nodes netmap.Nodes, repl
 	}
 }
 
-func (c *Context) composePair(id *object.ID, n1, n2 *netmap.Node) {
+func (c *Context) composePair(id *oidSDK.ID, n1, n2 *netmap.Node) {
 	c.pairs = append(c.pairs, gamePair{
 		n1: n1,
 		n2: n2,
@@ -117,10 +117,10 @@ func (c *Context) composePair(id *object.ID, n1, n2 *netmap.Node) {
 	}
 }
 
-func (c *Context) iterateSGMembersPlacementRand(f func(*object.ID, int, netmap.Nodes) bool) {
+func (c *Context) iterateSGMembersPlacementRand(f func(*oidSDK.ID, int, netmap.Nodes) bool) {
 	// iterate over storage groups members for all storage groups (one by one)
 	// with randomly shuffled members
-	c.iterateSGMembersRand(func(id *object.ID) bool {
+	c.iterateSGMembersRand(func(id *oidSDK.ID) bool {
 		// build placement vector for the current object
 		nn, err := c.buildPlacement(id)
 		if err != nil {
@@ -142,8 +142,8 @@ func (c *Context) iterateSGMembersPlacementRand(f func(*object.ID, int, netmap.N
 	})
 }
 
-func (c *Context) iterateSGMembersRand(f func(*object.ID) bool) {
-	c.iterateSGInfo(func(members []*object.ID) bool {
+func (c *Context) iterateSGMembersRand(f func(*oidSDK.ID) bool) {
+	c.iterateSGInfo(func(members []*oidSDK.ID) bool {
 		ln := len(members)
 
 		processed := make(map[uint64]struct{}, ln-1)
@@ -161,7 +161,7 @@ func (c *Context) iterateSGMembersRand(f func(*object.ID) bool) {
 	})
 }
 
-func (c *Context) iterateSGInfo(f func([]*object.ID) bool) {
+func (c *Context) iterateSGInfo(f func([]*oidSDK.ID) bool) {
 	c.sgMembersMtx.RLock()
 	defer c.sgMembersMtx.RUnlock()
 

--- a/pkg/services/audit/auditor/por.go
+++ b/pkg/services/audit/auditor/por.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 	"go.uber.org/zap"
 )
@@ -35,7 +35,7 @@ func (c *Context) executePoR() {
 	c.report.SetPoRCounters(c.porRequests.Load(), c.porRetries.Load())
 }
 
-func (c *Context) checkStorageGroupPoR(ind int, sg *object.ID) {
+func (c *Context) checkStorageGroupPoR(ind int, sg *oidSDK.ID) {
 	storageGroup, err := c.cnrCom.GetSG(c.task, sg) // get storage group
 	if err != nil {
 		c.log.Warn("can't get storage group",

--- a/pkg/services/audit/report.go
+++ b/pkg/services/audit/report.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Report tracks the progress of auditing container data.
@@ -48,7 +48,7 @@ func (r *Report) Complete() {
 }
 
 // PassedPoR updates list of passed storage groups.
-func (r *Report) PassedPoR(sg *object.ID) {
+func (r *Report) PassedPoR(sg *oidSDK.ID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -56,7 +56,7 @@ func (r *Report) PassedPoR(sg *object.ID) {
 }
 
 // FailedPoR updates list of failed storage groups.
-func (r *Report) FailedPoR(sg *object.ID) {
+func (r *Report) FailedPoR(sg *oidSDK.ID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/services/audit/task.go
+++ b/pkg/services/audit/task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Task groups groups the container audit parameters.
@@ -23,7 +23,7 @@ type Task struct {
 
 	cnrNodes netmap.ContainerNodes
 
-	sgList []*object.ID
+	sgList []*oidSDK.ID
 }
 
 // WithReporter sets audit report writer.
@@ -111,7 +111,7 @@ func (t *Task) ContainerNodes() netmap.ContainerNodes {
 }
 
 // WithStorageGroupList sets list of storage groups from container under audit.
-func (t *Task) WithStorageGroupList(sgList []*object.ID) *Task {
+func (t *Task) WithStorageGroupList(sgList []*oidSDK.ID) *Task {
 	if t != nil {
 		t.sgList = sgList
 	}
@@ -120,6 +120,6 @@ func (t *Task) WithStorageGroupList(sgList []*object.ID) *Task {
 }
 
 // StorageGroupList returns list of storage groups from container under audit.
-func (t *Task) StorageGroupList() []*object.ID {
+func (t *Task) StorageGroupList() []*oidSDK.ID {
 	return t.sgList
 }

--- a/pkg/services/control/server/gc.go
+++ b/pkg/services/control/server/gc.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 // DeletedObjectHandler is a handler of objects to be removed.
-type DeletedObjectHandler func([]*object.Address) error
+type DeletedObjectHandler func([]*objectSDKAddress.Address) error
 
 // DropObjects marks objects to be removed from the local node.
 //
@@ -26,10 +26,10 @@ func (s *Server) DropObjects(_ context.Context, req *control.DropObjectsRequest)
 	}
 
 	binAddrList := req.GetBody().GetAddressList()
-	addrList := make([]*object.Address, 0, len(binAddrList))
+	addrList := make([]*objectSDKAddress.Address, 0, len(binAddrList))
 
 	for i := range binAddrList {
-		a := object.NewAddress()
+		a := objectSDKAddress.NewAddress()
 
 		err := a.Unmarshal(binAddrList[i])
 		if err != nil {

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -21,7 +21,8 @@ import (
 	eaclV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl/v2"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objectSDKID "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/util/signature"
 )
@@ -72,7 +73,7 @@ type (
 
 		cid *cid.ID
 
-		oid *objectSDK.ID
+		oid *objectSDKID.ID
 
 		senderKey []byte
 
@@ -517,23 +518,23 @@ func useObjectIDFromSession(req *requestInfo, token *session.SessionToken) {
 		return
 	}
 
-	req.oid = objectSDK.NewIDFromV2(
+	req.oid = objectSDKID.NewIDFromV2(
 		objCtx.GetAddress().GetObjectID(),
 	)
 }
 
-func getObjectIDFromRequestBody(body interface{}) *objectSDK.ID {
+func getObjectIDFromRequestBody(body interface{}) *objectSDKID.ID {
 	switch v := body.(type) {
 	default:
 		return nil
 	case interface {
 		GetObjectID() *refs.ObjectID
 	}:
-		return objectSDK.NewIDFromV2(v.GetObjectID())
+		return objectSDKID.NewIDFromV2(v.GetObjectID())
 	case interface {
 		GetAddress() *refs.Address
 	}:
-		return objectSDK.NewIDFromV2(v.GetAddress().GetObjectID())
+		return objectSDKID.NewIDFromV2(v.GetAddress().GetObjectID())
 	}
 }
 
@@ -632,7 +633,7 @@ func eACLCheck(msg interface{}, reqInfo requestInfo, cfg *eACLCfg) bool {
 
 	hdrSrcOpts := make([]eaclV2.Option, 0, 3)
 
-	addr := objectSDK.NewAddress()
+	addr := objectSDKAddress.NewAddress()
 	addr.SetContainerID(reqInfo.cid)
 	addr.SetObjectID(reqInfo.oid)
 

--- a/pkg/services/object/acl/eacl/v2/eacl_test.go
+++ b/pkg/services/object/acl/eacl/v2/eacl_test.go
@@ -13,37 +13,39 @@ import (
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objectSDKID "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
 type testLocalStorage struct {
 	t *testing.T
 
-	expAddr *objectSDK.Address
+	expAddr *objectSDKAddress.Address
 
 	obj *object.Object
 }
 
-func (s *testLocalStorage) Head(addr *objectSDK.Address) (*object.Object, error) {
+func (s *testLocalStorage) Head(addr *objectSDKAddress.Address) (*object.Object, error) {
 	require.True(s.t, addr.ContainerID().Equal(addr.ContainerID()) && addr.ObjectID().Equal(addr.ObjectID()))
 
 	return s.obj, nil
 }
 
-func testID(t *testing.T) *objectSDK.ID {
+func testID(t *testing.T) *objectSDKID.ID {
 	cs := [sha256.Size]byte{}
 
 	_, err := rand.Read(cs[:])
 	require.NoError(t, err)
 
-	id := objectSDK.NewID()
+	id := objectSDKID.NewID()
 	id.SetSHA256(cs)
 
 	return id
 }
 
-func testAddress(t *testing.T) *objectSDK.Address {
-	addr := objectSDK.NewAddress()
+func testAddress(t *testing.T) *objectSDKAddress.Address {
+	addr := objectSDKAddress.NewAddress()
 	addr.SetObjectID(testID(t))
 	addr.SetContainerID(cidtest.ID())
 

--- a/pkg/services/object/acl/eacl/v2/localstore.go
+++ b/pkg/services/object/acl/eacl/v2/localstore.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type localStorage struct {
 	ls *engine.StorageEngine
 }
 
-func (s *localStorage) Head(addr *objectSDK.Address) (*object.Object, error) {
+func (s *localStorage) Head(addr *objectSDKAddress.Address) (*object.Object, error) {
 	if s.ls == nil {
 		return nil, io.ErrUnexpectedEOF
 	}

--- a/pkg/services/object/acl/eacl/v2/object.go
+++ b/pkg/services/object/acl/eacl/v2/object.go
@@ -7,7 +7,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	objectSDKID "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 )
 
@@ -23,7 +24,7 @@ func (s *sysObjHdr) Value() string {
 	return s.v
 }
 
-func idValue(id *objectSDK.ID) string {
+func idValue(id *objectSDKID.ID) string {
 	return id.String()
 }
 
@@ -39,7 +40,7 @@ func u64Value(v uint64) string {
 	return strconv.FormatUint(v, 10)
 }
 
-func headersFromObject(obj *object.Object, addr *objectSDK.Address) []eaclSDK.Header {
+func headersFromObject(obj *object.Object, addr *objectSDKAddress.Address) []eaclSDK.Header {
 	var count int
 	for obj := obj; obj != nil; obj = obj.GetParent() {
 		count += 9 + len(obj.Attributes())

--- a/pkg/services/object/delete/exec.go
+++ b/pkg/services/object/delete/exec.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -59,7 +61,7 @@ func (exec execCtx) isLocal() bool {
 	return exec.prm.common.LocalOnly()
 }
 
-func (exec *execCtx) address() *objectSDK.Address {
+func (exec *execCtx) address() *addressSDK.Address {
 	return exec.prm.addr
 }
 
@@ -71,8 +73,8 @@ func (exec *execCtx) commonParameters() *util.CommonPrm {
 	return exec.prm.common
 }
 
-func (exec *execCtx) newAddress(id *objectSDK.ID) *objectSDK.Address {
-	a := objectSDK.NewAddress()
+func (exec *execCtx) newAddress(id *oidSDK.ID) *addressSDK.Address {
+	a := addressSDK.NewAddress()
 	a.SetObjectID(id)
 	a.SetContainerID(exec.containerID())
 
@@ -123,7 +125,7 @@ func (exec *execCtx) collectMembers() (ok bool) {
 func (exec *execCtx) collectChain() bool {
 	var (
 		err   error
-		chain []*objectSDK.ID
+		chain []*oidSDK.ID
 	)
 
 	exec.log.Debug("assembling chain...")
@@ -204,7 +206,7 @@ func (exec *execCtx) supplementBySplitID() bool {
 	}
 }
 
-func (exec *execCtx) addMembers(incoming []*objectSDK.ID) {
+func (exec *execCtx) addMembers(incoming []*oidSDK.ID) {
 	members := exec.tombstone.Members()
 
 	for i := range members {

--- a/pkg/services/object/delete/local.go
+++ b/pkg/services/object/delete/local.go
@@ -2,6 +2,7 @@ package deletesvc
 
 import (
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -42,7 +43,7 @@ func (exec *execCtx) formTombstone() (ok bool) {
 	exec.tombstone.SetExpirationEpoch(
 		exec.svc.netInfo.CurrentEpoch() + tsLifetime,
 	)
-	exec.addMembers([]*objectSDK.ID{exec.address().ObjectID()})
+	exec.addMembers([]*oidSDK.ID{exec.address().ObjectID()})
 
 	exec.log.Debug("forming split info...")
 

--- a/pkg/services/object/delete/prm.go
+++ b/pkg/services/object/delete/prm.go
@@ -2,19 +2,19 @@ package deletesvc
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // TombstoneAddressWriter is an interface of tombstone address setter.
 type TombstoneAddressWriter interface {
-	SetAddress(*object.Address)
+	SetAddress(*addressSDK.Address)
 }
 
 // Prm groups parameters of Delete service call.
 type Prm struct {
 	common *util.CommonPrm
 
-	addr *object.Address
+	addr *addressSDK.Address
 
 	tombAddrWriter TombstoneAddressWriter
 }
@@ -25,7 +25,7 @@ func (p *Prm) SetCommonParameters(common *util.CommonPrm) {
 }
 
 // WithAddress sets address of the object to be removed.
-func (p *Prm) WithAddress(addr *object.Address) {
+func (p *Prm) WithAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 

--- a/pkg/services/object/delete/service.go
+++ b/pkg/services/object/delete/service.go
@@ -7,6 +7,7 @@ import (
 	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"go.uber.org/zap"
 )
@@ -39,18 +40,18 @@ type cfg struct {
 		// must return (nil, nil) for PHY objects
 		splitInfo(*execCtx) (*objectSDK.SplitInfo, error)
 
-		children(*execCtx) ([]*objectSDK.ID, error)
+		children(*execCtx) ([]*oidSDK.ID, error)
 
 		// must return (nil, nil) for 1st object in chain
-		previous(*execCtx, *objectSDK.ID) (*objectSDK.ID, error)
+		previous(*execCtx, *oidSDK.ID) (*oidSDK.ID, error)
 	}
 
 	searcher interface {
-		splitMembers(*execCtx) ([]*objectSDK.ID, error)
+		splitMembers(*execCtx) ([]*oidSDK.ID, error)
 	}
 
 	placer interface {
-		put(*execCtx, bool) (*objectSDK.ID, error)
+		put(*execCtx, bool) (*oidSDK.ID, error)
 	}
 
 	netInfo NetworkInfo

--- a/pkg/services/object/delete/util.go
+++ b/pkg/services/object/delete/util.go
@@ -9,6 +9,8 @@ import (
 	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type headSvcWrapper getsvc.Service
@@ -18,10 +20,10 @@ type searchSvcWrapper searchsvc.Service
 type putSvcWrapper putsvc.Service
 
 type simpleIDWriter struct {
-	ids []*objectSDK.ID
+	ids []*oidSDK.ID
 }
 
-func (w *headSvcWrapper) headAddress(exec *execCtx, addr *objectSDK.Address) (*object.Object, error) {
+func (w *headSvcWrapper) headAddress(exec *execCtx, addr *addressSDK.Address) (*object.Object, error) {
 	wr := getsvc.NewSimpleObjectWriter()
 
 	p := getsvc.HeadPrm{}
@@ -53,7 +55,7 @@ func (w *headSvcWrapper) splitInfo(exec *execCtx) (*objectSDK.SplitInfo, error) 
 	}
 }
 
-func (w *headSvcWrapper) children(exec *execCtx) ([]*objectSDK.ID, error) {
+func (w *headSvcWrapper) children(exec *execCtx) ([]*oidSDK.ID, error) {
 	a := exec.newAddress(exec.splitInfo.Link())
 
 	linking, err := w.headAddress(exec, a)
@@ -64,7 +66,7 @@ func (w *headSvcWrapper) children(exec *execCtx) ([]*objectSDK.ID, error) {
 	return linking.Children(), nil
 }
 
-func (w *headSvcWrapper) previous(exec *execCtx, id *objectSDK.ID) (*objectSDK.ID, error) {
+func (w *headSvcWrapper) previous(exec *execCtx, id *oidSDK.ID) (*oidSDK.ID, error) {
 	a := exec.newAddress(id)
 
 	h, err := w.headAddress(exec, a)
@@ -75,7 +77,7 @@ func (w *headSvcWrapper) previous(exec *execCtx, id *objectSDK.ID) (*objectSDK.I
 	return h.PreviousID(), nil
 }
 
-func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]*objectSDK.ID, error) {
+func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]*oidSDK.ID, error) {
 	fs := objectSDK.SearchFilters{}
 	fs.AddSplitIDFilter(objectSDK.MatchStringEqual, exec.splitInfo.SplitID())
 
@@ -95,13 +97,13 @@ func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]*objectSDK.ID, error) 
 	return wr.ids, nil
 }
 
-func (s *simpleIDWriter) WriteIDs(ids []*objectSDK.ID) error {
+func (s *simpleIDWriter) WriteIDs(ids []*oidSDK.ID) error {
 	s.ids = append(s.ids, ids...)
 
 	return nil
 }
 
-func (w *putSvcWrapper) put(exec *execCtx, broadcast bool) (*objectSDK.ID, error) {
+func (w *putSvcWrapper) put(exec *execCtx, broadcast bool) (*oidSDK.ID, error) {
 	streamer, err := (*putsvc.Service)(w).Put(exec.context())
 	if err != nil {
 		return nil, err

--- a/pkg/services/object/delete/v2/util.go
+++ b/pkg/services/object/delete/v2/util.go
@@ -4,7 +4,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	deletesvc "github.com/nspcc-dev/neofs-node/pkg/services/object/delete"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type tombstoneBodyWriter struct {
@@ -21,7 +21,7 @@ func (s *Service) toPrm(req *objectV2.DeleteRequest, respBody *objectV2.DeleteRe
 	p.SetCommonParameters(commonPrm)
 
 	body := req.GetBody()
-	p.WithAddress(object.NewAddressFromV2(body.GetAddress()))
+	p.WithAddress(addressSDK.NewAddressFromV2(body.GetAddress()))
 	p.WithTombstoneAddressTarget(&tombstoneBodyWriter{
 		body: respBody,
 	})
@@ -29,6 +29,6 @@ func (s *Service) toPrm(req *objectV2.DeleteRequest, respBody *objectV2.DeleteRe
 	return p, nil
 }
 
-func (w *tombstoneBodyWriter) SetAddress(addr *object.Address) {
+func (w *tombstoneBodyWriter) SetAddress(addr *addressSDK.Address) {
 	w.body.SetTombstone(addr.ToV2())
 }

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -3,6 +3,8 @@ package getsvc
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -59,7 +61,7 @@ func (exec *execCtx) assemble() {
 	}
 }
 
-func (exec *execCtx) initFromChild(id *objectSDK.ID) (prev *objectSDK.ID, children []*objectSDK.ID) {
+func (exec *execCtx) initFromChild(id *oidSDK.ID) (prev *oidSDK.ID, children []*oidSDK.ID) {
 	log := exec.log.With(zap.Stringer("child ID", id))
 
 	log.Debug("starting assembling from child")
@@ -118,7 +120,7 @@ func (exec *execCtx) initFromChild(id *objectSDK.ID) (prev *objectSDK.ID, childr
 	return child.PreviousID(), child.Children()
 }
 
-func (exec *execCtx) overtakePayloadDirectly(children []*objectSDK.ID, rngs []*objectSDK.Range, checkRight bool) {
+func (exec *execCtx) overtakePayloadDirectly(children []*oidSDK.ID, rngs []*objectSDK.Range, checkRight bool) {
 	withRng := len(rngs) > 0 && exec.ctxRange() != nil
 
 	for i := range children {
@@ -141,7 +143,7 @@ func (exec *execCtx) overtakePayloadDirectly(children []*objectSDK.ID, rngs []*o
 	exec.err = nil
 }
 
-func (exec *execCtx) overtakePayloadInReverse(prev *objectSDK.ID) bool {
+func (exec *execCtx) overtakePayloadInReverse(prev *oidSDK.ID) bool {
 	chain, rngs, ok := exec.buildChainInReverse(prev)
 	if !ok {
 		return false
@@ -163,9 +165,9 @@ func (exec *execCtx) overtakePayloadInReverse(prev *objectSDK.ID) bool {
 	return exec.status == statusOK
 }
 
-func (exec *execCtx) buildChainInReverse(prev *objectSDK.ID) ([]*objectSDK.ID, []*objectSDK.Range, bool) {
+func (exec *execCtx) buildChainInReverse(prev *oidSDK.ID) ([]*oidSDK.ID, []*objectSDK.Range, bool) {
 	var (
-		chain   = make([]*objectSDK.ID, 0)
+		chain   = make([]*oidSDK.ID, 0)
 		rngs    = make([]*objectSDK.Range, 0)
 		seekRng = exec.ctxRange()
 		from    = seekRng.GetOffset()
@@ -216,7 +218,7 @@ func (exec *execCtx) buildChainInReverse(prev *objectSDK.ID) ([]*objectSDK.ID, [
 	return chain, rngs, true
 }
 
-func equalAddresses(a, b *objectSDK.Address) bool {
+func equalAddresses(a, b *addressSDK.Address) bool {
 	return a.ContainerID().Equal(b.ContainerID()) &&
 		a.ObjectID().Equal(b.ObjectID())
 }

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -93,7 +95,7 @@ func (exec execCtx) isRaw() bool {
 	return exec.prm.raw
 }
 
-func (exec execCtx) address() *objectSDK.Address {
+func (exec execCtx) address() *addressSDK.Address {
 	return exec.prm.addr
 }
 
@@ -158,7 +160,7 @@ func (exec *execCtx) initEpoch() bool {
 	}
 }
 
-func (exec *execCtx) generateTraverser(addr *objectSDK.Address) (*placement.Traverser, bool) {
+func (exec *execCtx) generateTraverser(addr *addressSDK.Address) (*placement.Traverser, bool) {
 	t, err := exec.svc.traverserGenerator.GenerateTraverser(addr, exec.curProcEpoch)
 
 	switch {
@@ -176,7 +178,7 @@ func (exec *execCtx) generateTraverser(addr *objectSDK.Address) (*placement.Trav
 	}
 }
 
-func (exec *execCtx) getChild(id *objectSDK.ID, rng *objectSDK.Range, withHdr bool) (*object.Object, bool) {
+func (exec *execCtx) getChild(id *oidSDK.ID, rng *objectSDK.Range, withHdr bool) (*object.Object, bool) {
 	w := NewSimpleObjectWriter()
 
 	p := exec.prm
@@ -184,7 +186,7 @@ func (exec *execCtx) getChild(id *objectSDK.ID, rng *objectSDK.Range, withHdr bo
 	p.objWriter = w
 	p.SetRange(rng)
 
-	addr := objectSDK.NewAddress()
+	addr := addressSDK.NewAddress()
 	addr.SetContainerID(exec.address().ContainerID())
 	addr.SetObjectID(id)
 
@@ -205,8 +207,8 @@ func (exec *execCtx) getChild(id *objectSDK.ID, rng *objectSDK.Range, withHdr bo
 	return child, ok
 }
 
-func (exec *execCtx) headChild(id *objectSDK.ID) (*object.Object, bool) {
-	childAddr := objectSDK.NewAddress()
+func (exec *execCtx) headChild(id *oidSDK.ID) (*object.Object, bool) {
+	childAddr := addressSDK.NewAddress()
 	childAddr.SetContainerID(exec.containerID())
 	childAddr.SetObjectID(id)
 

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // Prm groups parameters of Get service call.
@@ -44,7 +45,7 @@ type commonPrm struct {
 
 	common *util.CommonPrm
 
-	addr *objectSDK.Address
+	addr *addressSDK.Address
 
 	raw bool
 
@@ -111,7 +112,7 @@ func (p *commonPrm) SetRequestForwarder(f RequestForwarder) {
 }
 
 // WithAddress sets object address to be read.
-func (p *commonPrm) WithAddress(addr *objectSDK.Address) {
+func (p *commonPrm) WithAddress(addr *addressSDK.Address) {
 	p.addr = addr
 }
 

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"go.uber.org/zap"
 )
@@ -41,7 +42,7 @@ type cfg struct {
 	}
 
 	traverserGenerator interface {
-		GenerateTraverser(*objectSDK.Address, uint64) (*placement.Traverser, error)
+		GenerateTraverser(*addressSDK.Address, uint64) (*placement.Traverser, error)
 	}
 
 	currentEpochReceiver interface {

--- a/pkg/services/object/get/v2/util.go
+++ b/pkg/services/object/get/v2/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/internal"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	signature2 "github.com/nspcc-dev/neofs-sdk-go/util/signature"
 	"github.com/nspcc-dev/tzhash/tz"
 )
@@ -41,7 +42,7 @@ func (s *Service) toPrm(req *objectV2.GetRequest, stream objectSvc.GetObjectStre
 	p.SetCommonParameters(commonPrm)
 
 	body := req.GetBody()
-	p.WithAddress(objectSDK.NewAddressFromV2(body.GetAddress()))
+	p.WithAddress(addressSDK.NewAddressFromV2(body.GetAddress()))
 	p.WithRawFlag(body.GetRaw())
 	p.SetObjectWriter(&streamObjectWriter{stream})
 
@@ -165,7 +166,7 @@ func (s *Service) toRangePrm(req *objectV2.GetRangeRequest, stream objectSvc.Get
 	p.SetCommonParameters(commonPrm)
 
 	body := req.GetBody()
-	p.WithAddress(objectSDK.NewAddressFromV2(body.GetAddress()))
+	p.WithAddress(addressSDK.NewAddressFromV2(body.GetAddress()))
 	p.WithRawFlag(body.GetRaw())
 	p.SetChunkWriter(&streamObjectRangeWriter{stream})
 	p.SetRange(objectSDK.NewRangeFromV2(body.GetRange()))
@@ -264,7 +265,7 @@ func (s *Service) toHashRangePrm(req *objectV2.GetRangeHashRequest) (*getsvc.Ran
 	p.SetCommonParameters(commonPrm)
 
 	body := req.GetBody()
-	p.WithAddress(objectSDK.NewAddressFromV2(body.GetAddress()))
+	p.WithAddress(addressSDK.NewAddressFromV2(body.GetAddress()))
 
 	rngsV2 := body.GetRanges()
 	rngs := make([]*objectSDK.Range, 0, len(rngsV2))
@@ -321,7 +322,7 @@ func (s *Service) toHeadPrm(ctx context.Context, req *objectV2.HeadRequest, resp
 
 	body := req.GetBody()
 
-	objAddr := objectSDK.NewAddressFromV2(body.GetAddress())
+	objAddr := addressSDK.NewAddressFromV2(body.GetAddress())
 
 	p.WithAddress(objAddr)
 	p.WithRawFlag(body.GetRaw())

--- a/pkg/services/object/head/prm.go
+++ b/pkg/services/object/head/prm.go
@@ -1,14 +1,14 @@
 package headsvc
 
 import (
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type Prm struct {
-	addr *object.Address
+	addr *addressSDK.Address
 }
 
-func (p *Prm) WithAddress(v *object.Address) *Prm {
+func (p *Prm) WithAddress(v *addressSDK.Address) *Prm {
 	if p != nil {
 		p.addr = v
 	}

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -10,7 +10,7 @@ import (
 	internalclient "github.com/nspcc-dev/neofs-node/pkg/services/object/internal/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type ClientConstructor interface {
@@ -54,7 +54,7 @@ func (p *RemoteHeadPrm) WithNodeInfo(v *netmap.NodeInfo) *RemoteHeadPrm {
 }
 
 // WithObjectAddress sets object address.
-func (p *RemoteHeadPrm) WithObjectAddress(v *objectSDK.Address) *RemoteHeadPrm {
+func (p *RemoteHeadPrm) WithObjectAddress(v *addressSDK.Address) *RemoteHeadPrm {
 	if p != nil {
 		p.commonHeadPrm = new(Prm).WithAddress(v)
 	}

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -11,6 +11,8 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/token"
 )
@@ -104,7 +106,7 @@ func (x *GetObjectPrm) SetRawFlag() {
 // SetAddress sets object address.
 //
 // Required parameter.
-func (x *GetObjectPrm) SetAddress(addr *object.Address) {
+func (x *GetObjectPrm) SetAddress(addr *addressSDK.Address) {
 	x.cliPrm.WithAddress(addr)
 }
 
@@ -155,7 +157,7 @@ func (x *HeadObjectPrm) SetRawFlag() {
 // SetAddress sets object address.
 //
 // Required parameter.
-func (x *HeadObjectPrm) SetAddress(addr *object.Address) {
+func (x *HeadObjectPrm) SetAddress(addr *addressSDK.Address) {
 	x.cliPrm.WithAddress(addr)
 }
 
@@ -206,7 +208,7 @@ func (x *PayloadRangePrm) SetRawFlag() {
 // SetAddress sets object address.
 //
 // Required parameter.
-func (x *PayloadRangePrm) SetAddress(addr *object.Address) {
+func (x *PayloadRangePrm) SetAddress(addr *addressSDK.Address) {
 	x.cliPrm.WithAddress(addr)
 }
 
@@ -267,7 +269,7 @@ type PutObjectRes struct {
 }
 
 // ID returns identifier of the stored object.
-func (x PutObjectRes) ID() *object.ID {
+func (x PutObjectRes) ID() *oidSDK.ID {
 	return x.cliRes.ID()
 }
 
@@ -313,7 +315,7 @@ type SearchObjectsRes struct {
 }
 
 // IDList returns identifiers of the matched objects.
-func (x SearchObjectsRes) IDList() []*object.ID {
+func (x SearchObjectsRes) IDList() []*oidSDK.ID {
 	return x.cliRes.IDList()
 }
 

--- a/pkg/services/object/put/res.go
+++ b/pkg/services/object/put/res.go
@@ -1,13 +1,13 @@
 package putsvc
 
 import (
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type PutResponse struct {
-	id *object.ID
+	id *oidSDK.ID
 }
 
-func (r *PutResponse) ObjectID() *object.ID {
+func (r *PutResponse) ObjectID() *oidSDK.ID {
 	return r.id
 }

--- a/pkg/services/object/search/exec.go
+++ b/pkg/services/object/search/exec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -132,7 +133,7 @@ func (exec execCtx) remoteClient(info client.NodeInfo) (searchClient, bool) {
 	return nil, false
 }
 
-func (exec *execCtx) writeIDList(ids []*objectSDK.ID) {
+func (exec *execCtx) writeIDList(ids []*oidSDK.ID) {
 	err := exec.prm.writer.WriteIDs(ids)
 
 	switch {

--- a/pkg/services/object/search/prm.go
+++ b/pkg/services/object/search/prm.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Prm groups parameters of Get service call.
@@ -23,12 +24,12 @@ type Prm struct {
 // IDListWriter is an interface of target component
 // to write list of object identifiers.
 type IDListWriter interface {
-	WriteIDs([]*objectSDK.ID) error
+	WriteIDs([]*oidSDK.ID) error
 }
 
 // RequestForwarder is a callback for forwarding of the
 // original Search requests.
-type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) ([]*objectSDK.ID, error)
+type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) ([]*oidSDK.ID, error)
 
 // SetCommonParameters sets common parameters of the operation.
 func (p *Prm) SetCommonParameters(common *util.CommonPrm) {

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"go.uber.org/zap"
 )
@@ -25,7 +25,7 @@ type Service struct {
 type Option func(*cfg)
 
 type searchClient interface {
-	searchObjects(*execCtx, client.NodeInfo) ([]*object.ID, error)
+	searchObjects(*execCtx, client.NodeInfo) ([]*oidSDK.ID, error)
 }
 
 type ClientConstructor interface {
@@ -36,7 +36,7 @@ type cfg struct {
 	log *logger.Logger
 
 	localStorage interface {
-		search(*execCtx) ([]*object.ID, error)
+		search(*execCtx) ([]*oidSDK.ID, error)
 	}
 
 	clientConstructor interface {

--- a/pkg/services/object/search/util.go
+++ b/pkg/services/object/search/util.go
@@ -10,7 +10,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type uniqueIDWriter struct {
@@ -44,7 +45,7 @@ func newUniqueAddressWriter(w IDListWriter) IDListWriter {
 	}
 }
 
-func (w *uniqueIDWriter) WriteIDs(list []*objectSDK.ID) error {
+func (w *uniqueIDWriter) WriteIDs(list []*oidSDK.ID) error {
 	w.mtx.Lock()
 
 	for i := 0; i < len(list); i++ { // don't use range, slice mutates in body
@@ -79,7 +80,7 @@ func (c *clientConstructorWrapper) get(info client.NodeInfo) (searchClient, erro
 	}, nil
 }
 
-func (c *clientWrapper) searchObjects(exec *execCtx, info client.NodeInfo) ([]*objectSDK.ID, error) {
+func (c *clientWrapper) searchObjects(exec *execCtx, info client.NodeInfo) ([]*oidSDK.ID, error) {
 	if exec.prm.forwarder != nil {
 		return exec.prm.forwarder(info, c.client)
 	}
@@ -110,7 +111,7 @@ func (c *clientWrapper) searchObjects(exec *execCtx, info client.NodeInfo) ([]*o
 	return res.IDList(), nil
 }
 
-func (e *storageEngineWrapper) search(exec *execCtx) ([]*objectSDK.ID, error) {
+func (e *storageEngineWrapper) search(exec *execCtx) ([]*oidSDK.ID, error) {
 	r, err := (*engine.StorageEngine)(e).Select(new(engine.SelectPrm).
 		WithFilters(exec.searchFilters()).
 		WithContainerID(exec.containerID()),
@@ -122,8 +123,8 @@ func (e *storageEngineWrapper) search(exec *execCtx) ([]*objectSDK.ID, error) {
 	return idsFromAddresses(r.AddressList()), nil
 }
 
-func idsFromAddresses(addrs []*objectSDK.Address) []*objectSDK.ID {
-	ids := make([]*objectSDK.ID, len(addrs))
+func idsFromAddresses(addrs []*addressSDK.Address) []*oidSDK.ID {
+	ids := make([]*oidSDK.ID, len(addrs))
 
 	for i := range addrs {
 		ids[i] = addrs[i].ObjectID()
@@ -133,7 +134,7 @@ func idsFromAddresses(addrs []*objectSDK.Address) []*objectSDK.ID {
 }
 
 func (e *traverseGeneratorWrapper) generateTraverser(cid *cid.ID, epoch uint64) (*placement.Traverser, error) {
-	a := objectSDK.NewAddress()
+	a := addressSDK.NewAddress()
 	a.SetContainerID(cid)
 
 	return (*util.TraverserGenerator)(e).GenerateTraverser(a, epoch)

--- a/pkg/services/object/search/v2/streamer.go
+++ b/pkg/services/object/search/v2/streamer.go
@@ -4,14 +4,14 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	objectSvc "github.com/nspcc-dev/neofs-node/pkg/services/object"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type streamWriter struct {
 	stream objectSvc.SearchStream
 }
 
-func (s *streamWriter) WriteIDs(ids []*objectSDK.ID) error {
+func (s *streamWriter) WriteIDs(ids []*oidSDK.ID) error {
 	r := new(object.SearchResponse)
 
 	body := new(object.SearchResponseBody)

--- a/pkg/services/object/search/v2/util.go
+++ b/pkg/services/object/search/v2/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStream) (*searchsvc.Prm, error) {
@@ -44,7 +45,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 			return nil, err
 		}
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) ([]*objectSDK.ID, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) ([]*oidSDK.ID, error) {
 			var err error
 
 			// once compose and resign forwarding request
@@ -72,7 +73,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 			// code below is copy-pasted from c.SearchObjects implementation,
 			// perhaps it is worth highlighting the utility function in neofs-api-go
 			var (
-				searchResult []*objectSDK.ID
+				searchResult []*oidSDK.ID
 				resp         = new(objectV2.SearchResponse)
 			)
 
@@ -99,7 +100,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 
 				chunk := resp.GetBody().GetIDList()
 				for i := range chunk {
-					searchResult = append(searchResult, objectSDK.NewIDFromV2(chunk[i]))
+					searchResult = append(searchResult, oidSDK.NewIDFromV2(chunk[i]))
 				}
 			}
 
@@ -114,11 +115,11 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 	return p, nil
 }
 
-func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) ([]*objectSDK.ID, error)) searchsvc.RequestForwarder {
-	return func(info client.NodeInfo, c client.MultiAddressClient) ([]*objectSDK.ID, error) {
+func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) ([]*oidSDK.ID, error)) searchsvc.RequestForwarder {
+	return func(info client.NodeInfo, c client.MultiAddressClient) ([]*oidSDK.ID, error) {
 		var (
 			firstErr error
-			res      []*objectSDK.ID
+			res      []*oidSDK.ID
 
 			key = info.PublicKey()
 		)

--- a/pkg/services/object/util/placement.go
+++ b/pkg/services/object/util/placement.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	netmapSDK "github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type localPlacement struct {
@@ -42,7 +42,7 @@ func NewLocalPlacement(b placement.Builder, s netmap.AnnouncedKeys) placement.Bu
 	}
 }
 
-func (p *localPlacement) BuildPlacement(addr *object.Address, policy *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
+func (p *localPlacement) BuildPlacement(addr *addressSDK.Address, policy *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
 	vs, err := p.builder.BuildPlacement(addr, policy)
 	if err != nil {
 		return nil, fmt.Errorf("(%T) could not build object placement: %w", p, err)
@@ -76,7 +76,7 @@ func NewRemotePlacementBuilder(b placement.Builder, s netmap.AnnouncedKeys) plac
 	}
 }
 
-func (p *remotePlacement) BuildPlacement(addr *object.Address, policy *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
+func (p *remotePlacement) BuildPlacement(addr *addressSDK.Address, policy *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
 	vs, err := p.builder.BuildPlacement(addr, policy)
 	if err != nil {
 		return nil, fmt.Errorf("(%T) could not build object placement: %w", p, err)
@@ -123,7 +123,7 @@ func (g *TraverserGenerator) WithTraverseOptions(opts ...placement.Option) *Trav
 
 // GenerateTraverser generates placement Traverser for provided object address
 // using epoch-th network map.
-func (g *TraverserGenerator) GenerateTraverser(addr *object.Address, epoch uint64) (*placement.Traverser, error) {
+func (g *TraverserGenerator) GenerateTraverser(addr *addressSDK.Address, epoch uint64) (*placement.Traverser, error) {
 	// get network map by epoch
 	nm, err := g.netMapSrc.GetNetMapByEpoch(epoch)
 	if err != nil {

--- a/pkg/services/object_manager/placement/netmap.go
+++ b/pkg/services/object_manager/placement/netmap.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	netmapSDK "github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type netMapBuilder struct {
@@ -34,7 +35,7 @@ func (s *netMapSrc) GetNetMap(diff uint64) (*netmapSDK.Netmap, error) {
 	return s.nm, nil
 }
 
-func (b *netMapBuilder) BuildPlacement(a *object.Address, p *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
+func (b *netMapBuilder) BuildPlacement(a *addressSDK.Address, p *netmapSDK.PlacementPolicy) ([]netmapSDK.Nodes, error) {
 	nm, err := netmap.GetLatestNetworkMap(b.nmSrc)
 	if err != nil {
 		return nil, fmt.Errorf("could not get network map: %w", err)
@@ -48,7 +49,7 @@ func (b *netMapBuilder) BuildPlacement(a *object.Address, p *netmapSDK.Placement
 	return BuildObjectPlacement(nm, cn, a.ObjectID())
 }
 
-func BuildObjectPlacement(nm *netmapSDK.Netmap, cnrNodes netmapSDK.ContainerNodes, id *object.ID) ([]netmapSDK.Nodes, error) {
+func BuildObjectPlacement(nm *netmapSDK.Netmap, cnrNodes netmapSDK.ContainerNodes, id *oidSDK.ID) ([]netmapSDK.Nodes, error) {
 	objectID := id.ToV2()
 	if objectID == nil {
 		return cnrNodes.Replicas(), nil

--- a/pkg/services/object_manager/placement/traverser.go
+++ b/pkg/services/object_manager/placement/traverser.go
@@ -8,7 +8,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Builder is an interface of the
@@ -19,7 +20,7 @@ type Builder interface {
 	//
 	// Must return all container nodes if object identifier
 	// is nil.
-	BuildPlacement(*object.Address, *netmap.PlacementPolicy) ([]netmap.Nodes, error)
+	BuildPlacement(*addressSDK.Address, *netmap.PlacementPolicy) ([]netmap.Nodes, error)
 }
 
 // Option represents placement traverser option.
@@ -40,7 +41,7 @@ type cfg struct {
 
 	flatSuccess *uint32
 
-	addr *object.Address
+	addr *addressSDK.Address
 
 	policy *netmap.PlacementPolicy
 
@@ -56,7 +57,7 @@ var errNilPolicy = errors.New("placement policy is nil")
 func defaultCfg() *cfg {
 	return &cfg{
 		trackCopies: true,
-		addr:        object.NewAddress(),
+		addr:        addressSDK.NewAddress(),
 	}
 }
 
@@ -226,7 +227,7 @@ func ForContainer(cnr *container.Container) Option {
 }
 
 // ForObject is a processing object setting option.
-func ForObject(id *object.ID) Option {
+func ForObject(id *oidSDK.ID) Option {
 	return func(c *cfg) {
 		c.addr.SetObjectID(id)
 	}

--- a/pkg/services/object_manager/placement/traverser_test.go
+++ b/pkg/services/object_manager/placement/traverser_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +15,7 @@ type testBuilder struct {
 	vectors []netmap.Nodes
 }
 
-func (b testBuilder) BuildPlacement(*object.Address, *netmap.PlacementPolicy) ([]netmap.Nodes, error) {
+func (b testBuilder) BuildPlacement(*addressSDK.Address, *netmap.PlacementPolicy) ([]netmap.Nodes, error) {
 	return b.vectors, nil
 }
 

--- a/pkg/services/object_manager/storagegroup/collect.go
+++ b/pkg/services/object_manager/storagegroup/collect.go
@@ -6,7 +6,8 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"github.com/nspcc-dev/tzhash/tz"
 )
@@ -15,12 +16,12 @@ import (
 // with information about members collected via HeadReceiver.
 //
 // Resulting storage group consists of physically stored objects only.
-func CollectMembers(r objutil.HeadReceiver, cid *cid.ID, members []*objectSDK.ID) (*storagegroup.StorageGroup, error) {
+func CollectMembers(r objutil.HeadReceiver, cid *cid.ID, members []*oidSDK.ID) (*storagegroup.StorageGroup, error) {
 	var (
 		sumPhySize uint64
-		phyMembers []*objectSDK.ID
+		phyMembers []*oidSDK.ID
 		phyHashes  [][]byte
-		addr       = objectSDK.NewAddress()
+		addr       = addressSDK.NewAddress()
 		sg         = storagegroup.New()
 	)
 

--- a/pkg/services/object_manager/transformer/fmt.go
+++ b/pkg/services/object_manager/transformer/fmt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
@@ -70,7 +71,7 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 	f.obj.SetCreationEpoch(curEpoch)
 
 	var (
-		parID  *objectSDK.ID
+		parID  *oidSDK.ID
 		parHdr *objectSDK.Object
 	)
 

--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 )
 
@@ -23,7 +24,7 @@ type payloadSizeLimiter struct {
 
 	currentHashers, parentHashers []*payloadChecksumHasher
 
-	previous []*objectSDK.ID
+	previous []*oidSDK.ID
 
 	chunkWriter io.Writer
 

--- a/pkg/services/object_manager/transformer/types.go
+++ b/pkg/services/object_manager/transformer/types.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // AccessIdentifiers represents group of the object identifiers
 // that are returned after writing the object.
 // Consists of the ID of the stored object and the ID of the parent object.
 type AccessIdentifiers struct {
-	par, self *objectSDK.ID
+	par, self *oidSDK.ID
 
 	parHdr *objectSDK.Object
 }
@@ -50,7 +51,7 @@ type ObjectTarget interface {
 type TargetInitializer func() ObjectTarget
 
 // SelfID returns identifier of the written object.
-func (a *AccessIdentifiers) SelfID() *objectSDK.ID {
+func (a *AccessIdentifiers) SelfID() *oidSDK.ID {
 	if a != nil {
 		return a.self
 	}
@@ -59,7 +60,7 @@ func (a *AccessIdentifiers) SelfID() *objectSDK.ID {
 }
 
 // WithSelfID returns AccessIdentifiers with passed self identifier.
-func (a *AccessIdentifiers) WithSelfID(v *objectSDK.ID) *AccessIdentifiers {
+func (a *AccessIdentifiers) WithSelfID(v *oidSDK.ID) *AccessIdentifiers {
 	res := a
 	if res == nil {
 		res = new(AccessIdentifiers)
@@ -71,7 +72,7 @@ func (a *AccessIdentifiers) WithSelfID(v *objectSDK.ID) *AccessIdentifiers {
 }
 
 // ParentID return identifier of the parent of the written object.
-func (a *AccessIdentifiers) ParentID() *objectSDK.ID {
+func (a *AccessIdentifiers) ParentID() *oidSDK.ID {
 	if a != nil {
 		return a.par
 	}
@@ -80,7 +81,7 @@ func (a *AccessIdentifiers) ParentID() *objectSDK.ID {
 }
 
 // WithParentID returns AccessIdentifiers with passed parent identifier.
-func (a *AccessIdentifiers) WithParentID(v *objectSDK.ID) *AccessIdentifiers {
+func (a *AccessIdentifiers) WithParentID(v *oidSDK.ID) *AccessIdentifiers {
 	res := a
 	if res == nil {
 		res = new(AccessIdentifiers)

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -10,11 +10,11 @@ import (
 	headsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/head"
 	"github.com/nspcc-dev/neofs-node/pkg/services/replicator"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
-func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
+func (p *Policer) processObject(ctx context.Context, addr *addressSDK.Address) {
 	cnr, err := p.cnrSrc.Get(addr.ContainerID())
 	if err != nil {
 		p.log.Error("could not get container",
@@ -60,7 +60,7 @@ func (p *Policer) processObject(ctx context.Context, addr *object.Address) {
 	}
 }
 
-func (p *Policer) processNodes(ctx context.Context, addr *object.Address, nodes netmap.Nodes, shortage uint32) {
+func (p *Policer) processNodes(ctx context.Context, addr *addressSDK.Address, nodes netmap.Nodes, shortage uint32) {
 	log := p.log.With(
 		zap.Stringer("object", addr),
 	)

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/services/replicator"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
 )
@@ -35,7 +35,7 @@ type Option func(*cfg)
 
 // RedundantCopyCallback is a callback to pass
 // the redundant local copy of the object.
-type RedundantCopyCallback func(*object.Address)
+type RedundantCopyCallback func(*addressSDK.Address)
 
 type cfg struct {
 	headTimeout time.Duration

--- a/pkg/services/policer/process.go
+++ b/pkg/services/policer/process.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ func (p *Policer) Run(ctx context.Context) {
 
 func (p *Policer) shardPolicyWorker(ctx context.Context) {
 	var (
-		addrs  []*object.Address
+		addrs  []*addressSDK.Address
 		cursor *engine.Cursor
 		err    error
 	)

--- a/pkg/services/policer/queue.go
+++ b/pkg/services/policer/queue.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 type jobQueue struct {
 	localStorage *engine.StorageEngine
 }
 
-func (q *jobQueue) Select(cursor *engine.Cursor, count uint32) ([]*object.Address, *engine.Cursor, error) {
+func (q *jobQueue) Select(cursor *engine.Cursor, count uint32) ([]*addressSDK.Address, *engine.Cursor, error) {
 	prm := new(engine.ListWithCursorPrm)
 	prm.WithCursor(cursor)
 	prm.WithCount(count)

--- a/pkg/services/replicator/task.go
+++ b/pkg/services/replicator/task.go
@@ -2,14 +2,14 @@ package replicator
 
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 )
 
 // Task represents group of Replicator task parameters.
 type Task struct {
 	quantity uint32
 
-	addr *object.Address
+	addr *addressSDK.Address
 
 	nodes netmap.Nodes
 }
@@ -35,7 +35,7 @@ func (t *Task) WithCopiesNumber(v uint32) *Task {
 }
 
 // WithObjectAddress sets address of local object.
-func (t *Task) WithObjectAddress(v *object.Address) *Task {
+func (t *Task) WithObjectAddress(v *addressSDK.Address) *Task {
 	if t != nil {
 		t.addr = v
 	}


### PR DESCRIPTION
Rebase and merge only after #1101.

`object.Address` has been moved to `object/address`
`object.ID` has been moved to `object/id`

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>