### PR TITLE
Revert "[#1141] morph/client: Allow to use more integer types as arguments"

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -451,13 +451,13 @@ func toStackParameter(value interface{}) (sc.Parameter, error) {
 		result.Type = sc.ByteArrayType
 	case int:
 		result.Type = sc.IntegerType
-		result.Value = big.NewInt(int64(v))
+		result.Value = int64(v)
 	case int64:
 		result.Type = sc.IntegerType
-		result.Value = big.NewInt(v)
+		result.Value = v
 	case uint64:
 		result.Type = sc.IntegerType
-		result.Value = new(big.Int).SetUint64(v)
+		result.Value = int64(v)
 	case [][]byte:
 		arr := make([]sc.Parameter, 0, len(v))
 		for i := range v {

--- a/pkg/morph/client/client_test.go
+++ b/pkg/morph/client/client_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"math/big"
 	"testing"
 
 	sc "github.com/nspcc-dev/neo-go/pkg/smartcontract"
@@ -21,12 +20,6 @@ func TestToStackParameter(t *testing.T) {
 		{
 			value:   int64(100),
 			expType: sc.IntegerType,
-			expVal:  big.NewInt(100),
-		},
-		{
-			value:   uint64(100),
-			expType: sc.IntegerType,
-			expVal:  big.NewInt(100),
 		},
 		{
 			value:   "hello world",


### PR DESCRIPTION
Partially revert, remove `big.Int`, leave `uint64` and `int` types.
This reverts commit 9349f422fd9a29ec529ef0648bbfabd1f9ff7651.