### PR TITLE
[#1213] morph/client: Return correct NNS from first attempt

### DIFF
--- a/pkg/morph/client/nns.go
+++ b/pkg/morph/client/nns.go
@@ -97,6 +97,7 @@ func (c *Client) NNSHash() (util.Uint160, error) {
 		c.mtx.Lock()
 		c.nnsHash = cs.Hash
 		c.mtx.Unlock()
+		nnsHash = cs.Hash
 	}
 	return nnsHash, nil
 }


### PR DESCRIPTION
Fixes error:
```
neofs-node/morph.go:55  failed to set group signer scope, continue with Global  {"error": "could not check presence in NNS contract for group.neofs: returned result stack is empty"}`
```
