### PR TITLE
Fix/Add details to LOCODE errors

### DIFF
--- a/pkg/util/locode/column/country.go
+++ b/pkg/util/locode/column/country.go
@@ -1,6 +1,8 @@
 package locodecolumn
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/pkg/util/locode"
 )
 
@@ -16,8 +18,11 @@ func (cc *CountryCode) Symbols() [countryCodeLen]uint8 {
 
 // CountryCodeFromString parses a string and returns the country code.
 func CountryCodeFromString(s string) (*CountryCode, error) {
-	if len(s) != countryCodeLen {
-		return nil, locode.ErrInvalidString
+	if l := len(s); l != countryCodeLen {
+		return nil, fmt.Errorf("incorrect country code length: expect: %d, got: %d",
+			countryCodeLen,
+			l,
+		)
 	}
 
 	for i := range s {

--- a/pkg/util/locode/column/location.go
+++ b/pkg/util/locode/column/location.go
@@ -1,6 +1,8 @@
 package locodecolumn
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/pkg/util/locode"
 )
 
@@ -16,8 +18,11 @@ func (lc *LocationCode) Symbols() [locationCodeLen]uint8 {
 
 // LocationCodeFromString parses a string and returns the location code.
 func LocationCodeFromString(s string) (*LocationCode, error) {
-	if len(s) != locationCodeLen {
-		return nil, locode.ErrInvalidString
+	if l := len(s); l != locationCodeLen {
+		return nil, fmt.Errorf("incorrect location code length: expect: %d, got: %d",
+			locationCodeLen,
+			l,
+		)
 	}
 
 	for i := range s {

--- a/pkg/util/locode/record.go
+++ b/pkg/util/locode/record.go
@@ -2,6 +2,7 @@ package locode
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -51,11 +52,18 @@ var ErrInvalidString = errors.New("invalid string format in UN/Locode")
 //
 // If string has incorrect format, ErrInvalidString returns.
 func FromString(s string) (*LOCODE, error) {
-	const locationSeparator = " "
+	const (
+		locationSeparator = " "
+		locodePartsNumber = 2
+	)
 
 	words := strings.Split(s, locationSeparator)
-	if ln := len(words); ln != 1 && ln != 2 {
-		return nil, ErrInvalidString
+	if ln := len(words); ln != locodePartsNumber {
+		return nil, fmt.Errorf(
+			"incorrect locode: it must consist of %d codes separated with a witespase, got: %d",
+			locodePartsNumber,
+			ln,
+		)
 	}
 
 	l := new(LOCODE)


### PR DESCRIPTION
Make error messages more descriptive when parsing LOCODE from string errors
appear.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1394.