### PR TITLE
[#1288] neofs-adm: Allow to store garbage in alphabet wallet dir

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/native/nativenames"
@@ -193,14 +192,15 @@ func openAlphabetWallets(walletDir string) ([]*wallet.Wallet, error) {
 
 	var size int
 loop:
-	for i := range walletFiles {
-		for j := 0; j < len(walletFiles); j++ {
-			letter := innerring.GlagoliticLetter(j).String()
-			if strings.HasPrefix(walletFiles[i].Name(), letter) {
+	for i := 0; i < len(walletFiles); i++ {
+		name := innerring.GlagoliticLetter(i).String() + ".json"
+		for j := range walletFiles {
+			if walletFiles[j].Name() == name {
 				size++
 				continue loop
 			}
 		}
+		break
 	}
 	if size == 0 {
 		return nil, errors.New("alphabet wallets dir is empty (run `generate-alphabet` command first)")


### PR DESCRIPTION
Close #1288.

Check the full file name instead of just prefix. Also, fix a bug where
a single missing wallet could lead to an incorrect size calculation.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>