### PR TITLE
Fix cursor output with inhumed objects

### DIFF
--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -114,7 +114,16 @@ func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorR
 			continue
 		}
 
-		result = append(result, res.AddressList()...)
+		addressList := res.AddressList()
+		for j := range addressList {
+			_, err = e.exists(addressList[j])
+			if err != nil {
+				continue
+			}
+
+			result = append(result, addressList[j])
+		}
+
 		cursor.shardCursor = res.Cursor()
 		cursor.shardID = shardIDs[i]
 	}

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,42 @@ func TestListWithCursor(t *testing.T) {
 
 	got = sortAddresses(got)
 	require.Equal(t, expected, got)
+}
+
+func TestListWithCursorTomsbtoneDivergence(t *testing.T) {
+	s1 := testNewShard(t, 1)
+	s2 := testNewShard(t, 2)
+	cnrID := cidtest.ID()
+
+	// Shard1: [ Object1 ]
+	// Shard2: [ Object2, Tombstone(Object1) ]
+
+	regularObj1 := generateObjectWithCID(t, cnrID)
+	putPrm := new(shard.PutPrm).WithObject(regularObj1)
+	_, err := s1.Put(putPrm)
+	require.NoError(t, err)
+
+	tombstoneObj := generateObjectWithCID(t, cnrID)
+	inhumePrm := new(shard.InhumePrm).WithTarget(object.AddressOf(tombstoneObj), object.AddressOf(regularObj1))
+	_, err = s2.Inhume(inhumePrm)
+	require.NoError(t, err)
+
+	regularObj2 := generateObjectWithCID(t, cnrID)
+	putPrm = new(shard.PutPrm).WithObject(regularObj2)
+	_, err = s2.Put(putPrm)
+	require.NoError(t, err)
+
+	e := testNewEngineWithShards(s1, s2)
+	t.Cleanup(func() {
+		e.Close()
+		os.RemoveAll(t.Name())
+	})
+
+	prm := new(ListWithCursorPrm).WithCount(100)
+	res, err := e.ListWithCursor(prm)
+	require.NoError(t, err)
+	require.Len(t, res.AddressList(), 1) // must not return inhumed object
+	require.EqualValues(t, res.AddressList()[0], object.AddressOf(regularObj2))
 }
 
 func sortAddresses(addr []*addressSDK.Address) []*addressSDK.Address {


### PR DESCRIPTION
Inspired by https://github.com/nspcc-dev/neofs-node/issues/1186

I decided to check if it is possible to have inhumed object in cursor output. It is possible when object and tombstone are in different shards. Considering latest fixes, I think we have to process that as well.