### PR TITLE
Fix/NPE in ACL service

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -15,7 +15,6 @@ import (
 	v2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/v2"
 	bearerSDK "github.com/nspcc-dev/neofs-sdk-go/bearer"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
 
@@ -168,13 +167,10 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 
 	hdrSrcOpts := make([]eaclV2.Option, 0, 3)
 
-	addr := addressSDK.NewAddress()
-	addr.SetContainerID(cid)
-	addr.SetObjectID(*reqInfo.ObjectID())
-
 	hdrSrcOpts = append(hdrSrcOpts,
 		eaclV2.WithLocalObjectStorage(c.localStorage),
-		eaclV2.WithAddress(addr),
+		eaclV2.WithCID(cid),
+		eaclV2.WithOID(reqInfo.ObjectID()),
 	)
 
 	if req, ok := msg.(eaclV2.Request); ok {

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -144,10 +144,11 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 	}
 
 	var table eaclSDK.Table
+	cid := reqInfo.ContainerID()
 
 	bearerTok := reqInfo.Bearer()
 	if bearerTok == nil {
-		pTable, err := c.eaclSrc.GetEACL(reqInfo.ContainerID())
+		pTable, err := c.eaclSrc.GetEACL(&cid)
 		if err != nil {
 			if errors.Is(err, container.ErrEACLNotFound) {
 				return nil
@@ -168,7 +169,7 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 	hdrSrcOpts := make([]eaclV2.Option, 0, 3)
 
 	addr := addressSDK.NewAddress()
-	addr.SetContainerID(*reqInfo.ContainerID())
+	addr.SetContainerID(cid)
 	addr.SetObjectID(*reqInfo.ObjectID())
 
 	hdrSrcOpts = append(hdrSrcOpts,
@@ -195,7 +196,7 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 	action := c.validator.CalculateAction(new(eaclSDK.ValidationUnit).
 		WithRole(reqInfo.RequestRole()).
 		WithOperation(reqInfo.Operation()).
-		WithContainerID(reqInfo.ContainerID()).
+		WithContainerID(&cid).
 		WithSenderKey(reqInfo.SenderKey()).
 		WithHeaderSource(hdrSrc).
 		WithEACLTable(&table),

--- a/pkg/services/object/acl/eacl/v2/eacl_test.go
+++ b/pkg/services/object/acl/eacl/v2/eacl_test.go
@@ -103,11 +103,15 @@ func TestHeadRequest(t *testing.T) {
 		obj:     obj,
 	}
 
+	cid, _ := addr.ContainerID()
+	oid, _ := addr.ObjectID()
+
 	newSource := func(t *testing.T) eaclSDK.TypedHeaderSource {
 		hdrSrc, err := NewMessageHeaderSource(
 			WithObjectStorage(lStorage),
 			WithServiceRequest(req),
-			WithAddress(addr))
+			WithCID(cid),
+			WithOID(&oid))
 		require.NoError(t, err)
 		return hdrSrc
 	}

--- a/pkg/services/object/acl/eacl/v2/opts.go
+++ b/pkg/services/object/acl/eacl/v2/opts.go
@@ -2,7 +2,8 @@ package v2
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	cidSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 func WithObjectStorage(v ObjectStorage) Option {
@@ -36,8 +37,14 @@ func WithServiceResponse(resp Response, req Request) Option {
 	}
 }
 
-func WithAddress(v *addressSDK.Address) Option {
+func WithCID(v cidSDK.ID) Option {
 	return func(c *cfg) {
-		c.addr = v
+		c.cid = v
+	}
+}
+
+func WithOID(v *oidSDK.ID) Option {
+	return func(c *cfg) {
+		c.oid = v
 	}
 }

--- a/pkg/services/object/acl/v2/classifier.go
+++ b/pkg/services/object/acl/v2/classifier.go
@@ -19,8 +19,6 @@ type senderClassifier struct {
 	netmap    core.Source
 }
 
-var errContainerIDNotSet = errors.New("container id is not set")
-
 type classifyResult struct {
 	role eaclSDK.Role
 	isIR bool
@@ -29,12 +27,8 @@ type classifyResult struct {
 
 func (c senderClassifier) classify(
 	req MetaWithToken,
-	idCnr *cidSDK.ID,
+	idCnr cidSDK.ID,
 	cnr *container.Container) (res *classifyResult, err error) {
-	if idCnr == nil {
-		return nil, errContainerIDNotSet
-	}
-
 	ownerCnr := cnr.OwnerID()
 	if ownerCnr == nil {
 		return nil, errors.New("missing container owner")

--- a/pkg/services/object/acl/v2/request.go
+++ b/pkg/services/object/acl/v2/request.go
@@ -23,7 +23,7 @@ type RequestInfo struct {
 	operation   eaclSDK.Operation // put, get, head, etc.
 	cnrOwner    *user.ID          // container owner
 
-	idCnr *containerIDSDK.ID
+	idCnr containerIDSDK.ID
 
 	oid *oidSDK.ID
 
@@ -62,7 +62,7 @@ func (r RequestInfo) ObjectID() *oidSDK.ID {
 }
 
 // ContainerID return container ID.
-func (r RequestInfo) ContainerID() *containerIDSDK.ID {
+func (r RequestInfo) ContainerID() containerIDSDK.ID {
 	return r.idCnr
 }
 

--- a/pkg/services/object/acl/v2/request.go
+++ b/pkg/services/object/acl/v2/request.go
@@ -25,6 +25,8 @@ type RequestInfo struct {
 
 	idCnr containerIDSDK.ID
 
+	// optional for some request
+	// e.g. Put, Search
 	oid *oidSDK.ID
 
 	senderKey []byte

--- a/pkg/services/object/acl/v2/service.go
+++ b/pkg/services/object/acl/v2/service.go
@@ -202,8 +202,6 @@ func (b Service) Head(
 }
 
 func (b Service) Search(request *objectV2.SearchRequest, stream object.SearchStream) error {
-	var id *cidSDK.ID
-
 	id, err := getContainerIDFromRequest(request)
 	if err != nil {
 		return err
@@ -442,9 +440,9 @@ func (g *searchStreamBasicChecker) Send(resp *objectV2.SearchResponse) error {
 
 func (b Service) findRequestInfo(
 	req MetaWithToken,
-	cid *cidSDK.ID,
+	cid cidSDK.ID,
 	op eaclSDK.Operation) (info RequestInfo, err error) {
-	cnr, err := b.containers.Get(cid) // fetch actual container
+	cnr, err := b.containers.Get(&cid) // fetch actual container
 	if err != nil {
 		return info, err
 	} else if cnr.OwnerID() == nil {

--- a/pkg/services/object/acl/v2/util.go
+++ b/pkg/services/object/acl/v2/util.go
@@ -20,9 +20,9 @@ import (
 
 var errMissingContainerID = errors.New("missing container ID")
 
-func getContainerIDFromRequest(req interface{}) (*containerIDSDK.ID, error) {
+func getContainerIDFromRequest(req interface{}) (containerIDSDK.ID, error) {
 	var idV2 *refsV2.ContainerID
-	id := new(containerIDSDK.ID)
+	var id containerIDSDK.ID
 
 	switch v := req.(type) {
 	case *objectV2.GetRequest:
@@ -30,7 +30,7 @@ func getContainerIDFromRequest(req interface{}) (*containerIDSDK.ID, error) {
 	case *objectV2.PutRequest:
 		part, ok := v.GetBody().GetObjectPart().(*objectV2.PutObjectPartInit)
 		if !ok {
-			return nil, errors.New("can't get container ID in chunk")
+			return containerIDSDK.ID{}, errors.New("can't get container ID in chunk")
 		}
 
 		idV2 = part.GetHeader().GetContainerID()
@@ -45,11 +45,11 @@ func getContainerIDFromRequest(req interface{}) (*containerIDSDK.ID, error) {
 	case *objectV2.GetRangeHashRequest:
 		idV2 = v.GetBody().GetAddress().GetContainerID()
 	default:
-		return nil, errors.New("unknown request type")
+		return containerIDSDK.ID{}, errors.New("unknown request type")
 	}
 
 	if idV2 == nil {
-		return nil, errMissingContainerID
+		return containerIDSDK.ID{}, errMissingContainerID
 	}
 
 	return id, id.ReadFromV2(*idV2)


### PR DESCRIPTION
After the SDK update there appeared an NPE error: we tried to dereference nil OID pointer for the `Put` and `Search` requests that do not contain (or not always contain) object ID. Make OID optional for requests (in general).