### PR TITLE
services/control: extend tests for `ShardInfo` marshaling

### DIFF
--- a/pkg/services/control/service_test.go
+++ b/pkg/services/control/service_test.go
@@ -108,14 +108,25 @@ func equalListShardResponseBodies(b1, b2 *control.ListShardsResponse_Body) bool 
 		}
 	}
 
+	for i := range b1.Shards {
+		for j := i + 1; j < len(b1.Shards); j++ {
+			if b1.Shards[i].GetMetabasePath() == b2.Shards[j].GetMetabasePath() ||
+				b1.Shards[i].GetBlobstorPath() == b2.Shards[j].GetBlobstorPath() ||
+				b1.Shards[i].GetWritecachePath() == b2.Shards[j].GetWritecachePath() ||
+				bytes.Equal(b1.Shards[i].GetShard_ID(), b2.Shards[j].GetShard_ID()) {
+				return false
+			}
+		}
+	}
+
 	return true
 }
 
 func generateListShardsResponseBody() *control.ListShardsResponse_Body {
 	body := new(control.ListShardsResponse_Body)
 	body.SetShards([]*control.ShardInfo{
-		generateShardInfo(),
-		generateShardInfo(),
+		generateShardInfo(0),
+		generateShardInfo(1),
 	})
 
 	return body

--- a/pkg/services/control/types_test.go
+++ b/pkg/services/control/types_test.go
@@ -2,6 +2,8 @@ package control_test
 
 import (
 	"bytes"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -125,19 +127,19 @@ func equalNodeInfos(n1, n2 *control.NodeInfo) bool {
 	return true
 }
 
-func generateShardInfo() *control.ShardInfo {
+func generateShardInfo(id int) *control.ShardInfo {
 	si := new(control.ShardInfo)
 
-	path := "/nice/dir/awesome/files"
+	path := "/nice/dir/awesome/files/" + strconv.Itoa(id)
 
 	uid, _ := uuid.NewRandom()
 	bin, _ := uid.MarshalBinary()
 
 	si.SetID(bin)
 	si.SetMode(control.ShardMode_READ_WRITE)
-	si.SetMetabasePath(path)
-	si.SetBlobstorPath(path)
-	si.SetWriteCachePath(path)
+	si.SetMetabasePath(filepath.Join(path, "meta"))
+	si.SetBlobstorPath(filepath.Join(path, "blobstor"))
+	si.SetWriteCachePath(filepath.Join(path, "writecache"))
 
 	return si
 }


### PR DESCRIPTION
It is nice to have different paths for different components and also
check that the information returned is different for different shards.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>