### PR TITLE
neofs-node: remove mutex from `lruNetCache`

### DIFF
--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -98,14 +98,12 @@ func (c *ttlNetCache) keys() []interface{} {
 
 // entity that provides LRU cache interface.
 type lruNetCache struct {
-	mtx sync.Mutex
-
 	cache *lru.Cache
 
 	netRdr netValueReader
 }
 
-// complicates netValueReader with LRU caching mechanism.
+// newNetworkLRUCache returns wrapper over netValueReader with LRU cache.
 func newNetworkLRUCache(sz int, netRdr netValueReader) *lruNetCache {
 	cache, err := lru.New(sz)
 	fatalOnErr(err)
@@ -122,9 +120,6 @@ func newNetworkLRUCache(sz int, netRdr netValueReader) *lruNetCache {
 //
 // returned value should not be modified.
 func (c *lruNetCache) get(key interface{}) (interface{}, error) {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
 	val, ok := c.cache.Get(key)
 	if ok {
 		return val, nil

--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -25,8 +24,6 @@ type valueWithTime struct {
 
 // entity that provides TTL cache interface.
 type ttlNetCache struct {
-	mtx sync.Mutex
-
 	ttl time.Duration
 
 	sz int
@@ -55,9 +52,6 @@ func newNetworkTTLCache(sz int, ttl time.Duration, netRdr netValueReader) *ttlNe
 //
 // returned value should not be modified.
 func (c *ttlNetCache) get(key interface{}) (interface{}, error) {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
 	val, ok := c.cache.Peek(key)
 	if ok {
 		valWithTime := val.(*valueWithTime)
@@ -83,16 +77,10 @@ func (c *ttlNetCache) get(key interface{}) (interface{}, error) {
 }
 
 func (c *ttlNetCache) remove(key interface{}) {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
 	c.cache.Remove(key)
 }
 
 func (c *ttlNetCache) keys() []interface{} {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
 	return c.cache.Keys()
 }
 


### PR DESCRIPTION
We already use thread-safe LRU and mutex shouldn't be taken while making
network requests.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>