### PR TITLE
[#1182] neofs-cli: use `BasicACL.String()` for user output

### DIFF
--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -842,7 +842,7 @@ func printJSONMarshaler(cmd *cobra.Command, j json.Marshaler, entity string) {
 }
 
 func prettyPrintBasicACL(cmd *cobra.Command, basicACL acl.BasicACL) {
-	cmd.Printf("basic ACL: %.8x", basicACL)
+	cmd.Printf("basic ACL: %s", basicACL)
 	for k, v := range wellKnownBasicACL {
 		if v == basicACL {
 			cmd.Printf(" (%s)\n", k)


### PR DESCRIPTION
Close #1182.
Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>