### PR TITLE
Check for object existence in parallel

### DIFF
--- a/pkg/local_object_storage/engine/put.go
+++ b/pkg/local_object_storage/engine/put.go
@@ -49,7 +49,9 @@ func (e *StorageEngine) put(prm *PutPrm) (*PutRes, error) {
 		defer elapsed(e.metrics.AddPutDuration)()
 	}
 
-	_, err := e.exists(prm.obj.Address()) // TODO: #1146 make this check parallel
+	// In #1146 this check was parallelized, however, it became
+	// much slower on fast machines for 4 shards.
+	_, err := e.exists(prm.obj.Address())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Close #1146 .

Benchmark results on my laptop (all shards are on a single SSD).
```
name               old time/op    new time/op    delta
Exists/2_shards-8    25.4µs ± 3%    31.7µs ±16%  +25.07%  (p=0.000 n=10+10)
Exists/4_shards-8    49.2µs ± 7%    48.1µs ±12%     ~     (p=0.579 n=10+10)
Exists/8_shards-8    93.4µs ± 1%    69.9µs ±25%  -25.22%  (p=0.000 n=10+9)

name               old alloc/op   new alloc/op   delta
Exists/2_shards-8    4.98kB ± 0%    5.22kB ± 0%   +4.83%  (p=0.000 n=10+10)
Exists/4_shards-8    9.42kB ± 1%    9.85kB ± 1%   +4.58%  (p=0.000 n=10+10)
Exists/8_shards-8    18.2kB ± 1%    19.0kB ± 0%   +4.40%  (p=0.000 n=10+9)

name               old allocs/op  new allocs/op  delta
Exists/2_shards-8       111 ± 1%       120 ± 0%   +7.37%  (p=0.000 n=10+10)
Exists/4_shards-8       203 ± 1%       215 ± 1%   +6.02%  (p=0.000 n=10+10)
Exists/8_shards-8       384 ± 1%       404 ± 0%   +5.15%  (p=0.000 n=10+9)
```

So there are no gains unless we have 8 shards. I propose to test this in a 1 shard per SSD setup and see how it goes. Anyway, we can always switch between parallel / sequential check based on the amount of shards.