### PR TITLE
neofs-adm: allow to change parameters of the Policy contract

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/policy.go
+++ b/cmd/neofs-adm/internal/modules/morph/policy.go
@@ -1,0 +1,63 @@
+package morph
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nspcc-dev/neo-go/pkg/core/native/nativenames"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
+	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	execFeeParam      = "ExecFeeFactor"
+	storagePriceParam = "StoragePrice"
+	setFeeParam       = "FeePerByte"
+)
+
+func setPolicyCmd(cmd *cobra.Command, args []string) error {
+	wCtx, err := newInitializeContext(cmd, viper.GetViper())
+	if err != nil {
+		return fmt.Errorf("can't to initialize context: %w", err)
+	}
+
+	policyHash, err := wCtx.Client.GetNativeContractHash(nativenames.Policy)
+	if err != nil {
+		return fmt.Errorf("can't get policy contract hash: %w", err)
+	}
+
+	bw := io.NewBufBinWriter()
+	for i := range args {
+		kv := strings.SplitN(args[i], "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid parameter format, must be Parameter=Value")
+		}
+
+		switch kv[0] {
+		case execFeeParam, storagePriceParam, setFeeParam:
+		default:
+			return fmt.Errorf("parameter must be one of %s, %s and %s", execFeeParam, storagePriceParam, setFeeParam)
+		}
+
+		value, err := strconv.ParseUint(kv[1], 10, 32)
+		if err != nil {
+			return fmt.Errorf("can't parse parameter value '%s': %w", args[1], err)
+		}
+
+		emit.AppCall(bw.BinWriter, policyHash, "set"+kv[0], callflag.All, int64(value))
+	}
+
+	// Unset group key to use `Global` signer scope. This function is unusual, because we
+	// work with native contract, not NeoFS one.
+	wCtx.groupKey = nil
+
+	if err := wCtx.sendCommitteeTx(bw.Bytes(), -1); err != nil {
+		return err
+	}
+
+	return wCtx.awaitTx()
+}

--- a/cmd/neofs-adm/internal/modules/morph/root.go
+++ b/cmd/neofs-adm/internal/modules/morph/root.go
@@ -106,6 +106,17 @@ var (
 		RunE: forceNewEpochCmd,
 	}
 
+	setPolicy = &cobra.Command{
+		Use:                   "set-policy [ExecFeeFactor=<n1>] [StoragePrice=<n2>] [FeePerByte=<n3>]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Set global policy values",
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
+			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
+		},
+		RunE: setPolicyCmd,
+	}
+
 	dumpContractHashesCmd = &cobra.Command{
 		Use:   "dump-hashes",
 		Short: "Dump deployed contract hashes.",
@@ -187,6 +198,10 @@ func init() {
 	RootCmd.AddCommand(forceNewEpoch)
 	forceNewEpoch.Flags().String(alphabetWalletsFlag, "", "path to alphabet wallets dir")
 	forceNewEpoch.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
+
+	RootCmd.AddCommand(setPolicy)
+	setPolicy.Flags().String(alphabetWalletsFlag, "", "path to alphabet wallets dir")
+	setPolicy.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
 
 	RootCmd.AddCommand(dumpContractHashesCmd)
 	dumpContractHashesCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")


### PR DESCRIPTION
Tested here (will finish testing with actual parameter update check later)  https://github.com/nspcc-dev/neofs-adm-tests/tree/set-policy):
```
$ make clone
$ NEOFS_REPO=https://github.com/fyrchik/neofs-node.git ./test.set-policy.sh neofs-adm-set-policy master
```

TODO: finish test, add to CI

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>