### PR TITLE
Fix/Remove object upon tombstone

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -318,6 +318,8 @@ func initObjectService(c *cfg) {
 		getsvc.WithKeyStorage(keyStorage),
 	)
 
+	*c.cfgObject.getSvc = *sGet // need smth better
+
 	sGetV2 := getsvcV2.NewService(
 		getsvcV2.WithInternalService(sGet),
 		getsvcV2.WithKeyStorage(keyStorage),

--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
@@ -153,15 +154,9 @@ func (e *StorageEngine) inhumeAddr(addr *addressSDK.Address, prm *shard.InhumePr
 	return
 }
 
-func (e *StorageEngine) processExpiredTombstones(ctx context.Context, addrs []*addressSDK.Address) {
-	tss := make(map[string]*addressSDK.Address, len(addrs))
-
-	for i := range addrs {
-		tss[addrs[i].String()] = addrs[i]
-	}
-
+func (e *StorageEngine) processExpiredTombstones(ctx context.Context, addrs []meta.TombstonedObject) {
 	e.iterateOverUnsortedShards(func(sh hashedShard) (stop bool) {
-		sh.HandleExpiredTombstones(tss)
+		sh.HandleExpiredTombstones(addrs)
 
 		select {
 		case <-ctx.Done():

--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -49,6 +49,7 @@ func (db *DB) init(reset bool) error {
 		string(containerVolumeBucketName): {},
 		string(graveyardBucketName):       {},
 		string(toMoveItBucketName):        {},
+		string(garbageBucketName):         {},
 	}
 
 	return db.boltDB.Update(func(tx *bbolt.Tx) error {

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -53,6 +53,7 @@ func newDB(t testing.TB, opts ...meta.Option) *meta.DB {
 		opts...)...)
 
 	require.NoError(t, bdb.Open())
+	require.NoError(t, bdb.Init())
 
 	t.Cleanup(func() {
 		bdb.Close()

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -86,12 +86,12 @@ func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []*addressSDK.Address) error {
 }
 
 func (db *DB) delete(tx *bbolt.Tx, addr *addressSDK.Address, refCounter referenceCounter) error {
-	// remove record from graveyard
-	graveyard := tx.Bucket(graveyardBucketName)
-	if graveyard != nil {
-		err := graveyard.Delete(addressKey(addr))
+	// remove record from the garbage bucket
+	garbageBKT := tx.Bucket(garbageBucketName)
+	if garbageBKT != nil {
+		err := garbageBKT.Delete(addressKey(addr))
 		if err != nil {
-			return fmt.Errorf("could not remove from graveyard: %w", err)
+			return fmt.Errorf("could not remove from garbage bucket: %w", err)
 		}
 	}
 

--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/stretchr/testify/require"
@@ -45,9 +46,6 @@ func TestDB_Delete(t *testing.T) {
 	err = meta.Inhume(db, object.AddressOf(child), object.AddressOf(ts))
 	require.NoError(t, err)
 
-	err = meta.Inhume(db, object.AddressOf(child), object.AddressOf(ts))
-	require.NoError(t, err)
-
 	// delete object
 	err = meta.Delete(db, object.AddressOf(child))
 	require.NoError(t, err)
@@ -57,13 +55,14 @@ func TestDB_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, l, 0)
 
-	// check if they removed from graveyard
+	// check if they marked as already removed
+
 	ok, err := meta.Exists(db, object.AddressOf(child))
-	require.NoError(t, err)
+	require.Error(t, apistatus.ObjectAlreadyRemoved{})
 	require.False(t, ok)
 
 	ok, err = meta.Exists(db, object.AddressOf(parent))
-	require.NoError(t, err)
+	require.Error(t, apistatus.ObjectAlreadyRemoved{})
 	require.False(t, ok)
 }
 

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -2,10 +2,10 @@ package meta
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
-	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
 

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -9,53 +8,74 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-// Grave represents descriptor of DB's graveyard item.
-type Grave struct {
-	gcMark bool
-
+// DeletedObject represents descriptor of the object that was
+// marked to be deleted.
+type DeletedObject struct {
 	addr *addressSDK.Address
 }
 
-// WithGCMark returns true if grave marked for GC to be removed.
-func (g *Grave) WithGCMark() bool {
-	return g.gcMark
-}
-
 // Address returns buried object address.
-func (g *Grave) Address() *addressSDK.Address {
+func (g *DeletedObject) Address() *addressSDK.Address {
 	return g.addr
 }
 
-// GraveHandler is a Grave handling function.
-type GraveHandler func(*Grave) error
+// Handler is a DeletedObject handling function.
+type Handler func(*DeletedObject) error
+
+// IterateOverGarbage iterates over all objects
+// marked with GC mark.
+//
+// If h returns ErrInterruptIterator, nil returns immediately.
+// Returns other errors of h directly.
+func (db *DB) IterateOverGarbage(h Handler) error {
+	return db.boltDB.View(func(tx *bbolt.Tx) error {
+		return db.iterateDeletedObj(tx, withGC, h)
+	})
+}
 
 // IterateOverGraveyard iterates over all graves in DB.
 //
 // If h returns ErrInterruptIterator, nil returns immediately.
 // Returns other errors of h directly.
-func (db *DB) IterateOverGraveyard(h GraveHandler) error {
+func (db *DB) IterateOverGraveyard(h Handler) error {
 	return db.boltDB.View(func(tx *bbolt.Tx) error {
-		return db.iterateOverGraveyard(tx, h)
+		return db.iterateDeletedObj(tx, grave, h)
 	})
 }
 
-func (db *DB) iterateOverGraveyard(tx *bbolt.Tx, h GraveHandler) error {
-	// get graveyard bucket
-	bktGraveyard := tx.Bucket(graveyardBucketName)
-	if bktGraveyard == nil {
+type deletedType uint8
+
+const (
+	_ deletedType = iota
+	grave
+	withGC
+)
+
+func (db *DB) iterateDeletedObj(tx *bbolt.Tx, t deletedType, h Handler) error {
+	var bkt *bbolt.Bucket
+	switch t {
+	case grave:
+		bkt = tx.Bucket(graveyardBucketName)
+	case withGC:
+		bkt = tx.Bucket(garbageBucketName)
+	default:
+		panic(fmt.Sprintf("metabase: unknown iteration object type: %d", t))
+	}
+
+	if bkt == nil {
 		return nil
 	}
 
-	// iterate over all graves
-	err := bktGraveyard.ForEach(func(k, v []byte) error {
-		// parse Grave
-		g, err := graveFromKV(k, v)
+	// iterate over all deleted objects
+	err := bkt.ForEach(func(k, v []byte) error {
+		// parse deleted object
+		delObj, err := deletedObjectFromKV(k, v)
 		if err != nil {
 			return fmt.Errorf("could not parse Grave: %w", err)
 		}
 
-		// handler Grave
-		return h(g)
+		// handler object
+		return h(delObj)
 	})
 
 	if errors.Is(err, ErrInterruptIterator) {
@@ -65,14 +85,13 @@ func (db *DB) iterateOverGraveyard(tx *bbolt.Tx, h GraveHandler) error {
 	return err
 }
 
-func graveFromKV(k, v []byte) (*Grave, error) {
+func deletedObjectFromKV(k, _ []byte) (*DeletedObject, error) {
 	addr, err := addressFromKey(k)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse address: %w", err)
 	}
 
-	return &Grave{
-		gcMark: bytes.Equal(v, []byte(inhumeGCMarkValue)),
-		addr:   addr,
+	return &DeletedObject{
+		addr: addr,
 	}, nil
 }

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -229,3 +229,25 @@ func graveFromKV(k, v []byte) (TombstonedObject, error) {
 		tomb: tomb,
 	}, nil
 }
+
+// DropGraves deletes tombstoned objects from the
+// graveyard bucket.
+//
+// Returns any error appeared during deletion process.
+func (db *DB) DropGraves(tss []TombstonedObject) error {
+	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket(graveyardBucketName)
+		if bkt == nil {
+			return nil
+		}
+
+		for _, ts := range tss {
+			err := bkt.Delete(addressKey(ts.Address()))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -1,97 +1,231 @@
 package meta
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
 
 	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 )
 
-// DeletedObject represents descriptor of the object that was
-// marked to be deleted.
-type DeletedObject struct {
+// GarbageObject represents descriptor of the
+// object that has been marked with GC.
+type GarbageObject struct {
 	addr *addressSDK.Address
 }
 
-// Address returns buried object address.
-func (g *DeletedObject) Address() *addressSDK.Address {
+// Address returns garbage object address.
+func (g GarbageObject) Address() *addressSDK.Address {
 	return g.addr
 }
 
-// Handler is a DeletedObject handling function.
-type Handler func(*DeletedObject) error
+// GarbageHandler is a GarbageObject handling function.
+type GarbageHandler func(GarbageObject) error
+
+// GarbageIterationPrm groups parameters of the garbage
+// iteration process.
+type GarbageIterationPrm struct {
+	h      GarbageHandler
+	offset *addressSDK.Address
+}
+
+// SetHandler sets a handler that will be called on every
+// GarbageObject.
+func (g *GarbageIterationPrm) SetHandler(h GarbageHandler) *GarbageIterationPrm {
+	g.h = h
+	return g
+}
+
+// SetOffset sets an offset of the iteration operation.
+// The handler will be applied to the next after the
+// specified offset if any are left.
+//
+// Note: if offset is not found in db, iteration starts
+// from the element that WOULD BE the following after the
+// offset if offset was presented. That means that it is
+// safe to delete offset element and pass if to the
+// iteration once again: iteration would start from the
+// next element.
+//
+// Nil offset means start an integration from the beginning.
+func (g *GarbageIterationPrm) SetOffset(offset *addressSDK.Address) *GarbageIterationPrm {
+	g.offset = offset
+	return g
+}
 
 // IterateOverGarbage iterates over all objects
 // marked with GC mark.
 //
 // If h returns ErrInterruptIterator, nil returns immediately.
 // Returns other errors of h directly.
-func (db *DB) IterateOverGarbage(h Handler) error {
+func (db *DB) IterateOverGarbage(p *GarbageIterationPrm) error {
 	return db.boltDB.View(func(tx *bbolt.Tx) error {
-		return db.iterateDeletedObj(tx, withGC, h)
+		return db.iterateDeletedObj(tx, gcHandler{p.h}, p.offset)
 	})
+}
+
+// TombstonedObject represents descriptor of the
+// object that has been covered with tombstone.
+type TombstonedObject struct {
+	addr *addressSDK.Address
+	tomb *addressSDK.Address
+}
+
+// Address returns tombstoned object address.
+func (g TombstonedObject) Address() *addressSDK.Address {
+	return g.addr
+}
+
+// Tombstone returns address of a tombstone that
+// covers object.
+func (g TombstonedObject) Tombstone() *addressSDK.Address {
+	return g.tomb
+}
+
+// TombstonedHandler is a TombstonedObject handling function.
+type TombstonedHandler func(object TombstonedObject) error
+
+// GraveyardIterationPrm groups parameters of the graveyard
+// iteration process.
+type GraveyardIterationPrm struct {
+	h      TombstonedHandler
+	offset *addressSDK.Address
+}
+
+// SetHandler sets a handler that will be called on every
+// TombstonedObject.
+func (g *GraveyardIterationPrm) SetHandler(h TombstonedHandler) *GraveyardIterationPrm {
+	g.h = h
+	return g
+}
+
+// SetOffset sets an offset of the iteration operation.
+// The handler will be applied to the next after the
+// specified offset if any are left.
+//
+// Note: if offset is not found in db, iteration starts
+// from the element that WOULD BE the following after the
+// offset if offset was presented. That means that it is
+// safe to delete offset element and pass if to the
+// iteration once again: iteration would start from the
+// next element.
+//
+// Nil offset means start an integration from the beginning.
+func (g *GraveyardIterationPrm) SetOffset(offset *addressSDK.Address) *GraveyardIterationPrm {
+	g.offset = offset
+	return g
 }
 
 // IterateOverGraveyard iterates over all graves in DB.
 //
 // If h returns ErrInterruptIterator, nil returns immediately.
 // Returns other errors of h directly.
-func (db *DB) IterateOverGraveyard(h Handler) error {
+func (db *DB) IterateOverGraveyard(p *GraveyardIterationPrm) error {
 	return db.boltDB.View(func(tx *bbolt.Tx) error {
-		return db.iterateDeletedObj(tx, grave, h)
+		return db.iterateDeletedObj(tx, graveyardHandler{p.h}, p.offset)
 	})
 }
 
-type deletedType uint8
+type kvHandler interface {
+	handleKV(k, v []byte) error
+}
 
-const (
-	_ deletedType = iota
-	grave
-	withGC
-)
+type gcHandler struct {
+	h GarbageHandler
+}
 
-func (db *DB) iterateDeletedObj(tx *bbolt.Tx, t deletedType, h Handler) error {
+func (g gcHandler) handleKV(k, _ []byte) error {
+	o, err := garbageFromKV(k)
+	if err != nil {
+		return fmt.Errorf("could not parse garbage object: %w", err)
+	}
+
+	return g.h(o)
+}
+
+type graveyardHandler struct {
+	h TombstonedHandler
+}
+
+func (g graveyardHandler) handleKV(k, v []byte) error {
+	o, err := graveFromKV(k, v)
+	if err != nil {
+		return fmt.Errorf("could not parse grave: %w", err)
+	}
+
+	return g.h(o)
+}
+
+func (db *DB) iterateDeletedObj(tx *bbolt.Tx, h kvHandler, offset *addressSDK.Address) error {
 	var bkt *bbolt.Bucket
-	switch t {
-	case grave:
+	switch t := h.(type) {
+	case graveyardHandler:
 		bkt = tx.Bucket(graveyardBucketName)
-	case withGC:
+	case gcHandler:
 		bkt = tx.Bucket(garbageBucketName)
 	default:
-		panic(fmt.Sprintf("metabase: unknown iteration object type: %d", t))
+		panic(fmt.Sprintf("metabase: unknown iteration object hadler: %T", t))
 	}
 
 	if bkt == nil {
 		return nil
 	}
 
-	// iterate over all deleted objects
-	err := bkt.ForEach(func(k, v []byte) error {
-		// parse deleted object
-		delObj, err := deletedObjectFromKV(k, v)
-		if err != nil {
-			return fmt.Errorf("could not parse Grave: %w", err)
+	c := bkt.Cursor()
+	var k, v []byte
+
+	if offset == nil {
+		k, v = c.First()
+	} else {
+		rawAddr := addressKey(offset)
+
+		k, v = c.Seek(rawAddr)
+		if bytes.Equal(k, rawAddr) {
+			// offset was found, move
+			// cursor to the next element
+			k, v = c.Next()
 		}
-
-		// handler object
-		return h(delObj)
-	})
-
-	if errors.Is(err, ErrInterruptIterator) {
-		err = nil
 	}
 
-	return err
+	for ; k != nil; k, v = c.Next() {
+		err := h.handleKV(k, v)
+		if err != nil {
+			if errors.Is(err, ErrInterruptIterator) {
+				return nil
+			}
+
+			return err
+		}
+	}
+
+	return nil
 }
 
-func deletedObjectFromKV(k, _ []byte) (*DeletedObject, error) {
+func garbageFromKV(k []byte) (GarbageObject, error) {
 	addr, err := addressFromKey(k)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse address: %w", err)
+		return GarbageObject{}, fmt.Errorf("could not parse address: %w", err)
 	}
 
-	return &DeletedObject{
+	return GarbageObject{
 		addr: addr,
+	}, nil
+}
+
+func graveFromKV(k, v []byte) (TombstonedObject, error) {
+	target, err := addressFromKey(k)
+	if err != nil {
+		return TombstonedObject{}, fmt.Errorf("could not parse address: %w", err)
+	}
+
+	tomb, err := addressFromKey(v)
+	if err != nil {
+		return TombstonedObject{}, err
+	}
+
+	return TombstonedObject{
+		addr: target,
+		tomb: tomb,
 	}, nil
 }

--- a/pkg/local_object_storage/metabase/graveyard_test.go
+++ b/pkg/local_object_storage/metabase/graveyard_test.go
@@ -70,9 +70,20 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, 4, counterAll)
-	require.True(t, equalAddresses([]*addressSDK.Address{object.AddressOf(obj1), object.AddressOf(obj2)}, buriedTS))
-	require.True(t, equalAddresses([]*addressSDK.Address{object.AddressOf(obj3), object.AddressOf(obj4)}, buriedGC))
+	// objects covered with a tombstone
+	// also receive GS mark
+	garbageExpected := []*addressSDK.Address{
+		object.AddressOf(obj1), object.AddressOf(obj2),
+		object.AddressOf(obj3), object.AddressOf(obj4),
+	}
+
+	graveyardExpected := []*addressSDK.Address{
+		object.AddressOf(obj1), object.AddressOf(obj2),
+	}
+
+	require.Equal(t, len(garbageExpected)+len(graveyardExpected), counterAll)
+	require.True(t, equalAddresses(graveyardExpected, buriedTS))
+	require.True(t, equalAddresses(garbageExpected, buriedGC))
 }
 
 func equalAddresses(aa1 []*addressSDK.Address, aa2 []*addressSDK.Address) bool {

--- a/pkg/local_object_storage/metabase/graveyard_test.go
+++ b/pkg/local_object_storage/metabase/graveyard_test.go
@@ -183,8 +183,8 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 	}
 
 	require.Equal(t, len(garbageExpected)+len(graveyardExpected), counterAll)
-	require.True(t, equalAddresses(graveyardExpected, buriedTS))
-	require.True(t, equalAddresses(garbageExpected, buriedGC))
+	require.ElementsMatch(t, graveyardExpected, buriedTS)
+	require.ElementsMatch(t, garbageExpected, buriedGC)
 }
 
 func TestDB_IterateOverGraveyard_Offset(t *testing.T) {
@@ -265,7 +265,7 @@ func TestDB_IterateOverGraveyard_Offset(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, len(expectedGraveyard), counter)
-	require.True(t, equalAddresses(gotGraveyard, expectedGraveyard))
+	require.ElementsMatch(t, gotGraveyard, expectedGraveyard)
 
 	// last received object (last in db) as offset
 	// should lead to no iteration at all
@@ -353,7 +353,7 @@ func TestDB_IterateOverGarbage_Offset(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, len(expectedGarbage), counter)
-	require.True(t, equalAddresses(gotGarbage, expectedGarbage))
+	require.ElementsMatch(t, gotGarbage, expectedGarbage)
 
 	// last received object (last in db) as offset
 	// should lead to no iteration at all
@@ -420,27 +420,4 @@ func TestDB_DropGraves(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Zero(t, counter)
-}
-
-func equalAddresses(aa1 []*addressSDK.Address, aa2 []*addressSDK.Address) bool {
-	if len(aa1) != len(aa2) {
-		return false
-	}
-
-	for _, a1 := range aa1 {
-		found := false
-
-		for _, a2 := range aa2 {
-			if a1.String() == a2.String() {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return false
-		}
-	}
-
-	return true
 }

--- a/pkg/local_object_storage/metabase/graveyard_test.go
+++ b/pkg/local_object_storage/metabase/graveyard_test.go
@@ -142,6 +142,7 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 		WithAddresses(object.AddressOf(obj3), object.AddressOf(obj4)).
 		WithGCMark(),
 	)
+	require.NoError(t, err)
 
 	var (
 		counterAll         int
@@ -158,6 +159,7 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 
 		return nil
 	}))
+	require.NoError(t, err)
 
 	iterGCPRM := new(meta.GarbageIterationPrm)
 
@@ -167,7 +169,6 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 
 		return nil
 	}))
-
 	require.NoError(t, err)
 
 	// objects covered with a tombstone

--- a/pkg/local_object_storage/metabase/graveyard_test.go
+++ b/pkg/local_object_storage/metabase/graveyard_test.go
@@ -9,10 +9,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDB_IterateDeletedObjects_EmptyDB(t *testing.T) {
+	db := newDB(t)
+
+	var counter int
+	iterGravePRM := new(meta.GraveyardIterationPrm)
+
+	err := db.IterateOverGraveyard(iterGravePRM.SetHandler(func(garbage meta.TombstonedObject) error {
+		counter++
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Zero(t, counter)
+
+	iterGCPRM := new(meta.GarbageIterationPrm)
+
+	err = db.IterateOverGarbage(iterGCPRM.SetHandler(func(garbage meta.GarbageObject) error {
+		counter++
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Zero(t, counter)
+}
+
+func TestDB_Iterate_OffsetNotFound(t *testing.T) {
+	db := newDB(t)
+
+	obj1 := generateObject(t)
+	obj2 := generateObject(t)
+
+	addr1 := addressSDK.NewAddress()
+	err := addr1.Parse("AUSF6rhReoAdPVKYUZWW9o2LbtTvekn54B3JXi7pdzmn/2daLhLB7yVXbjBaKkckkuvjX22BxRYuSHy9RPxuH9PZS")
+	require.NoError(t, err)
+
+	addr2 := addressSDK.NewAddress()
+	err = addr2.Parse("CwYYr6sFLU1zK6DeBTVd8SReADUoxYobUhSrxgXYxCVn/ANYbnJoQqdjmU5Dhk3LkxYj5E9nJHQFf8LjTEcap9TxM")
+	require.NoError(t, err)
+
+	addr3 := addressSDK.NewAddress()
+	err = addr3.Parse("6ay4GfhR9RgN28d5ufg63toPetkYHGcpcW7G3b7QWSek/ANYbnJoQqdjmU5Dhk3LkxYj5E9nJHQFf8LjTEcap9TxM")
+	require.NoError(t, err)
+
+	obj1.SetContainerID(addr1.ContainerID())
+	obj1.SetID(addr1.ObjectID())
+	obj2.SetContainerID(addr2.ContainerID())
+	obj2.SetID(addr2.ObjectID())
+
+	err = putBig(db, obj1)
+	require.NoError(t, err)
+
+	_, err = db.Inhume(new(meta.InhumePrm).
+		WithAddresses(object.AddressOf(obj1)).
+		WithGCMark(),
+	)
+	require.NoError(t, err)
+
+	var counter int
+
+	iterGCPRM := new(meta.GarbageIterationPrm).
+		SetOffset(object.AddressOf(obj2)).
+		SetHandler(func(garbage meta.GarbageObject) error {
+			require.Equal(t, *garbage.Address(), *addr1)
+			counter++
+
+			return nil
+		})
+
+	err = db.IterateOverGarbage(iterGCPRM.SetHandler(func(garbage meta.GarbageObject) error {
+		require.Equal(t, *garbage.Address(), *addr1)
+		counter++
+
+		return nil
+	}))
+	require.NoError(t, err)
+
+	// the second object would be put after the
+	// first, so it is expected that iteration
+	// will not receive the first object
+	require.Equal(t, 0, counter)
+
+	iterGCPRM.SetOffset(addr3)
+	err = db.IterateOverGarbage(iterGCPRM.SetHandler(func(garbage meta.GarbageObject) error {
+		require.Equal(t, *garbage.Address(), *addr1)
+		counter++
+
+		return nil
+	}))
+	require.NoError(t, err)
+
+	// the third object would be put before the
+	// first, so it is expected that iteration
+	// will receive the first object
+	require.Equal(t, 1, counter)
+}
+
 func TestDB_IterateDeletedObjects(t *testing.T) {
 	db := newDB(t)
 
-	// generate and put 2 objects
+	// generate and put 4 objects
 	obj1 := generateObject(t)
 	obj2 := generateObject(t)
 	obj3 := generateObject(t)
@@ -54,19 +148,25 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 		buriedTS, buriedGC []*addressSDK.Address
 	)
 
-	err = db.IterateOverGraveyard(func(deletedObject *meta.DeletedObject) error {
-		buriedTS = append(buriedTS, deletedObject.Address())
+	iterGravePRM := new(meta.GraveyardIterationPrm)
+
+	err = db.IterateOverGraveyard(iterGravePRM.SetHandler(func(tomstoned meta.TombstonedObject) error {
+		require.Equal(t, *addrTombstone, *tomstoned.Tombstone())
+
+		buriedTS = append(buriedTS, tomstoned.Address())
 		counterAll++
 
 		return nil
-	})
+	}))
 
-	err = db.IterateOverGarbage(func(deletedObject *meta.DeletedObject) error {
-		buriedGC = append(buriedGC, deletedObject.Address())
+	iterGCPRM := new(meta.GarbageIterationPrm)
+
+	err = db.IterateOverGarbage(iterGCPRM.SetHandler(func(garbage meta.GarbageObject) error {
+		buriedGC = append(buriedGC, garbage.Address())
 		counterAll++
 
 		return nil
-	})
+	}))
 
 	require.NoError(t, err)
 
@@ -84,6 +184,189 @@ func TestDB_IterateDeletedObjects(t *testing.T) {
 	require.Equal(t, len(garbageExpected)+len(graveyardExpected), counterAll)
 	require.True(t, equalAddresses(graveyardExpected, buriedTS))
 	require.True(t, equalAddresses(garbageExpected, buriedGC))
+}
+
+func TestDB_IterateOverGraveyard_Offset(t *testing.T) {
+	db := newDB(t)
+
+	// generate and put 4 objects
+	obj1 := generateObject(t)
+	obj2 := generateObject(t)
+	obj3 := generateObject(t)
+	obj4 := generateObject(t)
+
+	var err error
+
+	err = putBig(db, obj1)
+	require.NoError(t, err)
+
+	err = putBig(db, obj2)
+	require.NoError(t, err)
+
+	err = putBig(db, obj3)
+	require.NoError(t, err)
+
+	err = putBig(db, obj4)
+	require.NoError(t, err)
+
+	inhumePrm := new(meta.InhumePrm)
+
+	// inhume with tombstone
+	addrTombstone := generateAddress()
+
+	_, err = db.Inhume(inhumePrm.
+		WithAddresses(object.AddressOf(obj1), object.AddressOf(obj2), object.AddressOf(obj3), object.AddressOf(obj4)).
+		WithTombstoneAddress(addrTombstone),
+	)
+	require.NoError(t, err)
+
+	expectedGraveyard := []*addressSDK.Address{
+		object.AddressOf(obj1), object.AddressOf(obj2),
+		object.AddressOf(obj3), object.AddressOf(obj4),
+	}
+
+	var (
+		counter            int
+		firstIterationSize = len(expectedGraveyard) / 2
+
+		gotGraveyard []*addressSDK.Address
+	)
+
+	iterGraveyardPrm := new(meta.GraveyardIterationPrm)
+
+	err = db.IterateOverGraveyard(iterGraveyardPrm.SetHandler(func(tombstoned meta.TombstonedObject) error {
+		require.Equal(t, *addrTombstone, *tombstoned.Tombstone())
+
+		gotGraveyard = append(gotGraveyard, tombstoned.Address())
+
+		counter++
+		if counter == firstIterationSize {
+			return meta.ErrInterruptIterator
+		}
+
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, firstIterationSize, counter)
+	require.Equal(t, firstIterationSize, len(gotGraveyard))
+
+	// last received address is an offset
+	offset := gotGraveyard[len(gotGraveyard)-1]
+	iterGraveyardPrm.SetOffset(offset)
+
+	err = db.IterateOverGraveyard(iterGraveyardPrm.SetHandler(func(tombstoned meta.TombstonedObject) error {
+		require.Equal(t, *addrTombstone, *tombstoned.Tombstone())
+
+		gotGraveyard = append(gotGraveyard, tombstoned.Address())
+		counter++
+
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, len(expectedGraveyard), counter)
+	require.True(t, equalAddresses(gotGraveyard, expectedGraveyard))
+
+	// last received object (last in db) as offset
+	// should lead to no iteration at all
+	offset = gotGraveyard[len(gotGraveyard)-1]
+	iterGraveyardPrm.SetOffset(offset)
+
+	iWasCalled := false
+
+	err = db.IterateOverGraveyard(iterGraveyardPrm.SetHandler(func(tombstoned meta.TombstonedObject) error {
+		iWasCalled = true
+		return nil
+	}))
+	require.NoError(t, err)
+	require.False(t, iWasCalled)
+}
+
+func TestDB_IterateOverGarbage_Offset(t *testing.T) {
+	db := newDB(t)
+
+	// generate and put 4 objects
+	obj1 := generateObject(t)
+	obj2 := generateObject(t)
+	obj3 := generateObject(t)
+	obj4 := generateObject(t)
+
+	var err error
+
+	err = putBig(db, obj1)
+	require.NoError(t, err)
+
+	err = putBig(db, obj2)
+	require.NoError(t, err)
+
+	err = putBig(db, obj3)
+	require.NoError(t, err)
+
+	err = putBig(db, obj4)
+	require.NoError(t, err)
+
+	inhumePrm := new(meta.InhumePrm)
+
+	_, err = db.Inhume(inhumePrm.
+		WithAddresses(object.AddressOf(obj1), object.AddressOf(obj2), object.AddressOf(obj3), object.AddressOf(obj4)).
+		WithGCMark(),
+	)
+	require.NoError(t, err)
+
+	expectedGarbage := []*addressSDK.Address{
+		object.AddressOf(obj1), object.AddressOf(obj2),
+		object.AddressOf(obj3), object.AddressOf(obj4),
+	}
+
+	var (
+		counter            int
+		firstIterationSize = len(expectedGarbage) / 2
+
+		gotGarbage []*addressSDK.Address
+	)
+
+	iterGarbagePrm := new(meta.GarbageIterationPrm)
+
+	err = db.IterateOverGarbage(iterGarbagePrm.SetHandler(func(garbage meta.GarbageObject) error {
+		gotGarbage = append(gotGarbage, garbage.Address())
+
+		counter++
+		if counter == firstIterationSize {
+			return meta.ErrInterruptIterator
+		}
+
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, firstIterationSize, counter)
+	require.Equal(t, firstIterationSize, len(gotGarbage))
+
+	// last received address is an offset
+	offset := gotGarbage[len(gotGarbage)-1]
+	iterGarbagePrm.SetOffset(offset)
+
+	err = db.IterateOverGarbage(iterGarbagePrm.SetHandler(func(garbage meta.GarbageObject) error {
+		gotGarbage = append(gotGarbage, garbage.Address())
+		counter++
+
+		return nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, len(expectedGarbage), counter)
+	require.True(t, equalAddresses(gotGarbage, expectedGarbage))
+
+	// last received object (last in db) as offset
+	// should lead to no iteration at all
+	offset = gotGarbage[len(gotGarbage)-1]
+	iterGarbagePrm.SetOffset(offset)
+
+	iWasCalled := false
+
+	err = db.IterateOverGarbage(iterGarbagePrm.SetHandler(func(garbage meta.GarbageObject) error {
+		iWasCalled = true
+		return nil
+	}))
+	require.NoError(t, err)
+	require.False(t, iWasCalled)
 }
 
 func equalAddresses(aa1 []*addressSDK.Address, aa2 []*addressSDK.Address) bool {

--- a/pkg/local_object_storage/metabase/inhume_test.go
+++ b/pkg/local_object_storage/metabase/inhume_test.go
@@ -65,10 +65,11 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	require.NoError(t, err)
 
 	// record with {addr1:addr2} should be removed from graveyard
-	// as a tomb-on-tomb
-	res, err := db.Exists(existsPrm.WithAddress(addr1))
-	require.NoError(t, err)
-	require.False(t, res.Exists())
+	// as a tomb-on-tomb; metabase should return ObjectNotFound
+	// NOT ObjectAlreadyRemoved since that record has been removed
+	// from graveyard but addr1 is still marked with GC
+	_, err = db.Exists(existsPrm.WithAddress(addr1))
+	require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
 
 	// addr3 should be inhumed {addr3: addr1}
 	_, err = db.Exists(existsPrm.WithAddress(addr3))
@@ -82,10 +83,10 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	require.NoError(t, err)
 
 	// record with addr1 key should not appear in graveyard
-	// (tomb can not be inhumed)
-	res, err = db.Exists(existsPrm.WithAddress(addr1))
-	require.NoError(t, err)
-	require.False(t, res.Exists())
+	// (tomb can not be inhumed) but should be kept as object
+	// with GC mark
+	_, err = db.Exists(existsPrm.WithAddress(addr1))
+	require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
 }
 
 func TestInhumeLocked(t *testing.T) {

--- a/pkg/local_object_storage/metabase/util.go
+++ b/pkg/local_object_storage/metabase/util.go
@@ -21,7 +21,14 @@ bytes. Check it later.
 const invalidBase58String = "_"
 
 var (
-	graveyardBucketName       = []byte(invalidBase58String + "Graveyard")
+	// graveyardBucketName stores rows with the objects that have been
+	// covered with Tombstone objects. That objects should not be returned
+	// from the node and should not be accepted by the node from other
+	// nodes.
+	graveyardBucketName = []byte(invalidBase58String + "Graveyard")
+	// garbageBucketName stores rows with the objects that should be physically
+	// deleted by the node (Garbage Collector routine).
+	garbageBucketName         = []byte(invalidBase58String + "Garbage")
 	toMoveItBucketName        = []byte(invalidBase58String + "ToMoveIt")
 	containerVolumeBucketName = []byte(invalidBase58String + "ContainerSize")
 

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -166,7 +166,7 @@ func (gc *gc) stop() {
 	})
 }
 
-// iterates over metabase graveyard and deletes objects
+// iterates over metabase and deletes objects
 // with GC-marked graves.
 // Does nothing if shard is in "read-only" mode.
 func (s *Shard) removeGarbage() {
@@ -176,12 +176,10 @@ func (s *Shard) removeGarbage() {
 
 	buf := make([]*addressSDK.Address, 0, s.rmBatchSize)
 
-	// iterate over metabase graveyard and accumulate
-	// objects with GC mark (no more the s.rmBatchSize objects)
-	err := s.metaBase.IterateOverGraveyard(func(g *meta.Grave) error {
-		if g.WithGCMark() {
-			buf = append(buf, g.Address())
-		}
+	// iterate over metabase's objects with GC mark
+	// (no more than s.rmBatchSize objects)
+	err := s.metaBase.IterateOverGarbage(func(g *meta.DeletedObject) error {
+		buf = append(buf, g.Address())
 
 		if len(buf) == s.rmBatchSize {
 			return meta.ErrInterruptIterator

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -176,9 +176,11 @@ func (s *Shard) removeGarbage() {
 
 	buf := make([]*addressSDK.Address, 0, s.rmBatchSize)
 
+	iterPrm := new(meta.GarbageIterationPrm)
+
 	// iterate over metabase's objects with GC mark
 	// (no more than s.rmBatchSize objects)
-	err := s.metaBase.IterateOverGarbage(func(g *meta.DeletedObject) error {
+	err := s.metaBase.IterateOverGarbage(iterPrm.SetHandler(func(g meta.GarbageObject) error {
 		buf = append(buf, g.Address())
 
 		if len(buf) == s.rmBatchSize {
@@ -186,7 +188,7 @@ func (s *Shard) removeGarbage() {
 		}
 
 		return nil
-	})
+	}))
 	if err != nil {
 		s.log.Warn("iterator over metabase graveyard failed",
 			zap.String("error", err.Error()),

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -286,8 +286,8 @@ func (s *Shard) collectExpiredTombstones(ctx context.Context, e Event) {
 			}
 		}
 
-		log.Debug("handling expired tombstones batch", zap.Int("number", tssLen))
-		s.expiredTombstonesCallback(ctx, tss)
+		log.Debug("handling expired tombstones batch", zap.Int("number", len(tssExp)))
+		s.expiredTombstonesCallback(ctx, tssExp)
 
 		iterPrm.SetOffset(tss[tssLen-1].Address())
 		tss = tss[:0]

--- a/pkg/services/object/util/prm.go
+++ b/pkg/services/object/util/prm.go
@@ -31,10 +31,10 @@ func (p *CommonPrm) TTL() uint32 {
 		return p.ttl
 	}
 
-	return 0
+	return 1
 }
 
-// Returns X-Headers for new requests.
+// XHeaders returns X-Headers for new requests.
 func (p *CommonPrm) XHeaders() []*sessionsdk.XHeader {
 	if p != nil {
 		return p.xhdrs

--- a/pkg/services/object_manager/tombstone/checker.go
+++ b/pkg/services/object_manager/tombstone/checker.go
@@ -1,0 +1,93 @@
+package tombstone
+
+import (
+	"context"
+	"strconv"
+
+	lru "github.com/hashicorp/golang-lru"
+	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	"go.uber.org/zap"
+)
+
+// Source is a tombstone source interface.
+type Source interface {
+	// Tombstone must return tombstone from the source it was
+	// configured to fetch from and any error that appeared during
+	// fetching process.
+	//
+	// Tombstone MUST return (nil, nil) if requested tombstone is
+	// missing in the storage for the provided epoch.
+	Tombstone(ctx context.Context, a *addressSDK.Address, epoch uint64) (*object.Object, error)
+}
+
+// ExpirationChecker is a tombstone source wrapper.
+// It checks tombstones presence via tombstone
+// source, caches it checks its expiration.
+//
+// Must be created via NewChecker function. `var` and
+// `ExpirationChecker{}` declarations leads to undefined behaviour
+// and may lead to panics.
+type ExpirationChecker struct {
+	cache *lru.Cache
+
+	log *zap.Logger
+
+	tsSource Source
+}
+
+// IsTombstoneAvailable checks the tombstone presence in the system in the
+// following order:
+//  * 1. Local LRU cache;
+//  * 2. Tombstone source.
+//
+// If a tombstone was successfully fetched (regardless of its expiration)
+// it is cached in the LRU cache.
+func (g *ExpirationChecker) IsTombstoneAvailable(ctx context.Context, a *addressSDK.Address, epoch uint64) bool {
+	addrStr := a.String()
+	log := g.log.With(zap.String("address", addrStr))
+
+	expEpoch, ok := g.cache.Get(addrStr)
+	if ok {
+		return expEpoch.(uint64) > epoch
+	}
+
+	ts, err := g.tsSource.Tombstone(ctx, a, epoch)
+	if err != nil {
+		log.Warn(
+			"tombstone getter: could not get the tombstone the source",
+			zap.Error(err),
+		)
+	} else {
+		if ts != nil {
+			return g.handleTS(addrStr, ts, epoch)
+		}
+	}
+
+	// requested tombstone not
+	// found in the NeoFS network
+	return false
+}
+
+func (g *ExpirationChecker) handleTS(addr string, ts *object.Object, reqEpoch uint64) bool {
+	for _, atr := range ts.Attributes() {
+		if atr.Key() == objectV2.SysAttributeExpEpoch {
+			epoch, err := strconv.ParseUint(atr.Value(), 10, 64)
+			if err != nil {
+				g.log.Warn(
+					"tombstone getter: could not parse tombstone expiration epoch",
+					zap.Error(err),
+				)
+
+				return false
+			}
+
+			g.cache.Add(addr, epoch)
+			return epoch > reqEpoch
+		}
+	}
+
+	// unexpected tombstone without expiration epoch
+	return false
+}

--- a/pkg/services/object_manager/tombstone/constructor.go
+++ b/pkg/services/object_manager/tombstone/constructor.go
@@ -1,0 +1,84 @@
+package tombstone
+
+import (
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru"
+	"go.uber.org/zap"
+)
+
+const defaultLRUCacheSize = 100
+
+type cfg struct {
+	log *zap.Logger
+
+	cacheSize int
+
+	tsSource Source
+}
+
+// Option is an option of ExpirationChecker's constructor.
+type Option func(*cfg)
+
+func defaultCfg() *cfg {
+	return &cfg{
+		log:       zap.NewNop(),
+		cacheSize: defaultLRUCacheSize,
+	}
+}
+
+// NewChecker creates, initializes and returns tombstone ExpirationChecker.
+// The returned structure is ready to use.
+//
+// Panics if any of the provided options does not allow
+// constructing a valid tombstone ExpirationChecker.
+func NewChecker(oo ...Option) *ExpirationChecker {
+	cfg := defaultCfg()
+
+	for _, o := range oo {
+		o(cfg)
+	}
+
+	panicOnNil := func(v interface{}, name string) {
+		if v == nil {
+			panic(fmt.Sprintf("tombstone getter constructor: %s is nil", name))
+		}
+	}
+
+	panicOnNil(cfg.tsSource, "Tombstone source")
+
+	cache, err := lru.New(cfg.cacheSize)
+	if err != nil {
+		panic(fmt.Errorf("could not create LRU cache with %d size: %w", cfg.cacheSize, err))
+	}
+
+	return &ExpirationChecker{
+		cache:    cache,
+		log:      cfg.log,
+		tsSource: cfg.tsSource,
+	}
+}
+
+// WithLogger returns an option to specify
+// logger.
+func WithLogger(v *zap.Logger) Option {
+	return func(c *cfg) {
+		c.log = v
+	}
+}
+
+// WithCacheSize returns an option to specify
+// LRU cache size.
+func WithCacheSize(v int) Option {
+	return func(c *cfg) {
+		c.cacheSize = v
+	}
+}
+
+// WithTombstoneSource returns an option
+// to specify tombstone source.
+func WithTombstoneSource(v Source) Option {
+	return func(c *cfg) {
+		c.tsSource = v
+	}
+}

--- a/pkg/services/object_manager/tombstone/source/source.go
+++ b/pkg/services/object_manager/tombstone/source/source.go
@@ -1,0 +1,84 @@
+package tsourse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	getsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/get"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+)
+
+// Source represents wrapper over the object service that
+// allows checking if a tombstone is available in NeoFS
+// network.
+//
+// Must be created via NewSource function. `var` and `Source{}`
+// declarations leads to undefined behaviour and may lead
+// to panics.
+type Source struct {
+	s *getsvc.Service
+}
+
+// TombstoneSourcePrm groups required parameters for Source creation.
+type TombstoneSourcePrm struct {
+	s *getsvc.Service
+}
+
+// SetGetService sets object service.
+func (s *TombstoneSourcePrm) SetGetService(v *getsvc.Service) {
+	s.s = v
+}
+
+// NewSource creates, initialize and returns local tombstone Source.
+// The returned structure is ready to use.
+//
+// Panics if any of the provided options does not allow
+// constructing a valid tombstone local Source.
+func NewSource(p TombstoneSourcePrm) Source {
+	if p.s == nil {
+		panic("Tombstone source: nil object service")
+	}
+
+	return Source{s: p.s}
+}
+
+type headerWriter struct {
+	o *objectSDK.Object
+}
+
+func (h *headerWriter) WriteHeader(o *objectSDK.Object) error {
+	h.o = o
+	return nil
+}
+
+// Tombstone checks if the engine stores tombstone.
+// Returns nil, nil if the tombstone has been removed
+// or marked for removal.
+func (s Source) Tombstone(ctx context.Context, a *addressSDK.Address, _ uint64) (*object.Object, error) {
+	var hr headerWriter
+
+	var headPrm getsvc.HeadPrm
+	headPrm.WithAddress(a)
+	headPrm.SetHeaderWriter(&hr)
+	headPrm.SetCommonParameters(&util.CommonPrm{}) //default values are ok for that operation
+
+	err := s.s.Head(ctx, headPrm)
+	switch {
+	case errors.As(err, new(apistatus.ObjectNotFound)) || errors.As(err, new(apistatus.ObjectAlreadyRemoved)):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("could not get tombstone from the source: %w", err)
+	default:
+	}
+
+	if hr.o.Type() != objectSDK.TypeTombstone {
+		return nil, fmt.Errorf("returned %s object is not a tombstone", a)
+	}
+
+	return hr.o, nil
+}

--- a/pkg/services/object_manager/tombstone/source/source.go
+++ b/pkg/services/object_manager/tombstone/source/source.go
@@ -44,7 +44,7 @@ func NewSource(p TombstoneSourcePrm) Source {
 		panic("Tombstone source: nil object service")
 	}
 
-	return Source{s: p.s}
+	return Source(p)
 }
 
 type headerWriter struct {


### PR DESCRIPTION
Based on #1321, will rebase after its merge.

Key changes:
- `Graveyard` was separated on `Graveyard` and `Garbage` buckets since now it is possible to have an object which has both graveyard and GC records.
- When TS is received, the object covered with that TS is marked with GC immediately.
- TS info is kept in the `Graveyard` bucket once it appeared on a node.
- Every epoch all the tombstones are checked for their presence in the NeoFS network and TSs that have not been found are deleted from the `Graveyard`.
- Strange get service [initialization](https://github.com/nspcc-dev/neofs-node/pull/1318/files#diff-c9453c121fb79a56f041a2bd8b9f327c6c898ae5ce7be9db49a714446fdbdc5bR356): a get service needs a storage engine for initialization and a storage engine needs a get service.

Closes #1226.

TODO: add more tests to the engine/shard after approving the main idea of the PR.