### PR TITLE
[#1244] nats: Split client creation into 2 stages

### DIFF
--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -89,6 +89,7 @@ func initApp(c *cfg) {
 }
 
 func bootUp(c *cfg) {
+	connectNats(c)
 	serveGRPC(c)
 	makeAndWaitNotaryDeposit(c)
 	bootstrapNode(c)

--- a/pkg/services/notificator/nats/options.go
+++ b/pkg/services/notificator/nats/options.go
@@ -33,6 +33,6 @@ func WithConnectionName(name string) Option {
 
 func WithLogger(logger *zap.Logger) Option {
 	return func(o *opts) {
-		o.logger = logger
+		o.log = logger
 	}
 }


### PR DESCRIPTION
Close #1244.
Create and connect to an endpoint using separate functions.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>