### PR TITLE
Fix/Do not reset epoch timer on `NewEpoch`

### DIFF
--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -20,6 +20,7 @@ type (
 	// EpochTimerReseter is a callback interface for tickers component.
 	EpochTimerReseter interface {
 		ResetEpochTimer() error
+		ResetOnDeltaTimers() error
 	}
 
 	// EpochState is a callback interface for inner ring global state.

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -164,6 +164,11 @@ func (s *Server) ResetEpochTimer() error {
 	return s.epochTimer.Reset()
 }
 
+// ResetOnDeltaTimers resets OnDelta block timers of the epoch.
+func (s *Server) ResetOnDeltaTimers() error {
+	return s.epochTimer.ResetOnDelta()
+}
+
 func (s *Server) setHealthStatus(hs control.HealthStatus) {
 	s.healthStatus.Store(hs)
 }

--- a/pkg/morph/timer/block.go
+++ b/pkg/morph/timer/block.go
@@ -134,6 +134,27 @@ func (t *BlockTimer) Reset() error {
 	return nil
 }
 
+// ResetOnDelta resets only timers that were registered
+// via OnDelta call.
+//
+// Returns BlockMeter's error upon occurrence.
+func (t *BlockTimer) ResetOnDelta() error {
+	d, err := t.dur()
+	if err != nil {
+		return err
+	}
+
+	t.mtx.Lock()
+
+	for i := range t.ps {
+		t.ps[i].resetWithBaseInterval(d)
+	}
+
+	t.mtx.Unlock()
+
+	return nil
+}
+
 func (t *BlockTimer) resetWithBaseInterval(d uint32) {
 	t.rolledBack = false
 	t.baseDur = d


### PR DESCRIPTION
`NewEpoch` event is received in the next after `NewEpoch` morph call block.
It leads to the race: if that event is handled first, tick progress of the
`epochTimer` is lost and an epoch becomes one block longer.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>