### PR TITLE
innerring: disallow to tick timer twice on the same height

### DIFF
--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -66,9 +66,9 @@ func (s *Server) startBlockTimers() error {
 	return nil
 }
 
-func (s *Server) tickTimers() {
+func (s *Server) tickTimers(h uint32) {
 	for i := range s.blockTimers {
-		s.blockTimers[i].Tick()
+		s.blockTimers[i].Tick(h)
 	}
 }
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -241,7 +241,7 @@ func (s *Server) Start(ctx context.Context, intError chan<- error) (err error) {
 				zap.Uint32("block_index", b.Index))
 		}
 
-		s.tickTimers()
+		s.tickTimers(b.Index)
 	})
 
 	if !s.withoutMainNet {

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -23,7 +23,15 @@ func (np *Processor) processNewEpoch(ev netmapEvent.NewEpoch) {
 	}
 
 	np.epochState.SetEpochCounter(epoch)
-	if err := np.epochTimer.ResetEpochTimer(); err != nil {
+
+	h, err := np.netmapClient.Morph().TxHeight(ev.TxHash())
+	if err != nil {
+		np.log.Warn("can't get transaction height",
+			zap.String("hash", ev.TxHash().StringLE()),
+			zap.String("error", err.Error()))
+	}
+
+	if err := np.epochTimer.ResetEpochTimer(h); err != nil {
 		np.log.Warn("can't reset epoch timer",
 			zap.String("error", err.Error()))
 	}

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -19,7 +19,7 @@ import (
 type (
 	// EpochTimerReseter is a callback interface for tickers component.
 	EpochTimerReseter interface {
-		ResetEpochTimer() error
+		ResetEpochTimer(uint32) error
 	}
 
 	// EpochState is a callback interface for inner ring global state.

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -160,7 +160,8 @@ func (s *Server) WriteReport(r *audit.Report) error {
 // ResetEpochTimer resets block timer that produces events to update epoch
 // counter in netmap contract. Used to synchronize this even production
 // based on block with notification of last epoch.
-func (s *Server) ResetEpochTimer() error {
+func (s *Server) ResetEpochTimer(h uint32) error {
+	s.epochTimer.Tick(h)
 	return s.epochTimer.Reset()
 }
 

--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -341,6 +341,18 @@ func (c *Client) TxHalt(h util.Uint256) (res bool, err error) {
 	return len(aer.Executions) > 0 && aer.Executions[0].VMState.HasFlag(vm.HaltState), nil
 }
 
+// TxHeight returns true if transaction has been successfully executed and persisted.
+func (c *Client) TxHeight(h util.Uint256) (res uint32, err error) {
+	if c.multiClient != nil {
+		return res, c.multiClient.iterateClients(func(c *Client) error {
+			res, err = c.TxHeight(h)
+			return err
+		})
+	}
+
+	return c.client.GetTransactionHeight(h)
+}
+
 // NeoFSAlphabetList returns keys that stored in NeoFS Alphabet role. Main chain
 // stores alphabet node keys of inner ring there, however side chain stores both
 // alphabet and non alphabet node keys of inner ring.

--- a/pkg/morph/timer/block.go
+++ b/pkg/morph/timer/block.go
@@ -27,6 +27,8 @@ type BlockTimer struct {
 
 	cur, tgt uint32
 
+	last uint32
+
 	h BlockTickHandler
 
 	ps []BlockTimer
@@ -159,13 +161,18 @@ func (t *BlockTimer) reset() {
 // Tick ticks one block in the BlockTimer.
 //
 // Executes all callbacks which are awaiting execution at the new block.
-func (t *BlockTimer) Tick() {
+func (t *BlockTimer) Tick(h uint32) {
 	t.mtx.Lock()
-	t.tick()
+	t.tick(h)
 	t.mtx.Unlock()
 }
 
-func (t *BlockTimer) tick() {
+func (t *BlockTimer) tick(h uint32) {
+	if h != 0 && t.last == h {
+		return
+	}
+
+	t.last = h
 	t.cur++
 
 	if t.cur == t.tgt {
@@ -182,6 +189,6 @@ func (t *BlockTimer) tick() {
 	}
 
 	for i := range t.ps {
-		t.ps[i].tick()
+		t.ps[i].tick(h)
 	}
 }


### PR DESCRIPTION
Close #1208.

Provide current heights as an argument to ticker.
Zero height disables any checks, thus corresponding to the old
behaviour. If non-zero height is used, ignore the tick if the height
is less than the timer tick state.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>