### PR TITLE
innerring: Don't stop the same listener twice

### DIFF
--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -282,7 +282,9 @@ func (s *Server) Stop() {
 	s.setHealthStatus(control.HealthStatus_SHUTTING_DOWN)
 
 	go s.morphListener.Stop()
-	go s.mainnetListener.Stop()
+	if !s.withoutMainNet {
+		go s.mainnetListener.Stop()
+	}
 
 	for _, c := range s.closers {
 		if err := c(); err != nil {

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -282,9 +282,7 @@ func (s *Server) Stop() {
 	s.setHealthStatus(control.HealthStatus_SHUTTING_DOWN)
 
 	go s.morphListener.Stop()
-	if !s.withoutMainNet {
-		go s.mainnetListener.Stop()
-	}
+	go s.mainnetListener.Stop()
 
 	for _, c := range s.closers {
 		if err := c(); err != nil {


### PR DESCRIPTION
When IR node configured without main chain, both `morphListener` and `mainnetListener` are pointing into single listener component. We should not call `Stop()` twice, because it may trigger channel closing in neo-go or other components and it can throw panic.

Related to https://github.com/nspcc-dev/neo-go/pull/2420