### PR TITLE
Fix/Allow usage of empty wallet passwords

### DIFF
--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -215,9 +215,11 @@ func getKeyNoGenerate() (*ecdsa.PrivateKey, error) {
 }
 
 func getPassword() (string, error) {
-	if pass := viper.GetString(password); pass != "" {
-		return pass, nil
+	// this check allows empty passwords
+	if viper.IsSet(password) {
+		return viper.GetString(password), nil
 	}
+
 	return input.ReadPassword("Enter password > ")
 }
 


### PR DESCRIPTION
It was impossible to specify an empty password for wallets in `neofs-cli` via config file.