### PR TITLE
Fix/Add homomorphic hashing config param to `adm morph dump-config` command

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/dump.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump.go
@@ -187,7 +187,7 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 
 		v, err := tuple[1].TryBytes()
 		if err != nil {
-			return errors.New("invalid config value from netmap contract")
+			return invalidConfigValueErr(k)
 		}
 
 		switch string(k) {
@@ -202,6 +202,13 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%d (int)\n", k, n)))
 		case netmapEigenTrustAlphaKey:
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (str)\n", k, v)))
+		case netmapHomomorphicHashDisabledKey:
+			vBool, err := tuple[1].TryBool()
+			if err != nil {
+				return invalidConfigValueErr(k)
+			}
+
+			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%t (bool)\n", k, vBool)))
 		default:
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (hex)\n", k, hex.EncodeToString(v))))
 		}
@@ -211,4 +218,8 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 	cmd.Print(buf.String())
 
 	return nil
+}
+
+func invalidConfigValueErr(key []byte) error {
+	return fmt.Errorf("invalid %s config value from netmap contract", key)
 }


### PR DESCRIPTION
Related to #1300.

Not critical, just supporting new config param in `dump-config` command:

```
▶ ./bin/neofs-adm morph dump-config -r http://192.168.130.90:30333
AuditFee:                    10000 (int)
BasicIncomeRate:             100000000 (int)
ContainerAliasFee:           500 (int)
ContainerFee:                1000 (int)
EigenTrustAlpha:             0.1 (str)
EigenTrustIterations:        4 (int)
EpochDuration:               240 (int)
HomomorphicHashingDisabled:  true (bool)
InnerRingCandidateFee:       10000000000 (int)
MaxObjectSize:               67108864 (int)
SystemDNS:                   636f6e7461696e6572 (hex)
WithdrawFee:                 100000000 (int)
```