### PR TITLE
Fix/GC's event handler registration

### DIFF
--- a/pkg/local_object_storage/engine/lock_test.go
+++ b/pkg/local_object_storage/engine/lock_test.go
@@ -38,9 +38,7 @@ func TestLockUserScenario(t *testing.T) {
 
 	e := testEngineFromShardOpts(t, 2, func(i int) []shard.Option {
 		return []shard.Option{
-			shard.WithGCEventChannelInitializer(func() <-chan shard.Event {
-				return chEvents[i]
-			}),
+			shard.WithGCEventChannel(chEvents[i]),
 			shard.WithGCWorkerPoolInitializer(func(sz int) util.WorkerPool {
 				pool, err := ants.NewPool(sz)
 				require.NoError(t, err)
@@ -136,9 +134,7 @@ func TestLockExpiration(t *testing.T) {
 
 	e := testEngineFromShardOpts(t, 2, func(i int) []shard.Option {
 		return []shard.Option{
-			shard.WithGCEventChannelInitializer(func() <-chan shard.Event {
-				return chEvents[i]
-			}),
+			shard.WithGCEventChannel(chEvents[i]),
 			shard.WithGCWorkerPoolInitializer(func(sz int) util.WorkerPool {
 				pool, err := ants.NewPool(sz)
 				require.NoError(t, err)

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -64,7 +64,7 @@ type gc struct {
 }
 
 type gcCfg struct {
-	eventChanInit func() <-chan Event
+	eventChan <-chan Event
 
 	removerInterval time.Duration
 
@@ -78,9 +78,7 @@ func defaultGCCfg() *gcCfg {
 	close(ch)
 
 	return &gcCfg{
-		eventChanInit: func() <-chan Event {
-			return ch
-		},
+		eventChan:       ch,
 		removerInterval: 10 * time.Second,
 		log:             zap.L(),
 		workerPoolInit: func(int) util.WorkerPool {
@@ -105,10 +103,8 @@ func (gc *gc) init() {
 }
 
 func (gc *gc) listenEvents() {
-	eventChan := gc.eventChanInit()
-
 	for {
-		event, ok := <-eventChan
+		event, ok := <-gc.eventChan
 		if !ok {
 			gc.log.Warn("stop event listener by closed channel")
 			return

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -167,11 +167,10 @@ func WithGCWorkerPoolInitializer(wpInit func(int) util.WorkerPool) Option {
 	}
 }
 
-// WithGCEventChannelInitializer returns option to set set initializer of
-// GC event channel.
-func WithGCEventChannelInitializer(chInit func() <-chan Event) Option {
+// WithGCEventChannel returns option to set a GC event channel.
+func WithGCEventChannel(eventChan <-chan Event) Option {
 	return func(c *cfg) {
-		c.gcCfg.eventChanInit = chInit
+		c.gcCfg.eventChan = eventChan
 	}
 }
 


### PR DESCRIPTION
Morph "NewEpoch" event handling was registered in a closure over
`addNewEpochNotificationHandler` func. That may lead to the data race:
if a shard was initialized before the event registration, everything works
as planned, but if registration was made earlier, it was not able to
include GC handlers since a shard has not called `eventChanInit` yet and,
therefore, it has not registered handler yet.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Also, we may rename the option and just pass a channel instead of func. Also, we may call `eventChanInit` on the shard's creation, not on its initialization.