### PR TITLE
[#1346] neofs-adm: do not ask password twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog for NeoFS Node
 ### Added
 - Config examples for Inner ring application (#1358)
 
+### Fixed
+- Do not ask for contract wallet password twice (#1346)
+
 ## [0.28.1] - 2022-05-05
 
 ### Fixed

--- a/cmd/neofs-adm/internal/modules/morph/group.go
+++ b/cmd/neofs-adm/internal/modules/morph/group.go
@@ -60,10 +60,7 @@ func openContractWallet(cmd *cobra.Command, walletDir string) (*wallet.Wallet, e
 
 		cmd.Printf("Contract group wallet is missing, initialize at %s\n",
 			filepath.Join(walletDir, contractWalletFilename))
-		w, err = initializeContractWallet(walletDir)
-		if err != nil {
-			return nil, err
-		}
+		return initializeContractWallet(walletDir)
 	}
 
 	password, err := getPassword(contractWalletPasswordKey, "Password for contract wallet > ")


### PR DESCRIPTION
Close #1346.

When a contract wallet is created, there is no need to decrypt
newly-created accounts.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>