### PR TITLE
[#1335] policer: Prevent potential object loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Basic income transfer's incorrect log message (#1374)
 - Listen to subnet removal events in notary-enabled env (#1224)
 - Update/remove nodes whose subnet has been removed (#1162)
+- Potential removal of local object when policy isn't complied (#1335)
 
 ## [0.28.1] - 2022-05-05
 


### PR DESCRIPTION
In previous implementation `Policer` considered local object copy as
redundant on processing single placement vector.

Make `Policer` to call redundant copy callback after full placement
processing. Also fix 404 error parsing.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #1335 