### PR TITLE
network: remove unused constants

### DIFF
--- a/pkg/network/address.go
+++ b/pkg/network/address.go
@@ -76,11 +76,6 @@ func (a *Address) FromString(s string) error {
 	return err
 }
 
-const (
-	grpcScheme    = "grpc"
-	grpcTLSScheme = "grpcs"
-)
-
 // multiaddrStringFromHostAddr converts "localhost:8080" to "/dns4/localhost/tcp/8080"
 func multiaddrStringFromHostAddr(host string) (string, error) {
 	endpoint, port, err := net.SplitHostPort(host)

--- a/pkg/network/address_test.go
+++ b/pkg/network/address_test.go
@@ -18,7 +18,7 @@ func TestAddressFromString(t *testing.T) {
 			{"213.44.87.1:32512", buildMultiaddr("/ip4/213.44.87.1/tcp/32512", t)},
 			{"[2004:eb1::1]:8080", buildMultiaddr("/ip6/2004:eb1::1/tcp/8080", t)},
 			{"grpc://example.com:7070", buildMultiaddr("/dns4/example.com/tcp/7070", t)},
-			{grpcTLSScheme + "://example.com:7070", buildMultiaddr("/dns4/example.com/tcp/7070/"+tlsProtocolName, t)},
+			{"grpcs://example.com:7070", buildMultiaddr("/dns4/example.com/tcp/7070/"+tlsProtocolName, t)},
 		}
 
 		var addr Address


### PR DESCRIPTION
Fix linter complaints. These constants are unused after
nspcc-dev/neofs-node#1232.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>