### PR TITLE
Upgrade `address` package

### DIFF
--- a/cmd/neofs-cli/internal/client/prm.go
+++ b/cmd/neofs-cli/internal/client/prm.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/bearer"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 )
 
@@ -22,11 +22,11 @@ func (x *commonPrm) SetClient(cli *client.Client) {
 }
 
 type containerIDPrm struct {
-	cnrID *cid.ID
+	cnrID cid.ID
 }
 
 // SetContainerID sets the container identifier.
-func (x *containerIDPrm) SetContainerID(id *cid.ID) {
+func (x *containerIDPrm) SetContainerID(id cid.ID) {
 	x.cnrID = id
 }
 
@@ -40,10 +40,10 @@ func (x *bearerTokenPrm) SetBearerToken(tok *bearer.Token) {
 }
 
 type objectAddressPrm struct {
-	objAddr *addressSDK.Address
+	objAddr oid.Address
 }
 
-func (x *objectAddressPrm) SetAddress(addr *addressSDK.Address) {
+func (x *objectAddressPrm) SetAddress(addr oid.Address) {
 	x.objAddr = addr
 }
 

--- a/cmd/neofs-cli/internal/common/token.go
+++ b/cmd/neofs-cli/internal/common/token.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/nspcc-dev/neofs-sdk-go/bearer"
@@ -33,13 +34,24 @@ func ReadBearerToken(cmd *cobra.Command, flagname string) *bearer.Token {
 	return &tok
 }
 
-// ReadSessionToken reads session token as JSON file with session token
-// from path provided in a specified flag.
+// ReadSessionToken calls ReadSessionTokenErr and exists on error.
 func ReadSessionToken(cmd *cobra.Command, dst json.Unmarshaler, fPath string) {
+	ExitOnErr(cmd, "", ReadSessionTokenErr(dst, fPath))
+}
+
+// ReadSessionTokenErr reads session token as JSON file with session token
+// from path provided in a specified flag.
+func ReadSessionTokenErr(dst json.Unmarshaler, fPath string) error {
 	// try to read session token from file
 	data, err := os.ReadFile(fPath)
-	ExitOnErr(cmd, "could not open file with session token: %w", err)
+	if err != nil {
+		return fmt.Errorf("could not open file with session token <%s>: %w", fPath, err)
+	}
 
 	err = dst.UnmarshalJSON(data)
-	ExitOnErr(cmd, "could not unmarshal session token from file: %w", err)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal session token from file: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/neofs-cli/modules/accounting/balance.go
+++ b/cmd/neofs-cli/modules/accounting/balance.go
@@ -24,22 +24,22 @@ var accountingBalanceCmd = &cobra.Command{
 	Short: "Get internal balance of NeoFS account",
 	Long:  `Get internal balance of NeoFS account`,
 	Run: func(cmd *cobra.Command, args []string) {
-		var oid user.ID
+		var idUser user.ID
 
 		pk := key.GetOrGenerate(cmd)
 
 		balanceOwner, _ := cmd.Flags().GetString(ownerFlag)
 		if balanceOwner == "" {
-			user.IDFromKey(&oid, pk.PublicKey)
+			user.IDFromKey(&idUser, pk.PublicKey)
 		} else {
-			common.ExitOnErr(cmd, "can't decode owner ID wallet address: %w", oid.DecodeString(balanceOwner))
+			common.ExitOnErr(cmd, "can't decode owner ID wallet address: %w", idUser.DecodeString(balanceOwner))
 		}
 
 		cli := internalclient.GetSDKClientByFlag(cmd, pk, commonflags.RPC)
 
 		var prm internalclient.BalanceOfPrm
 		prm.SetClient(cli)
-		prm.SetAccount(oid)
+		prm.SetAccount(idUser)
 
 		res, err := internalclient.BalanceOf(prm)
 		common.ExitOnErr(cmd, "rpc error: %w", err)

--- a/cmd/neofs-cli/modules/container.go
+++ b/cmd/neofs-cli/modules/container.go
@@ -22,7 +22,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/nspcc-dev/neofs-sdk-go/policy"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	subnetid "github.com/nspcc-dev/neofs-sdk-go/subnet/id"
@@ -205,7 +204,7 @@ It will be stored in sidechain when inner ring will accepts it.`,
 		if containerAwait {
 			cmd.Println("awaiting...")
 
-			getPrm.SetContainer(*id)
+			getPrm.SetContainer(id)
 
 			for i := 0; i < awaitTimeout; i++ {
 				time.Sleep(1 * time.Second)
@@ -288,11 +287,9 @@ var listContainerObjectsCmd = &cobra.Command{
 
 		var prm internalclient.SearchObjectsPrm
 
-		sessionObjectCtxAddress := addressSDK.NewAddress()
-		sessionObjectCtxAddress.SetContainerID(*id)
-		prepareSessionPrm(cmd, sessionObjectCtxAddress, &prm)
+		prepareSessionPrm(cmd, *id, nil, &prm)
 		prepareObjectPrm(cmd, &prm)
-		prm.SetContainerID(id)
+		prm.SetContainerID(*id)
 		prm.SetFilters(*filters)
 
 		res, err := internalclient.SearchObjects(prm)
@@ -301,7 +298,7 @@ var listContainerObjectsCmd = &cobra.Command{
 		objectIDs := res.IDList()
 
 		for i := range objectIDs {
-			cmd.Println(objectIDs[i].String())
+			cmd.Println(objectIDs[i])
 		}
 	},
 }
@@ -603,7 +600,7 @@ func init() {
 
 func prettyPrintContainerList(cmd *cobra.Command, list []cid.ID) {
 	for i := range list {
-		cmd.Println(list[i].String())
+		cmd.Println(list[i])
 	}
 }
 

--- a/cmd/neofs-cli/modules/control/drop_objects.go
+++ b/cmd/neofs-cli/modules/control/drop_objects.go
@@ -1,14 +1,11 @@
 package control
 
 import (
-	"fmt"
-
 	rawclient "github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/key"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	"github.com/spf13/cobra"
 )
 
@@ -22,20 +19,10 @@ var dropObjectsCmd = &cobra.Command{
 		pk := key.Get(cmd)
 
 		dropObjectsList, _ := cmd.Flags().GetStringSlice(dropObjectsFlag)
-		binAddrList := make([][]byte, 0, len(dropObjectsList))
+		binAddrList := make([][]byte, len(dropObjectsList))
 
 		for i := range dropObjectsList {
-			a := addressSDK.NewAddress()
-
-			err := a.Parse(dropObjectsList[i])
-			if err != nil {
-				common.ExitOnErr(cmd, "", fmt.Errorf("could not parse address #%d: %w", i, err))
-			}
-
-			binAddr, err := a.Marshal()
-			common.ExitOnErr(cmd, "could not marshal the address: %w", err)
-
-			binAddrList = append(binAddrList, binAddr)
+			binAddrList[i] = []byte(dropObjectsList[i])
 		}
 
 		body := new(control.DropObjectsRequest_Body)

--- a/cmd/neofs-cli/modules/control/util.go
+++ b/cmd/neofs-cli/modules/control/util.go
@@ -24,15 +24,12 @@ func verifyResponse(cmd *cobra.Command,
 		GetSign() []byte
 	},
 	body interface {
-		StableMarshal([]byte) ([]byte, error)
+		StableMarshal([]byte) []byte
 	},
 ) {
 	if sigControl == nil {
 		common.ExitOnErr(cmd, "", errors.New("missing response signature"))
 	}
-
-	bodyData, err := body.StableMarshal(nil)
-	common.ExitOnErr(cmd, "marshal response body: %w", err)
 
 	// TODO(@cthulhu-rider): #1387 use Signature message from NeoFS API to avoid conversion
 	var sigV2 refs.Signature
@@ -43,7 +40,7 @@ func verifyResponse(cmd *cobra.Command,
 	var sig neofscrypto.Signature
 	sig.ReadFromV2(sigV2)
 
-	if !sig.Verify(bodyData) {
+	if !sig.Verify(body.StableMarshal(nil)) {
 		common.ExitOnErr(cmd, "", errors.New("invalid response signature"))
 	}
 }

--- a/cmd/neofs-cli/modules/lock.go
+++ b/cmd/neofs-cli/modules/lock.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/key"
-	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
@@ -51,7 +50,7 @@ var cmdObjectLock = &cobra.Command{
 
 		var prm internalclient.PutObjectPrm
 
-		prepareSessionPrmWithOwner(cmd, objectcore.AddressOf(obj), key, idOwner, &prm)
+		prepareSessionPrmWithOwner(cmd, cnr, nil, key, *idOwner, &prm)
 		prepareObjectPrm(cmd, &prm)
 		prm.SetHeader(obj)
 

--- a/cmd/neofs-lens/internal/commands/inspect/inspect.go
+++ b/cmd/neofs-lens/internal/commands/inspect/inspect.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/spf13/cobra"
 )
@@ -57,8 +56,9 @@ func init() {
 }
 
 func objectInspectCmd(cmd *cobra.Command, _ []string) {
-	addr := addressSDK.NewAddress()
-	err := addr.Parse(vAddress)
+	var addr oid.Address
+
+	err := addr.DecodeString(vAddress)
 	common.ExitOnErr(cmd, common.Errf("invalid address argument: %w", err))
 
 	if vOut == "" && !vHeader {
@@ -72,7 +72,7 @@ func objectInspectCmd(cmd *cobra.Command, _ []string) {
 
 		defer db.Close()
 
-		data, err := writecache.Get(db, []byte(addr.String()))
+		data, err := writecache.Get(db, []byte(vAddress))
 		common.ExitOnErr(cmd, common.Errf("could not fetch object: %w", err))
 		printObjectInfo(cmd, data)
 		return

--- a/cmd/neofs-lens/internal/commands/list/list.go
+++ b/cmd/neofs-lens/internal/commands/list/list.go
@@ -1,12 +1,13 @@
 package cmdlist
 
 import (
+	"fmt"
 	"io"
 
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/spf13/cobra"
 )
 
@@ -40,8 +41,8 @@ var Command = &cobra.Command{
 		// other targets can be supported
 		w := cmd.OutOrStderr()
 
-		wAddr := func(addr *addressSDK.Address) error {
-			_, err := io.WriteString(w, addr.String()+"\n")
+		wAddr := func(addr oid.Address) error {
+			_, err := io.WriteString(w, fmt.Sprintf("%s\n", addr))
 			return err
 		}
 

--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -141,7 +141,7 @@ func newCachedContainerStorage(v container.Source) *ttlContainerStorage {
 			return nil, err
 		}
 
-		return v.Get(&id)
+		return v.Get(id)
 	})
 
 	return (*ttlContainerStorage)(lruCnrCache)
@@ -149,8 +149,8 @@ func newCachedContainerStorage(v container.Source) *ttlContainerStorage {
 
 // Get returns container value from the cache. If value is missing in the cache
 // or expired, then it returns value from side chain and updates the cache.
-func (s *ttlContainerStorage) Get(cid *cid.ID) (*containerSDK.Container, error) {
-	val, err := (*ttlNetCache)(s).get(cid.String())
+func (s *ttlContainerStorage) Get(cnr cid.ID) (*containerSDK.Container, error) {
+	val, err := (*ttlNetCache)(s).get(cnr.EncodeToString())
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func newCachedEACLStorage(v eacl.Source) *ttlEACLStorage {
 			return nil, err
 		}
 
-		return v.GetEACL(&id)
+		return v.GetEACL(id)
 	})
 
 	return (*ttlEACLStorage)(lruCnrCache)
@@ -182,8 +182,8 @@ func newCachedEACLStorage(v eacl.Source) *ttlEACLStorage {
 
 // GetEACL returns eACL value from the cache. If value is missing in the cache
 // or expired, then it returns value from side chain and updates cache.
-func (s *ttlEACLStorage) GetEACL(cid *cid.ID) (*eaclSDK.Table, error) {
-	val, err := (*ttlNetCache)(s).get(cid.String())
+func (s *ttlEACLStorage) GetEACL(cnr cid.ID) (*eaclSDK.Table, error) {
+	val, err := (*ttlNetCache)(s).get(cnr.EncodeToString())
 	if err != nil {
 		return nil, err
 	}
@@ -192,8 +192,8 @@ func (s *ttlEACLStorage) GetEACL(cid *cid.ID) (*eaclSDK.Table, error) {
 }
 
 // InvalidateEACL removes cached eACL value.
-func (s *ttlEACLStorage) InvalidateEACL(cid *cid.ID) {
-	(*ttlNetCache)(s).remove(cid.String())
+func (s *ttlEACLStorage) InvalidateEACL(cnr cid.ID) {
+	(*ttlNetCache)(s).remove(cnr.EncodeToString())
 }
 
 type lruNetmapSource struct {
@@ -270,11 +270,11 @@ func newCachedContainerLister(c *cntClient.Client) *ttlContainerLister {
 // List returns list of container IDs from the cache. If list is missing in the
 // cache or expired, then it returns container IDs from side chain and updates
 // the cache.
-func (s *ttlContainerLister) List(id *user.ID) ([]*cid.ID, error) {
+func (s *ttlContainerLister) List(id *user.ID) ([]cid.ID, error) {
 	var str string
 
 	if id != nil {
-		str = id.String()
+		str = id.EncodeToString()
 	}
 
 	val, err := (*ttlNetCache)(s).get(str)
@@ -282,12 +282,12 @@ func (s *ttlContainerLister) List(id *user.ID) ([]*cid.ID, error) {
 		return nil, err
 	}
 
-	return val.([]*cid.ID), nil
+	return val.([]cid.ID), nil
 }
 
 // InvalidateContainerList removes cached list of container IDs.
-func (s *ttlContainerLister) InvalidateContainerList(id *user.ID) {
-	(*ttlNetCache)(s).remove(id.String())
+func (s *ttlContainerLister) InvalidateContainerList(id user.ID) {
+	(*ttlNetCache)(s).remove(id.EncodeToString())
 }
 
 type cachedIRFetcher ttlNetCache

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -54,7 +54,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const addressSize = 72 // 32 bytes oid, 32 bytes cid, 8 bytes protobuf encoding
+const addressSize = 72 // 32 bytes object ID, 32 bytes container ID, 8 bytes protobuf encoding
 
 const maxMsgSize = 4 << 20 // transport msg limit 4 MiB
 

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"google.golang.org/grpc"
 )
 
@@ -33,7 +33,7 @@ func initControlService(c *cfg) {
 		controlSvc.WithHealthChecker(c),
 		controlSvc.WithNetMapSource(c.netMapSource),
 		controlSvc.WithNodeState(c),
-		controlSvc.WithDeletedObjectHandler(func(addrList []*addressSDK.Address) error {
+		controlSvc.WithDeletedObjectHandler(func(addrList []oid.Address) error {
 			prm := new(engine.DeletePrm).WithAddresses(addrList...)
 
 			_, err := c.cfgObject.cfgLocalStorage.localStorage.Delete(prm)

--- a/cmd/neofs-node/notificator.go
+++ b/cmd/neofs-node/notificator.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/notificator"
 	"github.com/nspcc-dev/neofs-node/pkg/services/notificator/nats"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ type notificationSource struct {
 	defaultTopic string
 }
 
-func (n *notificationSource) Iterate(epoch uint64, handler func(topic string, addr *addressSDK.Address)) {
+func (n *notificationSource) Iterate(epoch uint64, handler func(topic string, addr oid.Address)) {
 	log := n.l.With(zap.Uint64("epoch", epoch))
 
 	listRes, err := n.e.ListContainers(engine.ListContainersPrm{})
@@ -64,8 +64,8 @@ func (n *notificationSource) Iterate(epoch uint64, handler func(topic string, ad
 }
 
 func (n *notificationSource) processAddress(
-	a *addressSDK.Address,
-	h func(topic string, addr *addressSDK.Address),
+	a oid.Address,
+	h func(topic string, addr oid.Address),
 ) error {
 	prm := new(engine.HeadPrm)
 	prm.WithAddress(a)
@@ -96,7 +96,7 @@ type notificationWriter struct {
 	w *nats.Writer
 }
 
-func (n notificationWriter) Notify(topic string, address *addressSDK.Address) {
+func (n notificationWriter) Notify(topic string, address oid.Address) {
 	if err := n.w.Notify(topic, address); err != nil {
 		n.l.Warn("could not write object notification",
 			zap.Stringer("address", address),

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -42,7 +42,7 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"go.uber.org/zap"
 )
@@ -102,7 +102,7 @@ type localObjectInhumer struct {
 	log *logger.Logger
 }
 
-func (r *localObjectInhumer) DeleteObjects(ts *addressSDK.Address, addr ...*addressSDK.Address) error {
+func (r *localObjectInhumer) DeleteObjects(ts oid.Address, addr ...oid.Address) error {
 	prm := new(engine.InhumePrm)
 	prm.WithTarget(ts, addr...)
 
@@ -124,8 +124,8 @@ func (i *delNetInfo) TombstoneLifetime() (uint64, error) {
 // returns node owner ID calculated from configured private key.
 //
 // Implements method needed for Object.Delete service.
-func (i *delNetInfo) LocalNodeID() *user.ID {
-	return &i.cfg.ownerIDFromKey
+func (i *delNetInfo) LocalNodeID() user.ID {
+	return i.cfg.ownerIDFromKey
 }
 
 type innerRingFetcherWithNotary struct {
@@ -234,7 +234,7 @@ func initObjectService(c *cfg) {
 			policerconfig.HeadTimeout(c.appCfg),
 		),
 		policer.WithReplicator(repl),
-		policer.WithRedundantCopyCallback(func(addr *addressSDK.Address) {
+		policer.WithRedundantCopyCallback(func(addr oid.Address) {
 			_, err := ls.Inhume(new(engine.InhumePrm).MarkAsGarbage(addr))
 			if err != nil {
 				c.log.Warn("could not inhume mark redundant copy as garbage",
@@ -412,8 +412,8 @@ func (s *signedEACLTable) SignedDataSize() int {
 	return (*eaclSDK.Table)(s).ToV2().StableSize()
 }
 
-func (s *morphEACLFetcher) GetEACL(cid *cid.ID) (*eaclSDK.Table, error) {
-	table, err := s.w.GetEACL(cid)
+func (s *morphEACLFetcher) GetEACL(cnr cid.ID) (*eaclSDK.Table, error) {
+	table, err := s.w.GetEACL(cnr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/neofs-node/session.go
+++ b/cmd/neofs-node/session.go
@@ -20,7 +20,7 @@ import (
 
 type sessionStorage interface {
 	Create(ctx context.Context, body *session.CreateRequestBody) (*session.CreateResponseBody, error)
-	Get(ownerID *user.ID, tokenID []byte) *storage.PrivateToken
+	Get(ownerID user.ID, tokenID []byte) *storage.PrivateToken
 	RemoveOld(epoch uint64)
 
 	Close() error

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.98.3
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220321144137-d5a9af5860af // indirect
-	github.com/nspcc-dev/neofs-api-go/v2 v2.12.1
+	github.com/nspcc-dev/neofs-api-go/v2 v2.12.2-0.20220530190258-c82dcf7e1610
 	github.com/nspcc-dev/neofs-contract v0.15.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220526065457-bef4618cd6b9
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531091404-82d762f536a3
 	github.com/nspcc-dev/tzhash v1.5.2
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220321144137-d5a9af5860af h1:QO
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220321144137-d5a9af5860af/go.mod h1:QBE0I30F2kOAISNpT5oks82yF4wkkUq3SCfI3Hqgx/Y=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.12.1 h1:PVU2rLlG9S0jDe5eKyaUs4nKo/la+mN5pvz32Gib3qM=
-github.com/nspcc-dev/neofs-api-go/v2 v2.12.1/go.mod h1:73j09Xa7I2zQbM3HCvAHnDHPYiiWnEHa1d6Z6RDMBLU=
+github.com/nspcc-dev/neofs-api-go/v2 v2.12.2-0.20220530190258-c82dcf7e1610 h1:JwrxHWQJSOxx0LvnEvFj3MpKjWQAPXOq55uuGimghR0=
+github.com/nspcc-dev/neofs-api-go/v2 v2.12.2-0.20220530190258-c82dcf7e1610/go.mod h1:73j09Xa7I2zQbM3HCvAHnDHPYiiWnEHa1d6Z6RDMBLU=
 github.com/nspcc-dev/neofs-contract v0.15.1 h1:1r27t4SGKF7W1PRPOIfircEXHvALThNYNagT+SIabcA=
 github.com/nspcc-dev/neofs-contract v0.15.1/go.mod h1:kxO5ZTqdzFnRM5RMvM+Fhd+3GGrJo6AmG2ZyA9OCqqQ=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
@@ -407,8 +407,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220526065457-bef4618cd6b9 h1:TV2/sp/2CY7h7R2MJfU7HYDvXjKGAcOMJvpmV/w4lFk=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220526065457-bef4618cd6b9/go.mod h1:u567oWTnAyGXbPWMrbcN0NB5zCPF+PqkaKg+vcijcho=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531091404-82d762f536a3 h1:AjuzmxXE32Gm/fCvKyRc40Qwqs45J8QSpA7sBR+VD4c=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.3.0.20220531091404-82d762f536a3/go.mod h1:ci0d8ppgduRvrAhZVGKj6PhuOiVpvKnlDvSlDI9hkJk=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/core/container/delete.go
+++ b/pkg/core/container/delete.go
@@ -8,7 +8,7 @@ import (
 // RemovalWitness groups the information required
 // to prove and verify the removal of a container.
 type RemovalWitness struct {
-	cid *cid.ID
+	cnr cid.ID
 
 	sig []byte
 
@@ -17,14 +17,14 @@ type RemovalWitness struct {
 
 // ContainerID returns the identifier of the container
 // to be removed.
-func (x RemovalWitness) ContainerID() *cid.ID {
-	return x.cid
+func (x RemovalWitness) ContainerID() cid.ID {
+	return x.cnr
 }
 
 // SetContainerID sets the identifier of the container
 // to be removed.
-func (x *RemovalWitness) SetContainerID(id *cid.ID) {
-	x.cid = id
+func (x *RemovalWitness) SetContainerID(id cid.ID) {
+	x.cnr = id
 }
 
 // Signature returns the signature of the container identifier.

--- a/pkg/core/container/fmt_test.go
+++ b/pkg/core/container/fmt_test.go
@@ -27,10 +27,10 @@ func TestCheckFormat(t *testing.T) {
 
 	require.Error(t, CheckFormat(c))
 
-	var oid user.ID
-	user.IDFromKey(&oid, test.DecodeKey(-1).PublicKey)
+	var idUser user.ID
+	user.IDFromKey(&idUser, test.DecodeKey(-1).PublicKey)
 
-	c.SetOwnerID(&oid)
+	c.SetOwnerID(&idUser)
 
 	// set incorrect nonce
 	cV2 := c.ToV2()

--- a/pkg/core/container/storage.go
+++ b/pkg/core/container/storage.go
@@ -19,7 +19,7 @@ type Source interface {
 	//
 	// Implementations must not retain the container pointer and modify
 	// the container through it.
-	Get(*cid.ID) (*container.Container, error)
+	Get(cid.ID) (*container.Container, error)
 }
 
 // IsErrNotFound checks if the error returned by Source.Get corresponds

--- a/pkg/core/object/fmt_test.go
+++ b/pkg/core/object/fmt_test.go
@@ -11,7 +11,7 @@ import (
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
@@ -117,7 +117,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 		require.Error(t, v.ValidateContent(obj)) // no tombstone content
 
 		content := object.NewTombstone()
-		content.SetMembers([]oidSDK.ID{oidtest.ID()})
+		content.SetMembers([]oid.ID{oidtest.ID()})
 
 		data, err := content.Marshal()
 		require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		require.Error(t, v.ValidateContent(obj)) // no members in tombstone
 
-		content.SetMembers([]oidSDK.ID{oidtest.ID()})
+		content.SetMembers([]oid.ID{oidtest.ID()})
 
 		data, err = content.Marshal()
 		require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		require.Error(t, v.ValidateContent(obj))
 
-		content.SetMembers([]oidSDK.ID{oidtest.ID()})
+		content.SetMembers([]oid.ID{oidtest.ID()})
 
 		data, err = content.Marshal()
 		require.NoError(t, err)

--- a/pkg/core/object/object.go
+++ b/pkg/core/object/object.go
@@ -2,26 +2,22 @@ package object
 
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // AddressOf returns the address of the object.
-func AddressOf(obj *object.Object) *addressSDK.Address {
-	if obj != nil {
-		addr := addressSDK.NewAddress()
+func AddressOf(obj *object.Object) oid.Address {
+	var addr oid.Address
 
-		id, ok := obj.ID()
-		if ok {
-			addr.SetObjectID(id)
-		}
-
-		cnr, ok := obj.ContainerID()
-		if ok {
-			addr.SetContainerID(cnr)
-		}
-
-		return addr
+	id, ok := obj.ID()
+	if ok {
+		addr.SetObject(id)
 	}
 
-	return nil
+	cnr, ok := obj.ContainerID()
+	if ok {
+		addr.SetContainer(cnr)
+	}
+
+	return addr
 }

--- a/pkg/innerring/internal/client/prm.go
+++ b/pkg/innerring/internal/client/prm.go
@@ -3,7 +3,7 @@ package neofsapiclient
 import (
 	"context"
 
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type contextPrm struct {
@@ -16,11 +16,11 @@ func (x *contextPrm) SetContext(ctx context.Context) {
 }
 
 type objectAddressPrm struct {
-	objAddr *addressSDK.Address
+	objAddr oid.Address
 }
 
 // SetAddress sets address of the object.
-func (x *objectAddressPrm) SetAddress(addr *addressSDK.Address) {
+func (x *objectAddressPrm) SetAddress(addr oid.Address) {
 	x.objAddr = addr
 }
 

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -110,8 +110,8 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 	}
 }
 
-func (ap *Processor) findStorageGroups(cid *cid.ID, shuffled netmap.Nodes) []oidSDK.ID {
-	var sg []oidSDK.ID
+func (ap *Processor) findStorageGroups(cnr cid.ID, shuffled netmap.Nodes) []oid.ID {
+	var sg []oid.ID
 
 	ln := len(shuffled)
 
@@ -120,11 +120,11 @@ func (ap *Processor) findStorageGroups(cid *cid.ID, shuffled netmap.Nodes) []oid
 		prm  SearchSGPrm
 	)
 
-	prm.id = cid
+	prm.id = cnr
 
 	for i := range shuffled { // consider iterating over some part of container
 		log := ap.log.With(
-			zap.Stringer("cid", cid),
+			zap.Stringer("cid", cnr),
 			zap.String("key", hex.EncodeToString(shuffled[0].PublicKey())),
 			zap.Int("try", i),
 			zap.Int("total_tries", ln),

--- a/pkg/innerring/processors/audit/processor.go
+++ b/pkg/innerring/processors/audit/processor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/nspcc-dev/neofs-node/pkg/services/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
 )
@@ -67,7 +67,7 @@ type (
 type SearchSGPrm struct {
 	ctx context.Context
 
-	id *cid.ID
+	id cid.ID
 
 	info client.NodeInfo
 }
@@ -78,7 +78,7 @@ func (x SearchSGPrm) Context() context.Context {
 }
 
 // CID returns the identifier of the container to search SG in.
-func (x SearchSGPrm) CID() *cid.ID {
+func (x SearchSGPrm) CID() cid.ID {
 	return x.id
 }
 
@@ -89,11 +89,11 @@ func (x SearchSGPrm) NodeInfo() client.NodeInfo {
 
 // SearchSGDst groups the target values which Processor expects from SG searching to process.
 type SearchSGDst struct {
-	ids []oidSDK.ID
+	ids []oid.ID
 }
 
 // WriteIDList writes a list of identifiers of storage group objects stored in the container.
-func (x *SearchSGDst) WriteIDList(ids []oidSDK.ID) {
+func (x *SearchSGDst) WriteIDList(ids []oid.ID) {
 	x.ids = ids
 }
 

--- a/pkg/innerring/processors/audit/scheduler.go
+++ b/pkg/innerring/processors/audit/scheduler.go
@@ -12,7 +12,7 @@ import (
 
 var ErrInvalidIRNode = errors.New("node is not in the inner ring list")
 
-func (ap *Processor) selectContainersToAudit(epoch uint64) ([]*cid.ID, error) {
+func (ap *Processor) selectContainersToAudit(epoch uint64) ([]cid.ID, error) {
 	containers, err := ap.containerClient.List(nil)
 	if err != nil {
 		return nil, fmt.Errorf("can't get list of containers to start audit: %w", err)
@@ -25,7 +25,7 @@ func (ap *Processor) selectContainersToAudit(epoch uint64) ([]*cid.ID, error) {
 	)
 
 	sort.Slice(containers, func(i, j int) bool {
-		return strings.Compare(containers[i].String(), containers[j].String()) < 0
+		return strings.Compare(containers[i].EncodeToString(), containers[j].EncodeToString()) < 0
 	})
 
 	ind := ap.irList.InnerRingIndex()
@@ -38,7 +38,7 @@ func (ap *Processor) selectContainersToAudit(epoch uint64) ([]*cid.ID, error) {
 	return Select(containers, epoch, uint64(ind), uint64(irSize)), nil
 }
 
-func Select(ids []*cid.ID, epoch, index, size uint64) []*cid.ID {
+func Select(ids []cid.ID, epoch, index, size uint64) []cid.ID {
 	if index >= size {
 		return nil
 	}

--- a/pkg/innerring/processors/audit/scheduler_test.go
+++ b/pkg/innerring/processors/audit/scheduler_test.go
@@ -26,10 +26,10 @@ func TestSelect(t *testing.T) {
 			require.Equal(t, len(cids)/irSize, len(s))
 
 			for _, id := range s {
-				n, ok := m[id.String()]
+				n, ok := m[id.EncodeToString()]
 				require.True(t, ok)
 				require.Equal(t, 0, n)
-				m[id.String()] = 1
+				m[id.EncodeToString()] = 1
 			}
 		}
 
@@ -45,10 +45,10 @@ func TestSelect(t *testing.T) {
 			s := audit.Select(cids, 0, uint64(i), irSize)
 
 			for _, id := range s {
-				n, ok := m[id.String()]
+				n, ok := m[id.EncodeToString()]
 				require.True(t, ok)
 				require.Equal(t, 0, n)
-				m[id.String()] = 1
+				m[id.EncodeToString()] = 1
 			}
 		}
 
@@ -64,10 +64,10 @@ func TestSelect(t *testing.T) {
 			s := audit.Select(cids, uint64(i), 0, irSize)
 
 			for _, id := range s {
-				n, ok := m[id.String()]
+				n, ok := m[id.EncodeToString()]
 				require.True(t, ok)
 				require.Equal(t, 0, n)
-				m[id.String()] = 1
+				m[id.EncodeToString()] = 1
 			}
 		}
 
@@ -75,22 +75,21 @@ func TestSelect(t *testing.T) {
 	})
 }
 
-func generateContainers(n int) []*cid.ID {
-	result := make([]*cid.ID, 0, n)
+func generateContainers(n int) []cid.ID {
+	result := make([]cid.ID, n)
 
 	for i := 0; i < n; i++ {
-		v := cidtest.ID()
-		result = append(result, &v)
+		result[i] = cidtest.ID()
 	}
 
 	return result
 }
 
-func hitMap(ids []*cid.ID) map[string]int {
+func hitMap(ids []cid.ID) map[string]int {
 	result := make(map[string]int, len(ids))
 
 	for _, id := range ids {
-		result[id.String()] = 0
+		result[id.EncodeToString()] = 0
 	}
 
 	return result

--- a/pkg/innerring/processors/container/common.go
+++ b/pkg/innerring/processors/container/common.go
@@ -115,7 +115,7 @@ func (cp *Processor) verifySignature(v signatureVerificationData) error {
 
 	if verificationKeys == nil {
 		var prm neofsid.AccountKeysPrm
-		prm.SetID(&v.ownerContainer)
+		prm.SetID(v.ownerContainer)
 
 		ownerKeys, err := cp.idClient.AccountKeys(prm)
 		if err != nil {

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -154,17 +154,17 @@ func (cp *Processor) processContainerDelete(delete *containerEvent.Delete) {
 }
 
 func (cp *Processor) checkDeleteContainer(e *containerEvent.Delete) error {
-	binCID := e.ContainerID()
+	binCnr := e.ContainerID()
 
 	var idCnr cid.ID
 
-	err := idCnr.Decode(binCID)
+	err := idCnr.Decode(binCnr)
 	if err != nil {
 		return fmt.Errorf("invalid container ID: %w", err)
 	}
 
 	// receive owner of the related container
-	cnr, err := cp.cnrClient.Get(binCID)
+	cnr, err := cp.cnrClient.Get(binCnr)
 	if err != nil {
 		return fmt.Errorf("could not receive the container: %w", err)
 	}
@@ -181,7 +181,7 @@ func (cp *Processor) checkDeleteContainer(e *containerEvent.Delete) error {
 		idContainer:     idCnr,
 		binTokenSession: e.SessionToken(),
 		signature:       e.Signature(),
-		signedData:      binCID,
+		signedData:      binCnr,
 	})
 	if err != nil {
 		return fmt.Errorf("auth container removal: %w", err)

--- a/pkg/innerring/processors/container/process_eacl.go
+++ b/pkg/innerring/processors/container/process_eacl.go
@@ -46,7 +46,7 @@ func (cp *Processor) checkSetEACL(e container.SetEACL) error {
 	}
 
 	// receive owner of the related container
-	cnr, err := cntClient.Get(cp.cnrClient, &idCnr)
+	cnr, err := cntClient.Get(cp.cnrClient, idCnr)
 	if err != nil {
 		return fmt.Errorf("could not receive the container: %w", err)
 	}

--- a/pkg/innerring/processors/settlement/audit/calculate.go
+++ b/pkg/innerring/processors/settlement/audit/calculate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"go.uber.org/zap"
@@ -152,7 +151,7 @@ func (c *Calculator) readContainerInfo(ctx *singleResultCtx) bool {
 
 	var err error
 
-	ctx.cnrInfo, err = c.prm.ContainerStorage.ContainerInfo(&cnr)
+	ctx.cnrInfo, err = c.prm.ContainerStorage.ContainerInfo(cnr)
 	if err != nil {
 		ctx.log.Error("could not get container info",
 			zap.String("error", err.Error()),
@@ -217,11 +216,11 @@ func (c *Calculator) sumSGSizes(ctx *singleResultCtx) bool {
 	sumPassSGSize := uint64(0)
 	fail := false
 
-	addr := addressSDK.NewAddress()
-	addr.SetContainerID(*ctx.containerID())
+	var addr oid.Address
+	addr.SetContainer(ctx.containerID())
 
 	ctx.auditResult.IteratePassedStorageGroups(func(id oid.ID) bool {
-		addr.SetObjectID(id)
+		addr.SetObject(id)
 
 		sgInfo, err := c.prm.SGStorage.SGInfo(addr)
 		if err != nil {
@@ -285,7 +284,7 @@ func (c *Calculator) fillTransferTable(ctx *singleResultCtx) bool {
 
 		ctx.txTable.Transfer(&common.TransferTx{
 			From:   cnrOwner,
-			To:     ownerID,
+			To:     *ownerID,
 			Amount: fee,
 		})
 	}
@@ -303,16 +302,16 @@ func (c *Calculator) fillTransferTable(ctx *singleResultCtx) bool {
 
 	ctx.txTable.Transfer(&common.TransferTx{
 		From:   cnrOwner,
-		To:     auditIR,
+		To:     *auditIR,
 		Amount: ctx.auditFee,
 	})
 
 	return false
 }
 
-func (c *singleResultCtx) containerID() *cid.ID {
+func (c *singleResultCtx) containerID() cid.ID {
 	cnr, _ := c.auditResult.Container()
-	return &cnr
+	return cnr
 }
 
 func (c *singleResultCtx) auditEpoch() uint64 {

--- a/pkg/innerring/processors/settlement/audit/prm.go
+++ b/pkg/innerring/processors/settlement/audit/prm.go
@@ -3,7 +3,7 @@ package audit
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement/common"
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // CalculatorPrm groups the parameters of Calculator's constructor.
@@ -39,7 +39,7 @@ type SGInfo interface {
 // SGStorage is an interface of storage of the storage groups.
 type SGStorage interface {
 	// Must return information about the storage group by address.
-	SGInfo(*addressSDK.Address) (SGInfo, error)
+	SGInfo(oid.Address) (SGInfo, error)
 }
 
 // FeeFetcher wraps AuditFee method that returns audit fee price from

--- a/pkg/innerring/processors/settlement/basic/collect.go
+++ b/pkg/innerring/processors/settlement/basic/collect.go
@@ -41,7 +41,8 @@ func (inc *IncomeSettlementContext) Collect() {
 		if err != nil {
 			inc.log.Warn("can't fetch container info",
 				zap.Uint64("epoch", inc.epoch),
-				zap.Stringer("container_id", cnrEstimations[i].ContainerID))
+				zap.Stringer("container_id", cnrEstimations[i].ContainerID),
+			)
 
 			continue
 		}
@@ -50,7 +51,8 @@ func (inc *IncomeSettlementContext) Collect() {
 		if err != nil {
 			inc.log.Debug("can't fetch container info",
 				zap.Uint64("epoch", inc.epoch),
-				zap.Stringer("container_id", cnrEstimations[i].ContainerID))
+				zap.Stringer("container_id", cnrEstimations[i].ContainerID),
+			)
 
 			continue
 		}
@@ -65,7 +67,7 @@ func (inc *IncomeSettlementContext) Collect() {
 
 		txTable.Transfer(&common.TransferTx{
 			From:   owner.Owner(),
-			To:     &inc.bankOwner,
+			To:     inc.bankOwner,
 			Amount: total,
 		})
 	}

--- a/pkg/innerring/processors/settlement/basic/context.go
+++ b/pkg/innerring/processors/settlement/basic/context.go
@@ -22,7 +22,7 @@ type (
 
 	// BalanceFetcher uses NEP-17 compatible balance contract
 	BalanceFetcher interface {
-		Balance(id *user.ID) (*big.Int, error)
+		Balance(id user.ID) (*big.Int, error)
 	}
 
 	IncomeSettlementContext struct {

--- a/pkg/innerring/processors/settlement/basic/distribute.go
+++ b/pkg/innerring/processors/settlement/basic/distribute.go
@@ -14,7 +14,7 @@ func (inc *IncomeSettlementContext) Distribute() {
 
 	txTable := common.NewTransferTable()
 
-	bankBalance, err := inc.balances.Balance(&inc.bankOwner)
+	bankBalance, err := inc.balances.Balance(inc.bankOwner)
 	if err != nil {
 		inc.log.Error("can't fetch balance of banking account",
 			zap.String("error", err.Error()))
@@ -35,8 +35,8 @@ func (inc *IncomeSettlementContext) Distribute() {
 		}
 
 		txTable.Transfer(&common.TransferTx{
-			From:   &inc.bankOwner,
-			To:     nodeOwner,
+			From:   inc.bankOwner,
+			To:     *nodeOwner,
 			Amount: normalizedValue(n, total, bankBalance),
 		})
 	})

--- a/pkg/innerring/processors/settlement/common/types.go
+++ b/pkg/innerring/processors/settlement/common/types.go
@@ -21,21 +21,21 @@ type NodeInfo interface {
 // necessary for calculating audit fee.
 type ContainerInfo interface {
 	// Must return identifier of the container owner.
-	Owner() *user.ID
+	Owner() user.ID
 }
 
 // ContainerStorage is an interface of
 // storage of the NeoFS containers.
 type ContainerStorage interface {
 	// Must return information about the container by ID.
-	ContainerInfo(*cid.ID) (ContainerInfo, error)
+	ContainerInfo(cid.ID) (ContainerInfo, error)
 }
 
 // PlacementCalculator is a component interface
 // that builds placement vectors.
 type PlacementCalculator interface {
-	// Must return information about the nodes from container cid of the epoch e.
-	ContainerNodes(e uint64, cid *cid.ID) ([]NodeInfo, error)
+	// Must return information about the nodes from container by its ID of the given epoch.
+	ContainerNodes(uint64, cid.ID) ([]NodeInfo, error)
 }
 
 // AccountStorage is an network member accounts interface.
@@ -50,5 +50,5 @@ type Exchanger interface {
 	// Must transfer amount of GASe-12 from sender to recipient.
 	//
 	// Amount must be positive.
-	Transfer(sender, recipient *user.ID, amount *big.Int, details []byte)
+	Transfer(sender, recipient user.ID, amount *big.Int, details []byte)
 }

--- a/pkg/innerring/processors/settlement/common/util.go
+++ b/pkg/innerring/processors/settlement/common/util.go
@@ -11,7 +11,7 @@ type TransferTable struct {
 }
 
 type TransferTx struct {
-	From, To *user.ID
+	From, To user.ID
 
 	Amount *big.Int
 }
@@ -23,11 +23,11 @@ func NewTransferTable() *TransferTable {
 }
 
 func (t *TransferTable) Transfer(tx *TransferTx) {
-	if tx.From.Equals(*tx.To) {
+	if tx.From.Equals(tx.To) {
 		return
 	}
 
-	from, to := tx.From.String(), tx.To.String()
+	from, to := tx.From.EncodeToString(), tx.To.EncodeToString()
 
 	m, ok := t.txs[from]
 	if !ok {

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -3,7 +3,6 @@ package innerring
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
 	"time"
 
@@ -16,8 +15,7 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"go.uber.org/zap"
 )
@@ -63,19 +61,16 @@ func (c *ClientCache) Get(info clientcore.NodeInfo) (clientcore.Client, error) {
 // Returns storage groups structure from received object.
 //
 // Returns an error of type apistatus.ObjectNotFound if storage group is missing.
-func (c *ClientCache) GetSG(task *audit.Task, id *oidSDK.ID) (*storagegroup.StorageGroup, error) {
-	sgAddress := new(addressSDK.Address)
-	sgAddress.SetContainerID(*task.ContainerID())
-	sgAddress.SetObjectID(*id)
+func (c *ClientCache) GetSG(task *audit.Task, id oid.ID) (*storagegroup.StorageGroup, error) {
+	var sgAddress oid.Address
+	sgAddress.SetContainer(task.ContainerID())
+	sgAddress.SetObject(id)
 
 	return c.getSG(task.AuditContext(), sgAddress, task.NetworkMap(), task.ContainerNodes())
 }
 
-func (c *ClientCache) getSG(ctx context.Context, addr *addressSDK.Address, nm *netmap.Netmap, cn netmap.ContainerNodes) (*storagegroup.StorageGroup, error) {
-	obj, ok := addr.ObjectID()
-	if !ok {
-		return nil, errors.New("missing object ID in object address")
-	}
+func (c *ClientCache) getSG(ctx context.Context, addr oid.Address, nm *netmap.Netmap, cn netmap.ContainerNodes) (*storagegroup.StorageGroup, error) {
+	obj := addr.Object()
 
 	nodes, err := placement.BuildObjectPlacement(nm, cn, &obj)
 	if err != nil {
@@ -129,10 +124,10 @@ func (c *ClientCache) getSG(ctx context.Context, addr *addressSDK.Address, nm *n
 }
 
 // GetHeader requests node from the container under audit to return object header by id.
-func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *oidSDK.ID, relay bool) (*object.Object, error) {
-	objAddress := new(addressSDK.Address)
-	objAddress.SetContainerID(*task.ContainerID())
-	objAddress.SetObjectID(*id)
+func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id oid.ID, relay bool) (*object.Object, error) {
+	var objAddress oid.Address
+	objAddress.SetContainer(task.ContainerID())
+	objAddress.SetObject(id)
 
 	var info clientcore.NodeInfo
 
@@ -167,10 +162,10 @@ func (c *ClientCache) GetHeader(task *audit.Task, node *netmap.Node, id *oidSDK.
 
 // GetRangeHash requests node from the container under audit to return Tillich-Zemor hash of the
 // payload range of the object with specified identifier.
-func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id *oidSDK.ID, rng *object.Range) ([]byte, error) {
-	objAddress := new(addressSDK.Address)
-	objAddress.SetContainerID(*task.ContainerID())
-	objAddress.SetObjectID(*id)
+func (c *ClientCache) GetRangeHash(task *audit.Task, node *netmap.Node, id oid.ID, rng *object.Range) ([]byte, error) {
+	var objAddress oid.Address
+	objAddress.SetContainer(task.ContainerID())
+	objAddress.SetObject(id)
 
 	var info clientcore.NodeInfo
 

--- a/pkg/local_object_storage/blobovnicza/delete.go
+++ b/pkg/local_object_storage/blobovnicza/delete.go
@@ -2,14 +2,14 @@ package blobovnicza
 
 import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // DeleteRes groups the resulting values of Delete operation.
@@ -17,7 +17,7 @@ type DeleteRes struct {
 }
 
 // SetAddress sets the address of the requested object.
-func (p *DeletePrm) SetAddress(addr *addressSDK.Address) {
+func (p *DeletePrm) SetAddress(addr oid.Address) {
 	p.addr = addr
 }
 

--- a/pkg/local_object_storage/blobovnicza/get.go
+++ b/pkg/local_object_storage/blobovnicza/get.go
@@ -3,14 +3,14 @@ package blobovnicza
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // GetRes groups the resulting values of Get operation.
@@ -19,7 +19,7 @@ type GetRes struct {
 }
 
 // SetAddress sets the address of the requested object.
-func (p *GetPrm) SetAddress(addr *addressSDK.Address) {
+func (p *GetPrm) SetAddress(addr oid.Address) {
 	p.addr = addr
 }
 

--- a/pkg/local_object_storage/blobovnicza/iterate.go
+++ b/pkg/local_object_storage/blobovnicza/iterate.go
@@ -3,7 +3,7 @@ package blobovnicza
 import (
 	"fmt"
 
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
@@ -57,7 +57,7 @@ func max(a, b uint64) uint64 {
 
 // IterationElement represents a unit of elements through which Iterate operation passes.
 type IterationElement struct {
-	addr *addressSDK.Address
+	addr oid.Address
 
 	data []byte
 }
@@ -68,7 +68,7 @@ func (x IterationElement) ObjectData() []byte {
 }
 
 // Address returns address of the stored object.
-func (x IterationElement) Address() *addressSDK.Address {
+func (x IterationElement) Address() oid.Address {
 	return x.addr
 }
 
@@ -124,11 +124,7 @@ func (b *Blobovnicza) Iterate(prm IteratePrm) (*IterateRes, error) {
 		return tx.ForEach(func(name []byte, buck *bbolt.Bucket) error {
 			return buck.ForEach(func(k, v []byte) error {
 				if prm.decodeAddresses {
-					if elem.addr == nil {
-						elem.addr = addressSDK.NewAddress()
-					}
-
-					if err := addressFromKey(elem.addr, k); err != nil {
+					if err := addressFromKey(&elem.addr, k); err != nil {
 						if prm.ignoreErrors {
 							return nil
 						}
@@ -164,7 +160,7 @@ func IterateObjects(blz *Blobovnicza, f func([]byte) error) error {
 }
 
 // IterateAddresses is a helper function which iterates over Blobovnicza and passes addresses of the objects to f.
-func IterateAddresses(blz *Blobovnicza, f func(*addressSDK.Address) error) error {
+func IterateAddresses(blz *Blobovnicza, f func(oid.Address) error) error {
 	var prm IteratePrm
 
 	prm.DecodeAddresses()

--- a/pkg/local_object_storage/blobovnicza/iterate_test.go
+++ b/pkg/local_object_storage/blobovnicza/iterate_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
@@ -18,7 +18,7 @@ func TestBlobovniczaIterate(t *testing.T) {
 	require.NoError(t, b.Init())
 
 	data := [][]byte{{0, 1, 2, 3}, {5, 6, 7, 8}}
-	addr := objecttest.Address()
+	addr := oidtest.Address()
 	_, err := b.Put(&PutPrm{addr: addr, objData: data[0]})
 	require.NoError(t, err)
 

--- a/pkg/local_object_storage/blobstor/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza_test.go
@@ -10,7 +10,7 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +63,7 @@ func TestBlobovniczas(t *testing.T) {
 
 	objSz := uint64(szLim / 2)
 
-	addrList := make([]*addressSDK.Address, 0)
+	addrList := make([]oid.Address, 0)
 	minFitObjNum := width * depth * szLim / objSz
 
 	for i := uint64(0); i < minFitObjNum; i++ {

--- a/pkg/local_object_storage/blobstor/exists.go
+++ b/pkg/local_object_storage/blobstor/exists.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -64,7 +64,7 @@ func (b *BlobStor) Exists(prm *ExistsPrm) (*ExistsRes, error) {
 }
 
 // checks if object is presented in shallow dir.
-func (b *BlobStor) existsBig(addr *addressSDK.Address) (bool, error) {
+func (b *BlobStor) existsBig(addr oid.Address) (bool, error) {
 	_, err := b.fsTree.Exists(addr)
 	if errors.Is(err, fstree.ErrFileNotFound) {
 		return false, nil
@@ -74,18 +74,18 @@ func (b *BlobStor) existsBig(addr *addressSDK.Address) (bool, error) {
 }
 
 // existsSmall checks if object is presented in blobovnicza.
-func (b *BlobStor) existsSmall(addr *addressSDK.Address) (bool, error) {
+func (b *BlobStor) existsSmall(addr oid.Address) (bool, error) {
 	return b.blobovniczas.existsSmall(addr)
 }
 
-func (b *blobovniczas) existsSmall(addr *addressSDK.Address) (bool, error) {
+func (b *blobovniczas) existsSmall(addr oid.Address) (bool, error) {
 	activeCache := make(map[string]struct{})
 
 	prm := new(blobovnicza.GetPrm)
 	prm.SetAddress(addr)
 
 	var found bool
-	err := b.iterateSortedLeaves(addr, func(p string) (bool, error) {
+	err := b.iterateSortedLeaves(&addr, func(p string) (bool, error) {
 		dirPath := filepath.Dir(p)
 
 		_, ok := activeCache[dirPath]

--- a/pkg/local_object_storage/blobstor/exists_test.go
+++ b/pkg/local_object_storage/blobstor/exists_test.go
@@ -7,7 +7,7 @@ import (
 
 	objectCore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +45,7 @@ func TestExists(t *testing.T) {
 		require.True(t, res.Exists())
 	}
 
-	prm.SetAddress(objecttest.Address())
+	prm.SetAddress(oidtest.Address())
 	res, err := b.Exists(prm)
 	require.NoError(t, err)
 	require.False(t, res.Exists())

--- a/pkg/local_object_storage/blobstor/iterate.go
+++ b/pkg/local_object_storage/blobstor/iterate.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // IterationElement represents a unit of elements through which Iterate operation passes.
@@ -88,7 +88,7 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 
 	elem.blzID = nil
 
-	err = b.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(_ *addressSDK.Address, data []byte) error {
+	err = b.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(_ oid.Address, data []byte) error {
 		// decompress the data
 		elem.data, err = b.decompressor(data)
 		if err != nil {

--- a/pkg/local_object_storage/blobstor/put.go
+++ b/pkg/local_object_storage/blobstor/put.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // PutPrm groups the parameters of Put operation.
@@ -72,7 +72,7 @@ func (b *BlobStor) NeedsCompression(obj *objectSDK.Object) bool {
 }
 
 // PutRaw saves an already marshaled object in BLOB storage.
-func (b *BlobStor) PutRaw(addr *addressSDK.Address, data []byte, compress bool) (*PutRes, error) {
+func (b *BlobStor) PutRaw(addr oid.Address, data []byte, compress bool) (*PutRes, error) {
 	big := b.isBig(data)
 
 	if big {

--- a/pkg/local_object_storage/blobstor/util.go
+++ b/pkg/local_object_storage/blobstor/util.go
@@ -3,15 +3,15 @@ package blobstor
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type address struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // SetAddress sets the address of the requested object.
-func (a *address) SetAddress(addr *addressSDK.Address) {
+func (a *address) SetAddress(addr oid.Address) {
 	a.addr = addr
 }
 

--- a/pkg/local_object_storage/engine/delete.go
+++ b/pkg/local_object_storage/engine/delete.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr []*addressSDK.Address
+	addr []oid.Address
 }
 
 // DeleteRes groups the resulting values of Delete operation.
@@ -19,7 +19,7 @@ type DeleteRes struct{}
 // WithAddresses is a Delete option to set the addresses of the objects to delete.
 //
 // Option is required.
-func (p *DeletePrm) WithAddresses(addr ...*addressSDK.Address) *DeletePrm {
+func (p *DeletePrm) WithAddresses(addr ...oid.Address) *DeletePrm {
 	if p != nil {
 		p.addr = append(p.addr, addr...)
 	}

--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -14,7 +14,6 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -49,7 +48,7 @@ func benchmarkExists(b *testing.B, shardNum int) {
 		_ = os.RemoveAll(b.Name())
 	})
 
-	addr := objecttest.Address()
+	addr := oidtest.Address()
 	for i := 0; i < 100; i++ {
 		obj := generateObjectWithCID(b, cidtest.ID())
 		err := Put(e, obj)

--- a/pkg/local_object_storage/engine/exists.go
+++ b/pkg/local_object_storage/engine/exists.go
@@ -3,10 +3,10 @@ package engine
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
-func (e *StorageEngine) exists(addr *addressSDK.Address) (bool, error) {
+func (e *StorageEngine) exists(addr oid.Address) (bool, error) {
 	shPrm := new(shard.ExistsPrm).WithAddress(addr)
 	alreadyRemoved := false
 	exists := false

--- a/pkg/local_object_storage/engine/get.go
+++ b/pkg/local_object_storage/engine/get.go
@@ -7,13 +7,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // GetRes groups the resulting values of Get operation.
@@ -24,7 +24,7 @@ type GetRes struct {
 // WithAddress is a Get option to set the address of the requested object.
 //
 // Option is required.
-func (p *GetPrm) WithAddress(addr *addressSDK.Address) *GetPrm {
+func (p *GetPrm) WithAddress(addr oid.Address) *GetPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -151,7 +151,7 @@ func (e *StorageEngine) get(prm *GetPrm) (*GetRes, error) {
 }
 
 // Get reads object from local storage by provided address.
-func Get(storage *StorageEngine, addr *addressSDK.Address) (*objectSDK.Object, error) {
+func Get(storage *StorageEngine, addr oid.Address) (*objectSDK.Object, error) {
 	res, err := storage.Get(new(GetPrm).
 		WithAddress(addr),
 	)

--- a/pkg/local_object_storage/engine/head.go
+++ b/pkg/local_object_storage/engine/head.go
@@ -7,12 +7,12 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // HeadPrm groups the parameters of Head operation.
 type HeadPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 	raw  bool
 }
 
@@ -24,7 +24,7 @@ type HeadRes struct {
 // WithAddress is a Head option to set the address of the requested object.
 //
 // Option is required.
-func (p *HeadPrm) WithAddress(addr *addressSDK.Address) *HeadPrm {
+func (p *HeadPrm) WithAddress(addr oid.Address) *HeadPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -140,7 +140,7 @@ func (e *StorageEngine) head(prm *HeadPrm) (*HeadRes, error) {
 }
 
 // Head reads object header from local storage by provided address.
-func Head(storage *StorageEngine, addr *addressSDK.Address) (*objectSDK.Object, error) {
+func Head(storage *StorageEngine, addr oid.Address) (*objectSDK.Object, error) {
 	res, err := storage.Head(new(HeadPrm).
 		WithAddress(addr),
 	)
@@ -153,7 +153,7 @@ func Head(storage *StorageEngine, addr *addressSDK.Address) (*objectSDK.Object, 
 
 // HeadRaw reads object header from local storage by provided address and raw
 // flag.
-func HeadRaw(storage *StorageEngine, addr *addressSDK.Address, raw bool) (*objectSDK.Object, error) {
+func HeadRaw(storage *StorageEngine, addr oid.Address, raw bool) (*objectSDK.Object, error) {
 	res, err := storage.Head(new(HeadPrm).
 		WithAddress(addr).
 		WithRaw(raw),

--- a/pkg/local_object_storage/engine/head_test.go
+++ b/pkg/local_object_storage/engine/head_test.go
@@ -7,31 +7,31 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHeadRaw(t *testing.T) {
 	defer os.RemoveAll(t.Name())
 
-	cid := cidtest.ID()
+	cnr := cidtest.ID()
 	splitID := object.NewSplitID()
 
-	parent := generateObjectWithCID(t, cid)
+	parent := generateObjectWithCID(t, cnr)
 	addAttribute(parent, "foo", "bar")
 
-	parentAddr := addressSDK.NewAddress()
-	parentAddr.SetContainerID(cid)
+	var parentAddr oid.Address
+	parentAddr.SetContainer(cnr)
 
 	idParent, _ := parent.ID()
-	parentAddr.SetObjectID(idParent)
+	parentAddr.SetObject(idParent)
 
-	child := generateObjectWithCID(t, cid)
+	child := generateObjectWithCID(t, cnr)
 	child.SetParent(parent)
 	child.SetParentID(idParent)
 	child.SetSplitID(splitID)
 
-	link := generateObjectWithCID(t, cid)
+	link := generateObjectWithCID(t, cnr)
 	link.SetParent(parent)
 	link.SetParentID(idParent)
 

--- a/pkg/local_object_storage/engine/inhume_test.go
+++ b/pkg/local_object_storage/engine/inhume_test.go
@@ -47,7 +47,7 @@ func TestStorageEngine_Inhume(t *testing.T) {
 		_, err = e.Inhume(inhumePrm)
 		require.NoError(t, err)
 
-		addrs, err := Select(e, &cnr, fs)
+		addrs, err := Select(e, cnr, fs)
 		require.NoError(t, err)
 		require.Empty(t, addrs)
 	})
@@ -71,7 +71,7 @@ func TestStorageEngine_Inhume(t *testing.T) {
 		_, err = e.Inhume(inhumePrm)
 		require.NoError(t, err)
 
-		addrs, err := Select(e, &cnr, fs)
+		addrs, err := Select(e, cnr, fs)
 		require.NoError(t, err)
 		require.Empty(t, addrs)
 	})

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // ErrEndOfListing is returned from an object listing with cursor
@@ -40,12 +40,12 @@ func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 
 // ListWithCursorRes contains values returned from ListWithCursor operation.
 type ListWithCursorRes struct {
-	addrList []*addressSDK.Address
+	addrList []oid.Address
 	cursor   *Cursor
 }
 
 // AddressList returns addresses selected by ListWithCursor operation.
-func (l ListWithCursorRes) AddressList() []*addressSDK.Address {
+func (l ListWithCursorRes) AddressList() []oid.Address {
 	return l.addrList
 }
 
@@ -62,7 +62,7 @@ func (l ListWithCursorRes) Cursor() *Cursor {
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
 func (e *StorageEngine) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, error) {
-	result := make([]*addressSDK.Address, 0, prm.count)
+	result := make([]oid.Address, 0, prm.count)
 
 	// 1. Get available shards and sort them.
 	e.mtx.RLock()

--- a/pkg/local_object_storage/engine/list_test.go
+++ b/pkg/local_object_storage/engine/list_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,8 +24,8 @@ func TestListWithCursor(t *testing.T) {
 
 	const total = 20
 
-	expected := make([]*addressSDK.Address, 0, total)
-	got := make([]*addressSDK.Address, 0, total)
+	expected := make([]oid.Address, 0, total)
+	got := make([]oid.Address, 0, total)
 
 	for i := 0; i < total; i++ {
 		containerID := cidtest.ID()
@@ -59,9 +59,9 @@ func TestListWithCursor(t *testing.T) {
 	require.Equal(t, expected, got)
 }
 
-func sortAddresses(addr []*addressSDK.Address) []*addressSDK.Address {
+func sortAddresses(addr []oid.Address) []oid.Address {
 	sort.Slice(addr, func(i, j int) bool {
-		return addr[i].String() < addr[j].String()
+		return addr[i].EncodeToString() < addr[j].EncodeToString()
 	})
 	return addr
 }

--- a/pkg/local_object_storage/engine/lock_test.go
+++ b/pkg/local_object_storage/engine/lock_test.go
@@ -13,8 +13,6 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/panjf2000/ants/v2"
@@ -61,26 +59,26 @@ func TestLockUserScenario(t *testing.T) {
 	cnr := cidtest.ID()
 	var err error
 
-	var objAddr address.Address
-	objAddr.SetContainerID(cnr)
+	var objAddr oid.Address
+	objAddr.SetContainer(cnr)
 
-	var tombAddr address.Address
-	tombAddr.SetContainerID(cnr)
-	tombAddr.SetObjectID(tombID)
+	var tombAddr oid.Address
+	tombAddr.SetContainer(cnr)
+	tombAddr.SetObject(tombID)
 
-	var lockerAddr address.Address
-	lockerAddr.SetContainerID(cnr)
-	lockerAddr.SetObjectID(lockerID)
+	var lockerAddr oid.Address
+	lockerAddr.SetContainer(cnr)
+	lockerAddr.SetObject(lockerID)
 
-	var tombForLockAddr address.Address
-	tombForLockAddr.SetContainerID(cnr)
-	tombForLockAddr.SetObjectID(tombForLockID)
+	var tombForLockAddr oid.Address
+	tombForLockAddr.SetContainer(cnr)
+	tombForLockAddr.SetObject(tombForLockID)
 
 	// 1.
 	obj := generateObjectWithCID(t, cnr)
 
 	id, _ := obj.ID()
-	objAddr.SetObjectID(id)
+	objAddr.SetObject(id)
 
 	err = Put(e, obj)
 	require.NoError(t, err)
@@ -90,7 +88,7 @@ func TestLockUserScenario(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3.
-	_, err = e.Inhume(new(InhumePrm).WithTarget(&tombAddr, &objAddr))
+	_, err = e.Inhume(new(InhumePrm).WithTarget(tombAddr, objAddr))
 	require.ErrorAs(t, err, new(apistatus.ObjectLocked))
 
 	// 4.
@@ -106,7 +104,7 @@ func TestLockUserScenario(t *testing.T) {
 	err = Put(e, tombObj)
 	require.NoError(t, err)
 
-	_, err = e.Inhume(new(InhumePrm).WithTarget(&tombForLockAddr, &lockerAddr))
+	_, err = e.Inhume(new(InhumePrm).WithTarget(tombForLockAddr, lockerAddr))
 	require.NoError(t, err, new(apistatus.ObjectLocked))
 
 	// 5.
@@ -117,7 +115,7 @@ func TestLockUserScenario(t *testing.T) {
 	// delay for GC
 	time.Sleep(time.Second)
 
-	_, err = e.Inhume(new(InhumePrm).WithTarget(&tombAddr, &objAddr))
+	_, err = e.Inhume(new(InhumePrm).WithTarget(tombAddr, objAddr))
 	require.NoError(t, err)
 }
 
@@ -179,7 +177,7 @@ func TestLockExpiration(t *testing.T) {
 	err = e.Lock(cnr, idLock, []oid.ID{id})
 	require.NoError(t, err)
 
-	_, err = e.Inhume(new(InhumePrm).WithTarget(objecttest.Address(), objectcore.AddressOf(obj)))
+	_, err = e.Inhume(new(InhumePrm).WithTarget(oidtest.Address(), objectcore.AddressOf(obj)))
 	require.ErrorAs(t, err, new(apistatus.ObjectLocked))
 
 	// 3.
@@ -192,6 +190,6 @@ func TestLockExpiration(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// 4.
-	_, err = e.Inhume(new(InhumePrm).WithTarget(objecttest.Address(), objectcore.AddressOf(obj)))
+	_, err = e.Inhume(new(InhumePrm).WithTarget(oidtest.Address(), objectcore.AddressOf(obj)))
 	require.NoError(t, err)
 }

--- a/pkg/local_object_storage/engine/range.go
+++ b/pkg/local_object_storage/engine/range.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -16,7 +16,7 @@ import (
 type RngPrm struct {
 	off, ln uint64
 
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // RngRes groups the resulting values of GetRange operation.
@@ -27,7 +27,7 @@ type RngRes struct {
 // WithAddress is a GetRng option to set the address of the requested object.
 //
 // Option is required.
-func (p *RngPrm) WithAddress(addr *addressSDK.Address) *RngPrm {
+func (p *RngPrm) WithAddress(addr oid.Address) *RngPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -167,7 +167,9 @@ func (e *StorageEngine) getRange(prm *RngPrm) (*RngRes, error) {
 			return nil, outError
 		}
 		e.reportShardError(shardWithMeta, "meta info was present, but object is missing",
-			metaError, zap.Stringer("address", prm.addr))
+			metaError,
+			zap.Stringer("address", prm.addr),
+		)
 	}
 
 	return &RngRes{
@@ -176,7 +178,7 @@ func (e *StorageEngine) getRange(prm *RngPrm) (*RngRes, error) {
 }
 
 // GetRange reads object payload range from local storage by provided address.
-func GetRange(storage *StorageEngine, addr *addressSDK.Address, rng *objectSDK.Range) ([]byte, error) {
+func GetRange(storage *StorageEngine, addr oid.Address, rng *objectSDK.Range) ([]byte, error) {
 	res, err := storage.GetRange(new(RngPrm).
 		WithAddress(addr).
 		WithPayloadRange(rng),

--- a/pkg/local_object_storage/metabase/control_test.go
+++ b/pkg/local_object_storage/metabase/control_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,9 +19,9 @@ func TestReset(t *testing.T) {
 	obj := generateObject(t)
 	addr := object.AddressOf(obj)
 
-	addrToInhume := objecttest.Address()
+	addrToInhume := oidtest.Address()
 
-	assertExists := func(addr *addressSDK.Address, expExists bool, assertErr func(error) bool) {
+	assertExists := func(addr oid.Address, expExists bool, assertErr func(error) bool) {
 		exists, err := meta.Exists(db, addr)
 		if assertErr != nil {
 			require.True(t, assertErr(err))
@@ -37,7 +37,7 @@ func TestReset(t *testing.T) {
 	err = putBig(db, obj)
 	require.NoError(t, err)
 
-	err = meta.Inhume(db, addrToInhume, objecttest.Address())
+	err = meta.Inhume(db, addrToInhume, oidtest.Address())
 	require.NoError(t, err)
 
 	assertExists(addr, true, nil)

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -10,7 +10,7 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -23,8 +23,8 @@ func putBig(db *meta.DB, obj *object.Object) error {
 	return meta.Put(db, obj, nil)
 }
 
-func testSelect(t *testing.T, db *meta.DB, cnr cid.ID, fs object.SearchFilters, exp ...*addressSDK.Address) {
-	res, err := meta.Select(db, &cnr, fs)
+func testSelect(t *testing.T, db *meta.DB, cnr cid.ID, fs object.SearchFilters, exp ...oid.Address) {
+	res, err := meta.Select(db, cnr, fs)
 	require.NoError(t, err)
 	require.Len(t, res, len(exp))
 

--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -9,18 +9,18 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDB_Delete(t *testing.T) {
 	db := newDB(t)
 
-	cid := cidtest.ID()
-	parent := generateObjectWithCID(t, cid)
+	cnr := cidtest.ID()
+	parent := generateObjectWithCID(t, cnr)
 	addAttribute(parent, "foo", "bar")
 
-	child := generateObjectWithCID(t, cid)
+	child := generateObjectWithCID(t, cnr)
 	child.SetParent(parent)
 	idParent, _ := parent.ID()
 	child.SetParentID(idParent)
@@ -43,7 +43,7 @@ func TestDB_Delete(t *testing.T) {
 	require.Error(t, err)
 
 	// inhume parent and child so they will be on graveyard
-	ts := generateObjectWithCID(t, cid)
+	ts := generateObjectWithCID(t, cnr)
 
 	err = meta.Inhume(db, object.AddressOf(child), object.AddressOf(ts))
 	require.NoError(t, err)
@@ -71,18 +71,18 @@ func TestDB_Delete(t *testing.T) {
 func TestDeleteAllChildren(t *testing.T) {
 	db := newDB(t)
 
-	cid := cidtest.ID()
+	cnr := cidtest.ID()
 
 	// generate parent object
-	parent := generateObjectWithCID(t, cid)
+	parent := generateObjectWithCID(t, cnr)
 
 	// generate 2 children
-	child1 := generateObjectWithCID(t, cid)
+	child1 := generateObjectWithCID(t, cnr)
 	child1.SetParent(parent)
 	idParent, _ := parent.ID()
 	child1.SetParentID(idParent)
 
-	child2 := generateObjectWithCID(t, cid)
+	child2 := generateObjectWithCID(t, cnr)
 	child2.SetParent(parent)
 	child2.SetParentID(idParent)
 
@@ -108,10 +108,10 @@ func TestDeleteAllChildren(t *testing.T) {
 func TestGraveOnlyDelete(t *testing.T) {
 	db := newDB(t)
 
-	addr := objecttest.Address()
+	addr := oidtest.Address()
 
 	// inhume non-existent object by address
-	require.NoError(t, meta.Inhume(db, addr, nil))
+	require.NoError(t, meta.Inhume(db, addr, oidtest.Address()))
 
 	// delete the object data
 	require.NoError(t, meta.Delete(db, addr))

--- a/pkg/local_object_storage/metabase/exists_test.go
+++ b/pkg/local_object_storage/metabase/exists_test.go
@@ -68,10 +68,10 @@ func TestDB_Exists(t *testing.T) {
 	})
 
 	t.Run("virtual object", func(t *testing.T) {
-		cid := cidtest.ID()
-		parent := generateObjectWithCID(t, cid)
+		cnr := cidtest.ID()
+		parent := generateObjectWithCID(t, cnr)
 
-		child := generateObjectWithCID(t, cid)
+		child := generateObjectWithCID(t, cnr)
 		child.SetParent(parent)
 		idParent, _ := parent.ID()
 		child.SetParentID(idParent)
@@ -86,19 +86,19 @@ func TestDB_Exists(t *testing.T) {
 	})
 
 	t.Run("merge split info", func(t *testing.T) {
-		cid := cidtest.ID()
+		cnr := cidtest.ID()
 		splitID := objectSDK.NewSplitID()
 
-		parent := generateObjectWithCID(t, cid)
+		parent := generateObjectWithCID(t, cnr)
 		addAttribute(parent, "foo", "bar")
 
-		child := generateObjectWithCID(t, cid)
+		child := generateObjectWithCID(t, cnr)
 		child.SetParent(parent)
 		idParent, _ := parent.ID()
 		child.SetParentID(idParent)
 		child.SetSplitID(splitID)
 
-		link := generateObjectWithCID(t, cid)
+		link := generateObjectWithCID(t, cnr)
 		link.SetParent(parent)
 		link.SetParentID(idParent)
 		idChild, _ := child.ID()

--- a/pkg/local_object_storage/metabase/get_test.go
+++ b/pkg/local_object_storage/metabase/get_test.go
@@ -9,7 +9,6 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
@@ -74,13 +73,13 @@ func TestDB_Get(t *testing.T) {
 	})
 
 	t.Run("put virtual object", func(t *testing.T) {
-		cid := cidtest.ID()
+		cnr := cidtest.ID()
 		splitID := objectSDK.NewSplitID()
 
-		parent := generateObjectWithCID(t, cid)
+		parent := generateObjectWithCID(t, cnr)
 		addAttribute(parent, "foo", "bar")
 
-		child := generateObjectWithCID(t, cid)
+		child := generateObjectWithCID(t, cnr)
 		child.SetParent(parent)
 		idParent, _ := parent.ID()
 		child.SetParentID(idParent)
@@ -116,15 +115,16 @@ func TestDB_Get(t *testing.T) {
 	})
 
 	t.Run("get removed object", func(t *testing.T) {
-		obj := objecttest.Address()
-		ts := objecttest.Address()
+		obj := oidtest.Address()
+		ts := oidtest.Address()
 
 		require.NoError(t, meta.Inhume(db, obj, ts))
 		_, err := meta.Get(db, obj)
 		require.ErrorAs(t, err, new(apistatus.ObjectAlreadyRemoved))
 
-		obj = objecttest.Address()
-		require.NoError(t, meta.Inhume(db, obj, nil))
+		obj = oidtest.Address()
+		_, err = db.Inhume(new(meta.InhumePrm).WithAddresses(obj))
+		require.NoError(t, err)
 		_, err = meta.Get(db, obj)
 		require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
 	})

--- a/pkg/local_object_storage/metabase/inhume_test.go
+++ b/pkg/local_object_storage/metabase/inhume_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
@@ -18,7 +17,7 @@ func TestDB_Inhume(t *testing.T) {
 	raw := generateObject(t)
 	addAttribute(raw, "foo", "bar")
 
-	tombstoneID := objecttest.Address()
+	tombstoneID := oidtest.Address()
 
 	err := putBig(db, raw)
 	require.NoError(t, err)
@@ -39,9 +38,9 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	var (
 		err error
 
-		addr1     = objecttest.Address()
-		addr2     = objecttest.Address()
-		addr3     = objecttest.Address()
+		addr1     = oidtest.Address()
+		addr2     = oidtest.Address()
+		addr3     = oidtest.Address()
 		inhumePrm = new(meta.InhumePrm)
 		existsPrm = new(meta.ExistsPrm)
 	)
@@ -78,7 +77,7 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	// try to inhume addr1 (which is already a tombstone in graveyard)
 	_, err = db.Inhume(inhumePrm.
 		WithAddresses(addr1).
-		WithTombstoneAddress(objecttest.Address()),
+		WithTombstoneAddress(oidtest.Address()),
 	)
 	require.NoError(t, err)
 
@@ -92,15 +91,13 @@ func TestInhumeTombOnTomb(t *testing.T) {
 func TestInhumeLocked(t *testing.T) {
 	db := newDB(t)
 
-	locked := *objecttest.Address()
-	cnr, _ := locked.ContainerID()
-	id, _ := locked.ObjectID()
+	locked := oidtest.Address()
 
-	err := db.Lock(cnr, oidtest.ID(), []oid.ID{id})
+	err := db.Lock(locked.Container(), oidtest.ID(), []oid.ID{locked.Object()})
 	require.NoError(t, err)
 
 	var prm meta.InhumePrm
-	prm.WithAddresses(&locked)
+	prm.WithAddresses(locked)
 
 	_, err = db.Inhume(&prm)
 

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -9,7 +9,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +21,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 		total      = containers * 5 // regular + ts + sg + child + lock
 	)
 
-	expected := make([]*addressSDK.Address, 0, total)
+	expected := make([]oid.Address, 0, total)
 
 	// fill metabase with objects
 	for i := 0; i < containers; i++ {
@@ -82,7 +82,7 @@ func TestLisObjectsWithCursor(t *testing.T) {
 
 	t.Run("success with various count", func(t *testing.T) {
 		for countPerReq := 1; countPerReq <= total; countPerReq++ {
-			got := make([]*addressSDK.Address, 0, total)
+			got := make([]oid.Address, 0, total)
 
 			res, cursor, err := meta.ListWithCursor(db, uint32(countPerReq), nil)
 			require.NoError(t, err, "count:%d", countPerReq)
@@ -125,15 +125,15 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 		obj := generateObject(t)
 		err := putBig(db, obj)
 		require.NoError(t, err)
-		expected[object.AddressOf(obj).String()] = 0
+		expected[object.AddressOf(obj).EncodeToString()] = 0
 	}
 
 	// get half of the objects
 	got, cursor, err := meta.ListWithCursor(db, total/2, nil)
 	require.NoError(t, err)
 	for _, obj := range got {
-		if _, ok := expected[obj.String()]; ok {
-			expected[obj.String()]++
+		if _, ok := expected[obj.EncodeToString()]; ok {
+			expected[obj.EncodeToString()]++
 		}
 	}
 
@@ -151,8 +151,8 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 			break
 		}
 		for _, obj := range got {
-			if _, ok := expected[obj.String()]; ok {
-				expected[obj.String()]++
+			if _, ok := expected[obj.EncodeToString()]; ok {
+				expected[obj.EncodeToString()]++
 			}
 		}
 	}
@@ -164,9 +164,9 @@ func TestAddObjectDuringListingWithCursor(t *testing.T) {
 
 }
 
-func sortAddresses(addr []*addressSDK.Address) []*addressSDK.Address {
+func sortAddresses(addr []oid.Address) []oid.Address {
 	sort.Slice(addr, func(i, j int) bool {
-		return addr[i].String() < addr[j].String()
+		return addr[i].EncodeToString() < addr[j].EncodeToString()
 	})
 	return addr
 }

--- a/pkg/local_object_storage/metabase/lock_test.go
+++ b/pkg/local_object_storage/metabase/lock_test.go
@@ -8,7 +8,6 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	"github.com/nspcc-dev/neofs-sdk-go/object/address"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
@@ -71,20 +70,20 @@ func TestDB_Lock(t *testing.T) {
 		err = db.Lock(cnr, tombID, []oid.ID{id})
 		require.NoError(t, err)
 
-		var tombAddr address.Address
-		tombAddr.SetContainerID(cnr)
-		tombAddr.SetObjectID(tombID)
+		var tombAddr oid.Address
+		tombAddr.SetContainer(cnr)
+		tombAddr.SetObject(tombID)
 
 		// try to inhume locked object using tombstone
-		err = meta.Inhume(db, objectcore.AddressOf(obj), &tombAddr)
+		err = meta.Inhume(db, objectcore.AddressOf(obj), tombAddr)
 		require.ErrorAs(t, err, new(apistatus.ObjectLocked))
 
 		// inhume the tombstone
-		_, err = db.Inhume(new(meta.InhumePrm).WithAddresses(&tombAddr).WithGCMark())
+		_, err = db.Inhume(new(meta.InhumePrm).WithAddresses(tombAddr).WithGCMark())
 		require.NoError(t, err)
 
 		// now we can inhume the object
-		err = meta.Inhume(db, objectcore.AddressOf(obj), &tombAddr)
+		err = meta.Inhume(db, objectcore.AddressOf(obj), tombAddr)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/local_object_storage/metabase/movable.go
+++ b/pkg/local_object_storage/metabase/movable.go
@@ -3,20 +3,20 @@ package meta
 import (
 	"fmt"
 
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
 // ToMoveItPrm groups the parameters of ToMoveIt operation.
 type ToMoveItPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // ToMoveItRes groups the resulting values of ToMoveIt operation.
 type ToMoveItRes struct{}
 
 // WithAddress sets address of the object to move into another shard.
-func (p *ToMoveItPrm) WithAddress(addr *addressSDK.Address) *ToMoveItPrm {
+func (p *ToMoveItPrm) WithAddress(addr oid.Address) *ToMoveItPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -26,14 +26,14 @@ func (p *ToMoveItPrm) WithAddress(addr *addressSDK.Address) *ToMoveItPrm {
 
 // DoNotMovePrm groups the parameters of DoNotMove operation.
 type DoNotMovePrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // DoNotMoveRes groups the resulting values of DoNotMove operation.
 type DoNotMoveRes struct{}
 
 // WithAddress sets address of the object to prevent moving into another shard.
-func (p *DoNotMovePrm) WithAddress(addr *addressSDK.Address) *DoNotMovePrm {
+func (p *DoNotMovePrm) WithAddress(addr oid.Address) *DoNotMovePrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -46,16 +46,16 @@ type MovablePrm struct{}
 
 // MovableRes groups the resulting values of Movable operation.
 type MovableRes struct {
-	addrList []*addressSDK.Address
+	addrList []oid.Address
 }
 
 // AddressList returns resulting addresses of Movable operation.
-func (p *MovableRes) AddressList() []*addressSDK.Address {
+func (p *MovableRes) AddressList() []oid.Address {
 	return p.addrList
 }
 
 // ToMoveIt marks object to move it into another shard.
-func ToMoveIt(db *DB, addr *addressSDK.Address) error {
+func ToMoveIt(db *DB, addr oid.Address) error {
 	_, err := db.ToMoveIt(new(ToMoveItPrm).WithAddress(addr))
 	return err
 }
@@ -76,7 +76,7 @@ func (db *DB) ToMoveIt(prm *ToMoveItPrm) (res *ToMoveItRes, err error) {
 }
 
 // DoNotMove prevents the object to be moved into another shard.
-func DoNotMove(db *DB, addr *addressSDK.Address) error {
+func DoNotMove(db *DB, addr oid.Address) error {
 	_, err := db.DoNotMove(new(DoNotMovePrm).WithAddress(addr))
 	return err
 }
@@ -96,7 +96,7 @@ func (db *DB) DoNotMove(prm *DoNotMovePrm) (res *DoNotMoveRes, err error) {
 }
 
 // Movable returns all movable objects of DB.
-func Movable(db *DB) ([]*addressSDK.Address, error) {
+func Movable(db *DB) ([]oid.Address, error) {
 	r, err := db.Movable(new(MovablePrm))
 	if err != nil {
 		return nil, err
@@ -128,16 +128,14 @@ func (db *DB) Movable(prm *MovablePrm) (*MovableRes, error) {
 	// we can parse strings to structures in-place, but probably it seems
 	// more efficient to keep bolt db TX code smaller because it might be
 	// bottleneck.
-	addrs := make([]*addressSDK.Address, 0, len(strAddrs))
+	addrs := make([]oid.Address, len(strAddrs))
 
 	for i := range strAddrs {
-		addr, err := addressFromKey([]byte(strAddrs[i]))
+		err = decodeAddressFromKey(&addrs[i], []byte(strAddrs[i]))
 		if err != nil {
 			return nil, fmt.Errorf("can't parse object address %v: %w",
 				strAddrs[i], err)
 		}
-
-		addrs = append(addrs, addr)
 	}
 
 	return &MovableRes{

--- a/pkg/local_object_storage/metabase/put_test.go
+++ b/pkg/local_object_storage/metabase/put_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 func prepareObjects(t testing.TB, n int) []*objectSDK.Object {
-	cid := cidtest.ID()
+	cnr := cidtest.ID()
 	parentID := objecttest.ID()
 	objs := make([]*objectSDK.Object, n)
 	for i := range objs {
-		objs[i] = generateObjectWithCID(t, cid)
+		objs[i] = generateObjectWithCID(t, cnr)
 
 		// FKBT indices.
 		attrs := make([]objectSDK.Attribute, 20)

--- a/pkg/local_object_storage/metabase/small.go
+++ b/pkg/local_object_storage/metabase/small.go
@@ -3,13 +3,13 @@ package meta
 import (
 	"github.com/nspcc-dev/neo-go/pkg/util/slice"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
 // IsSmallPrm groups the parameters of IsSmall operation.
 type IsSmallPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // IsSmallRes groups the resulting values of IsSmall operation.
@@ -18,7 +18,7 @@ type IsSmallRes struct {
 }
 
 // WithAddress is a IsSmall option to set the object address to check.
-func (p *IsSmallPrm) WithAddress(addr *addressSDK.Address) *IsSmallPrm {
+func (p *IsSmallPrm) WithAddress(addr oid.Address) *IsSmallPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -34,7 +34,7 @@ func (r *IsSmallRes) BlobovniczaID() *blobovnicza.ID {
 // IsSmall wraps work with DB.IsSmall method with specified
 // address and other parameters by default. Returns only
 // the blobovnicza identifier.
-func IsSmall(db *DB, addr *addressSDK.Address) (*blobovnicza.ID, error) {
+func IsSmall(db *DB, addr oid.Address) (*blobovnicza.ID, error) {
 	r, err := db.IsSmall(new(IsSmallPrm).WithAddress(addr))
 	if err != nil {
 		return nil, err
@@ -59,17 +59,13 @@ func (db *DB) IsSmall(prm *IsSmallPrm) (res *IsSmallRes, err error) {
 	return
 }
 
-func (db *DB) isSmall(tx *bbolt.Tx, addr *addressSDK.Address) (*blobovnicza.ID, error) {
-	cnr, _ := addr.ContainerID()
-
-	smallBucket := tx.Bucket(smallBucketName(&cnr))
+func (db *DB) isSmall(tx *bbolt.Tx, addr oid.Address) (*blobovnicza.ID, error) {
+	smallBucket := tx.Bucket(smallBucketName(addr.Container()))
 	if smallBucket == nil {
 		return nil, nil
 	}
 
-	id, _ := addr.ObjectID()
-
-	blobovniczaID := smallBucket.Get(objectKey(&id))
+	blobovniczaID := smallBucket.Get(objectKey(addr.Object()))
 	if len(blobovniczaID) == 0 {
 		return nil, nil
 	}

--- a/pkg/local_object_storage/shard/container.go
+++ b/pkg/local_object_storage/shard/container.go
@@ -7,16 +7,16 @@ import (
 )
 
 type ContainerSizePrm struct {
-	cid *cid.ID
+	cnr cid.ID
 }
 
 type ContainerSizeRes struct {
 	size uint64
 }
 
-func (p *ContainerSizePrm) WithContainerID(cid *cid.ID) *ContainerSizePrm {
+func (p *ContainerSizePrm) WithContainerID(cnr cid.ID) *ContainerSizePrm {
 	if p != nil {
-		p.cid = cid
+		p.cnr = cnr
 	}
 
 	return p
@@ -27,7 +27,7 @@ func (r *ContainerSizeRes) Size() uint64 {
 }
 
 func (s *Shard) ContainerSize(prm *ContainerSizePrm) (*ContainerSizeRes, error) {
-	size, err := s.metaBase.ContainerSize(prm.cid)
+	size, err := s.metaBase.ContainerSize(prm.cnr)
 	if err != nil {
 		return nil, fmt.Errorf("could not get container size: %w", err)
 	}
@@ -37,8 +37,8 @@ func (s *Shard) ContainerSize(prm *ContainerSizePrm) (*ContainerSizeRes, error) 
 	}, nil
 }
 
-func ContainerSize(s *Shard, cid *cid.ID) (uint64, error) {
-	res, err := s.ContainerSize(&ContainerSizePrm{cid: cid})
+func ContainerSize(s *Shard, cnr cid.ID) (uint64, error) {
+	res, err := s.ContainerSize(&ContainerSizePrm{cnr: cnr})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Open opens all Shard's components.
@@ -89,14 +89,12 @@ func (s *Shard) refillMetabase() error {
 			}
 
 			tombAddr := object.AddressOf(obj)
-			cnr, _ := tombAddr.ContainerID()
 			memberIDs := tombstone.Members()
-			tombMembers := make([]*addressSDK.Address, 0, len(memberIDs))
+			tombMembers := make([]oid.Address, 0, len(memberIDs))
 
 			for i := range memberIDs {
-				a := addressSDK.NewAddress()
-				a.SetContainerID(cnr)
-				a.SetObjectID(memberIDs[i])
+				a := tombAddr
+				a.SetObject(memberIDs[i])
 
 				tombMembers = append(tombMembers, a)
 			}

--- a/pkg/local_object_storage/shard/control_test.go
+++ b/pkg/local_object_storage/shard/control_test.go
@@ -10,7 +10,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +43,7 @@ func TestRefillMetabase(t *testing.T) {
 
 	type objAddr struct {
 		obj  *objectSDK.Object
-		addr *addressSDK.Address
+		addr oid.Address
 	}
 
 	mObjs := make(map[string]objAddr)
@@ -54,7 +54,7 @@ func TestRefillMetabase(t *testing.T) {
 
 		addr := object.AddressOf(obj)
 
-		mObjs[addr.String()] = objAddr{
+		mObjs[addr.EncodeToString()] = objAddr{
 			obj:  obj,
 			addr: addr,
 		}
@@ -70,14 +70,14 @@ func TestRefillMetabase(t *testing.T) {
 
 	tombObj.SetPayload(tombData)
 
-	tombMembers := make([]*addressSDK.Address, 0, len(tombstone.Members()))
+	tombMembers := make([]oid.Address, 0, len(tombstone.Members()))
 
 	members := tombstone.Members()
 	for i := range tombstone.Members() {
-		a := addressSDK.NewAddress()
-		a.SetObjectID(members[i])
+		var a oid.Address
+		a.SetObject(members[i])
 		cnr, _ := tombObj.ContainerID()
-		a.SetContainerID(cnr)
+		a.SetContainer(cnr)
 
 		tombMembers = append(tombMembers, a)
 	}
@@ -97,7 +97,7 @@ func TestRefillMetabase(t *testing.T) {
 
 	var headPrm HeadPrm
 
-	checkObj := func(addr *addressSDK.Address, expObj *objectSDK.Object) {
+	checkObj := func(addr oid.Address, expObj *objectSDK.Object) {
 		res, err := sh.Head(headPrm.WithAddress(addr))
 
 		if expObj == nil {

--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -5,13 +5,13 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
-	addr []*addressSDK.Address
+	addr []oid.Address
 }
 
 // DeleteRes groups the resulting values of Delete operation.
@@ -20,7 +20,7 @@ type DeleteRes struct{}
 // WithAddresses is a Delete option to set the addresses of the objects to delete.
 //
 // Option is required.
-func (p *DeletePrm) WithAddresses(addr ...*addressSDK.Address) *DeletePrm {
+func (p *DeletePrm) WithAddresses(addr ...oid.Address) *DeletePrm {
 	if p != nil {
 		p.addr = append(p.addr, addr...)
 	}
@@ -39,7 +39,7 @@ func (s *Shard) Delete(prm *DeletePrm) (*DeleteRes, error) {
 	delSmallPrm := new(blobstor.DeleteSmallPrm)
 	delBigPrm := new(blobstor.DeleteBigPrm)
 
-	smalls := make(map[*addressSDK.Address]*blobovnicza.ID, ln)
+	smalls := make(map[oid.Address]*blobovnicza.ID, ln)
 
 	for i := range prm.addr {
 		if s.hasWriteCache() {

--- a/pkg/local_object_storage/shard/dump_test.go
+++ b/pkg/local_object_storage/shard/dump_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +73,7 @@ func testDump(t *testing.T, objCount int, hasWriteCache bool) {
 
 	objects := make([]*objectSDK.Object, objCount)
 	for i := 0; i < objCount; i++ {
-		cid := cidtest.ID()
+		cnr := cidtest.ID()
 		var size int
 		switch i % 6 {
 		case 0, 1:
@@ -87,7 +87,7 @@ func testDump(t *testing.T, objCount int, hasWriteCache bool) {
 		}
 		data := make([]byte, size)
 		rand.Read(data)
-		obj := generateObjectWithPayload(cid, data)
+		obj := generateObjectWithPayload(cnr, data)
 		objects[i] = obj
 
 		prm := new(shard.PutPrm).WithObject(objects[i])
@@ -193,8 +193,8 @@ func TestStream(t *testing.T) {
 	const objCount = 5
 	objects := make([]*objectSDK.Object, objCount)
 	for i := 0; i < objCount; i++ {
-		cid := cidtest.ID()
-		obj := generateObjectWithCID(t, cid)
+		cnr := cidtest.ID()
+		obj := generateObjectWithCID(t, cnr)
 		objects[i] = obj
 
 		prm := new(shard.PutPrm).WithObject(objects[i])
@@ -301,7 +301,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dirName, addr[2:]), corruptedData, os.ModePerm))
 
 		// 1.2. Unreadable file.
-		addr = cidtest.ID().String() + "." + objecttest.ID().String()
+		addr = cidtest.ID().EncodeToString() + "." + objecttest.ID().EncodeToString()
 		dirName = filepath.Join(bsPath, addr[:2])
 		require.NoError(t, os.MkdirAll(dirName, os.ModePerm))
 
@@ -326,7 +326,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 
 		// 2.2. Invalid object in valid blobovnicza.
 		prm := new(blobovnicza.PutPrm)
-		prm.SetAddress(addressSDK.NewAddress())
+		prm.SetAddress(oid.Address{})
 		prm.SetMarshaledObject(corruptedData)
 		b := blobovnicza.New(blobovnicza.WithPath(filepath.Join(bTree, "1", "2")))
 		require.NoError(t, b.Open())
@@ -338,7 +338,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 	{
 		// 3. Invalid object in write-cache. Note that because shard is read-only
 		//    the object won't be flushed.
-		addr := cidtest.ID().String() + "." + objecttest.ID().String()
+		addr := cidtest.ID().EncodeToString() + "." + objecttest.ID().EncodeToString()
 		dir := filepath.Join(wcPath, addr[:1])
 		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, addr[1:]), nil, 0))

--- a/pkg/local_object_storage/shard/exists.go
+++ b/pkg/local_object_storage/shard/exists.go
@@ -3,13 +3,13 @@ package shard
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
 // ExistsPrm groups the parameters of Exists operation.
 type ExistsPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // ExistsRes groups the resulting values of Exists operation.
@@ -18,7 +18,7 @@ type ExistsRes struct {
 }
 
 // WithAddress is an Exists option to set object checked for existence.
-func (p *ExistsPrm) WithAddress(addr *addressSDK.Address) *ExistsPrm {
+func (p *ExistsPrm) WithAddress(addr oid.Address) *ExistsPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/get.go
+++ b/pkg/local_object_storage/shard/get.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ type storFetcher = func(stor *blobstor.BlobStor, id *blobovnicza.ID) (*objectSDK
 
 // GetPrm groups the parameters of Get operation.
 type GetPrm struct {
-	addr     *addressSDK.Address
+	addr     oid.Address
 	skipMeta bool
 }
 
@@ -34,7 +34,7 @@ type GetRes struct {
 // WithAddress is a Get option to set the address of the requested object.
 //
 // Option is required.
-func (p *GetPrm) WithAddress(addr *addressSDK.Address) *GetPrm {
+func (p *GetPrm) WithAddress(addr oid.Address) *GetPrm {
 	if p != nil {
 		p.addr = addr
 	}
@@ -103,7 +103,7 @@ func (s *Shard) Get(prm *GetPrm) (*GetRes, error) {
 }
 
 // fetchObjectData looks through writeCache and blobStor to find object.
-func (s *Shard) fetchObjectData(addr *addressSDK.Address, skipMeta bool, big, small storFetcher) (*objectSDK.Object, bool, error) {
+func (s *Shard) fetchObjectData(addr oid.Address, skipMeta bool, big, small storFetcher) (*objectSDK.Object, bool, error) {
 	var (
 		err error
 		res *objectSDK.Object

--- a/pkg/local_object_storage/shard/head.go
+++ b/pkg/local_object_storage/shard/head.go
@@ -6,12 +6,12 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // HeadPrm groups the parameters of Head operation.
 type HeadPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 	raw  bool
 }
 
@@ -23,7 +23,7 @@ type HeadRes struct {
 // WithAddress is a Head option to set the address of the requested object.
 //
 // Option is required.
-func (p *HeadPrm) WithAddress(addr *addressSDK.Address) *HeadPrm {
+func (p *HeadPrm) WithAddress(addr oid.Address) *HeadPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/head_test.go
+++ b/pkg/local_object_storage/shard/head_test.go
@@ -46,13 +46,13 @@ func testShardHead(t *testing.T, hasWriteCache bool) {
 	})
 
 	t.Run("virtual object", func(t *testing.T) {
-		cid := cidtest.ID()
+		cnr := cidtest.ID()
 		splitID := objectSDK.NewSplitID()
 
-		parent := generateObjectWithCID(t, cid)
+		parent := generateObjectWithCID(t, cnr)
 		addAttribute(parent, "foo", "bar")
 
-		child := generateObjectWithCID(t, cid)
+		child := generateObjectWithCID(t, cnr)
 		child.SetParent(parent)
 		idParent, _ := parent.ID()
 		child.SetParentID(idParent)

--- a/pkg/local_object_storage/shard/inhume.go
+++ b/pkg/local_object_storage/shard/inhume.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
 // InhumePrm encapsulates parameters for inhume operation.
 type InhumePrm struct {
-	target    []*addressSDK.Address
-	tombstone *addressSDK.Address
+	target    []oid.Address
+	tombstone *oid.Address
 }
 
 // InhumeRes encapsulates results of inhume operation.
@@ -22,10 +22,10 @@ type InhumeRes struct{}
 //
 // tombstone should not be nil, addr should not be empty.
 // Should not be called along with MarkAsGarbage.
-func (p *InhumePrm) WithTarget(tombstone *addressSDK.Address, addrs ...*addressSDK.Address) *InhumePrm {
+func (p *InhumePrm) WithTarget(tombstone oid.Address, addrs ...oid.Address) *InhumePrm {
 	if p != nil {
 		p.target = addrs
-		p.tombstone = tombstone
+		p.tombstone = &tombstone
 	}
 
 	return p
@@ -34,7 +34,7 @@ func (p *InhumePrm) WithTarget(tombstone *addressSDK.Address, addrs ...*addressS
 // MarkAsGarbage marks object to be physically removed from shard.
 //
 // Should not be called along with WithTarget.
-func (p *InhumePrm) MarkAsGarbage(addr ...*addressSDK.Address) *InhumePrm {
+func (p *InhumePrm) MarkAsGarbage(addr ...oid.Address) *InhumePrm {
 	if p != nil {
 		p.target = addr
 		p.tombstone = nil
@@ -64,7 +64,7 @@ func (s *Shard) Inhume(prm *InhumePrm) (*InhumeRes, error) {
 	metaPrm := new(meta.InhumePrm).WithAddresses(prm.target...)
 
 	if prm.tombstone != nil {
-		metaPrm.WithTombstoneAddress(prm.tombstone)
+		metaPrm.WithTombstoneAddress(*prm.tombstone)
 	} else {
 		metaPrm.WithGCMark()
 	}

--- a/pkg/local_object_storage/shard/inhume_test.go
+++ b/pkg/local_object_storage/shard/inhume_test.go
@@ -24,12 +24,12 @@ func testShardInhume(t *testing.T, hasWriteCache bool) {
 	sh := newShard(t, hasWriteCache)
 	defer releaseShard(sh, t)
 
-	cid := cidtest.ID()
+	cnr := cidtest.ID()
 
-	obj := generateObjectWithCID(t, cid)
+	obj := generateObjectWithCID(t, cnr)
 	addAttribute(obj, "foo", "bar")
 
-	ts := generateObjectWithCID(t, cid)
+	ts := generateObjectWithCID(t, cnr)
 
 	putPrm := new(shard.PutPrm)
 	putPrm.WithObject(obj)

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -6,7 +6,7 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -21,10 +21,10 @@ var ErrEndOfListing = meta.ErrEndOfListing
 type ListContainersPrm struct{}
 
 type ListContainersRes struct {
-	containers []*cid.ID
+	containers []cid.ID
 }
 
-func (r *ListContainersRes) Containers() []*cid.ID {
+func (r *ListContainersRes) Containers() []cid.ID {
 	return r.containers
 }
 
@@ -36,7 +36,7 @@ type ListWithCursorPrm struct {
 
 // ListWithCursorRes contains values returned from ListWithCursor operation.
 type ListWithCursorRes struct {
-	addrList []*addressSDK.Address
+	addrList []oid.Address
 	cursor   *Cursor
 }
 
@@ -55,7 +55,7 @@ func (p *ListWithCursorPrm) WithCursor(cursor *Cursor) *ListWithCursorPrm {
 }
 
 // AddressList returns addresses selected by ListWithCursor operation.
-func (r ListWithCursorRes) AddressList() []*addressSDK.Address {
+func (r ListWithCursorRes) AddressList() []oid.Address {
 	return r.addrList
 }
 
@@ -102,7 +102,7 @@ func (s *Shard) ListContainers(_ *ListContainersPrm) (*ListContainersRes, error)
 	}, nil
 }
 
-func ListContainers(s *Shard) ([]*cid.ID, error) {
+func ListContainers(s *Shard) ([]cid.ID, error) {
 	res, err := s.ListContainers(&ListContainersPrm{})
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (s *Shard) ListWithCursor(prm *ListWithCursorPrm) (*ListWithCursorRes, erro
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]*addressSDK.Address, *Cursor, error) {
+func ListWithCursor(s *Shard, count uint32, cursor *Cursor) ([]oid.Address, *Cursor, error) {
 	prm := new(ListWithCursorPrm).WithCount(count).WithCursor(cursor)
 	res, err := s.ListWithCursor(prm)
 	if err != nil {

--- a/pkg/local_object_storage/shard/list_test.go
+++ b/pkg/local_object_storage/shard/list_test.go
@@ -35,19 +35,19 @@ func testShardList(t *testing.T, sh *shard.Shard) {
 	putPrm := new(shard.PutPrm)
 
 	for i := 0; i < C; i++ {
-		cid := cidtest.ID()
+		cnr := cidtest.ID()
 
 		for j := 0; j < N; j++ {
-			obj := generateObjectWithCID(t, cid)
+			obj := generateObjectWithCID(t, cnr)
 			addPayload(obj, 1<<2)
 
 			// add parent as virtual object, it must be ignored in List()
-			parent := generateObjectWithCID(t, cid)
+			parent := generateObjectWithCID(t, cnr)
 			idParent, _ := parent.ID()
 			obj.SetParentID(idParent)
 			obj.SetParent(parent)
 
-			objs[object.AddressOf(obj).String()] = 0
+			objs[object.AddressOf(obj).EncodeToString()] = 0
 
 			putPrm.WithObject(obj)
 
@@ -60,10 +60,10 @@ func testShardList(t *testing.T, sh *shard.Shard) {
 	require.NoError(t, err)
 
 	for _, objID := range res.AddressList() {
-		i, ok := objs[objID.String()]
+		i, ok := objs[objID.EncodeToString()]
 		require.True(t, ok)
 		require.Equal(t, 0, i)
 
-		objs[objID.String()] = 1
+		objs[objID.EncodeToString()] = 1
 	}
 }

--- a/pkg/local_object_storage/shard/move.go
+++ b/pkg/local_object_storage/shard/move.go
@@ -2,13 +2,13 @@ package shard
 
 import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
 // ToMoveItPrm encapsulates parameters for ToMoveIt operation.
 type ToMoveItPrm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
 // ToMoveItRes encapsulates results of ToMoveIt operation.
@@ -16,7 +16,7 @@ type ToMoveItRes struct{}
 
 // WithAddress sets object address that should be marked to move into another
 // shard.
-func (p *ToMoveItPrm) WithAddress(addr *addressSDK.Address) *ToMoveItPrm {
+func (p *ToMoveItPrm) WithAddress(addr oid.Address) *ToMoveItPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/range.go
+++ b/pkg/local_object_storage/shard/range.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // RngPrm groups the parameters of GetRange operation.
@@ -13,7 +13,7 @@ type RngPrm struct {
 
 	off uint64
 
-	addr *addressSDK.Address
+	addr oid.Address
 
 	skipMeta bool
 }
@@ -27,7 +27,7 @@ type RngRes struct {
 // WithAddress is a Rng option to set the address of the requested object.
 //
 // Option is required.
-func (p *RngPrm) WithAddress(addr *addressSDK.Address) *RngPrm {
+func (p *RngPrm) WithAddress(addr oid.Address) *RngPrm {
 	if p != nil {
 		p.addr = addr
 	}

--- a/pkg/local_object_storage/shard/select.go
+++ b/pkg/local_object_storage/shard/select.go
@@ -6,24 +6,24 @@ import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // SelectPrm groups the parameters of Select operation.
 type SelectPrm struct {
-	cid     *cid.ID
+	cnr     cid.ID
 	filters object.SearchFilters
 }
 
 // SelectRes groups the resulting values of Select operation.
 type SelectRes struct {
-	addrList []*addressSDK.Address
+	addrList []oid.Address
 }
 
 // WithContainerID is a Select option to set the container id to search in.
-func (p *SelectPrm) WithContainerID(cid *cid.ID) *SelectPrm {
+func (p *SelectPrm) WithContainerID(cnr cid.ID) *SelectPrm {
 	if p != nil {
-		p.cid = cid
+		p.cnr = cnr
 	}
 
 	return p
@@ -39,7 +39,7 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) *SelectPrm {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []*addressSDK.Address {
+func (r *SelectRes) AddressList() []oid.Address {
 	return r.addrList
 }
 
@@ -48,7 +48,7 @@ func (r *SelectRes) AddressList() []*addressSDK.Address {
 // Returns any error encountered that
 // did not allow to completely select the objects.
 func (s *Shard) Select(prm *SelectPrm) (*SelectRes, error) {
-	addrList, err := meta.Select(s.metaBase, prm.cid, prm.filters)
+	addrList, err := meta.Select(s.metaBase, prm.cnr, prm.filters)
 	if err != nil {
 		return nil, fmt.Errorf("could not select objects from metabase: %w", err)
 	}

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +36,7 @@ type Option func(*cfg)
 type ExpiredTombstonesCallback func(context.Context, []meta.TombstonedObject)
 
 // ExpiredObjectsCallback is a callback handling list of expired objects.
-type ExpiredObjectsCallback func(context.Context, []*addressSDK.Address)
+type ExpiredObjectsCallback func(context.Context, []oid.Address)
 
 type cfg struct {
 	m sync.RWMutex

--- a/pkg/local_object_storage/util/splitinfo_test.go
+++ b/pkg/local_object_storage/util/splitinfo_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +19,8 @@ func TestMergeSplitInfo(t *testing.T) {
 	splitID.SetUUID(uid)
 
 	var rawLinkID, rawLastID [32]byte
-	var linkID oidSDK.ID
-	var lastID oidSDK.ID
+	var linkID oid.ID
+	var lastID oid.ID
 
 	_, err = rand.Read(rawLinkID[:])
 	require.NoError(t, err)

--- a/pkg/local_object_storage/writecache/delete.go
+++ b/pkg/local_object_storage/writecache/delete.go
@@ -6,21 +6,21 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
 // Delete removes object from write-cache.
 //
 // Returns an error of type apistatus.ObjectNotFound if object is missing in write-cache.
-func (c *cache) Delete(addr *addressSDK.Address) error {
+func (c *cache) Delete(addr oid.Address) error {
 	c.modeMtx.RLock()
 	defer c.modeMtx.RUnlock()
 	if c.readOnly() {
 		return ErrReadOnly
 	}
 
-	saddr := addr.String()
+	saddr := addr.EncodeToString()
 
 	// Check memory cache.
 	c.mtx.Lock()

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
@@ -133,8 +133,8 @@ func (c *cache) flushBigObjects() {
 			}
 
 			evictNum := 0
-			_ = c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr *addressSDK.Address, data []byte) error {
-				sAddr := addr.String()
+			_ = c.fsTree.Iterate(new(fstree.IterationPrm).WithHandler(func(addr oid.Address, data []byte) error {
+				sAddr := addr.EncodeToString()
 
 				if _, ok := c.store.flushed.Peek(sAddr); ok {
 					return nil

--- a/pkg/local_object_storage/writecache/get.go
+++ b/pkg/local_object_storage/writecache/get.go
@@ -3,15 +3,15 @@ package writecache
 import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
 // Get returns object from write-cache.
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in write-cache.
-func (c *cache) Get(addr *addressSDK.Address) (*objectSDK.Object, error) {
-	saddr := addr.String()
+func (c *cache) Get(addr oid.Address) (*objectSDK.Object, error) {
+	saddr := addr.EncodeToString()
 
 	c.mtx.RLock()
 	for i := range c.mem {
@@ -53,7 +53,7 @@ func (c *cache) Get(addr *addressSDK.Address) (*objectSDK.Object, error) {
 // Head returns object header from write-cache.
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in write-cache.
-func (c *cache) Head(addr *addressSDK.Address) (*objectSDK.Object, error) {
+func (c *cache) Head(addr oid.Address) (*objectSDK.Object, error) {
 	obj, err := c.Get(addr)
 	if err != nil {
 		return nil, err

--- a/pkg/local_object_storage/writecache/put.go
+++ b/pkg/local_object_storage/writecache/put.go
@@ -30,7 +30,7 @@ func (c *cache) Put(o *objectSDK.Object) error {
 	}
 
 	oi := objectInfo{
-		addr: object.AddressOf(o).String(),
+		addr: object.AddressOf(o).EncodeToString(),
 		obj:  o,
 		data: data,
 	}

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -11,7 +11,7 @@ import (
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
@@ -126,11 +126,12 @@ func (c *cache) deleteFromDB(keys [][]byte) error {
 func (c *cache) deleteFromDisk(keys [][]byte) error {
 	var lastErr error
 
+	var addr oid.Address
+
 	for i := range keys {
-		addr := addressSDK.NewAddress()
 		addrStr := string(keys[i])
 
-		if err := addr.Parse(addrStr); err != nil {
+		if err := addr.DecodeString(addrStr); err != nil {
 			c.log.Error("can't parse address", zap.String("address", addrStr))
 			continue
 		}

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -17,9 +17,9 @@ type Info struct {
 
 // Cache represents write-cache for objects.
 type Cache interface {
-	Get(*addressSDK.Address) (*object.Object, error)
-	Head(*addressSDK.Address) (*object.Object, error)
-	Delete(*addressSDK.Address) error
+	Get(address oid.Address) (*object.Object, error)
+	Head(oid.Address) (*object.Object, error)
+	Delete(oid.Address) error
 	Iterate(*IterationPrm) error
 	Put(*object.Object) error
 	SetMode(Mode)

--- a/pkg/morph/client/audit/list_results.go
+++ b/pkg/morph/client/audit/list_results.go
@@ -37,7 +37,7 @@ func (c *Client) ListAuditResultIDByEpoch(epoch uint64) ([]ResultID, error) {
 
 // ListAuditResultIDByCID returns a list of audit result IDs inside audit
 // contract for specific epoch number and container ID.
-func (c *Client) ListAuditResultIDByCID(epoch uint64, cnr *cid.ID) ([]ResultID, error) {
+func (c *Client) ListAuditResultIDByCID(epoch uint64, cnr cid.ID) ([]ResultID, error) {
 	binCnr := make([]byte, sha256.Size)
 	cnr.Encode(binCnr)
 
@@ -54,7 +54,7 @@ func (c *Client) ListAuditResultIDByCID(epoch uint64, cnr *cid.ID) ([]ResultID, 
 
 // ListAuditResultIDByNode returns a list of audit result IDs inside audit
 // contract for specific epoch number, container ID and inner ring public key.
-func (c *Client) ListAuditResultIDByNode(epoch uint64, cnr *cid.ID, nodeKey []byte) ([]ResultID, error) {
+func (c *Client) ListAuditResultIDByNode(epoch uint64, cnr cid.ID, nodeKey []byte) ([]ResultID, error) {
 	binCnr := make([]byte, sha256.Size)
 	cnr.Encode(binCnr)
 

--- a/pkg/morph/client/audit/result_test.go
+++ b/pkg/morph/client/audit/result_test.go
@@ -46,7 +46,7 @@ func TestAuditResults(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	list, err := auditClientWrapper.ListAuditResultIDByCID(epoch, &id)
+	list, err := auditClientWrapper.ListAuditResultIDByCID(epoch, id)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 

--- a/pkg/morph/client/balance/balanceOf.go
+++ b/pkg/morph/client/balance/balanceOf.go
@@ -11,7 +11,7 @@ import (
 
 // BalanceOf receives the amount of funds in the client's account
 // through the Balance contract call, and returns it.
-func (c *Client) BalanceOf(id *user.ID) (*big.Int, error) {
+func (c *Client) BalanceOf(id user.ID) (*big.Int, error) {
 	h, err := address.StringToUint160(id.EncodeToString())
 	if err != nil {
 		return nil, err

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -12,7 +12,7 @@ import (
 type TransferPrm struct {
 	Amount int64
 
-	From, To *user.ID
+	From, To user.ID
 
 	Details []byte
 

--- a/pkg/morph/client/container/delete.go
+++ b/pkg/morph/client/container/delete.go
@@ -13,13 +13,8 @@ import (
 //
 // Returns error if container ID is nil.
 func Delete(c *Client, witness core.RemovalWitness) error {
-	id := witness.ContainerID()
-	if id == nil {
-		return errNilArgument
-	}
-
 	binCnr := make([]byte, sha256.Size)
-	id.Encode(binCnr)
+	witness.ContainerID().Encode(binCnr)
 
 	var prm DeletePrm
 
@@ -35,7 +30,7 @@ func Delete(c *Client, witness core.RemovalWitness) error {
 
 // DeletePrm groups parameters of Delete client operation.
 type DeletePrm struct {
-	cid       []byte
+	cnr       []byte
 	signature []byte
 	token     []byte
 
@@ -44,7 +39,7 @@ type DeletePrm struct {
 
 // SetCID sets container ID.
 func (d *DeletePrm) SetCID(cid []byte) {
-	d.cid = cid
+	d.cnr = cid
 }
 
 // SetSignature sets signature.
@@ -71,7 +66,7 @@ func (c *Client) Delete(p DeletePrm) error {
 
 	prm := client.InvokePrm{}
 	prm.SetMethod(deleteMethod)
-	prm.SetArgs(p.cid, p.signature, p.token)
+	prm.SetArgs(p.cnr, p.signature, p.token)
 	prm.InvokePrmOptional = p.InvokePrmOptional
 
 	err := c.client.Invoke(prm)

--- a/pkg/morph/client/container/eacl.go
+++ b/pkg/morph/client/container/eacl.go
@@ -15,11 +15,7 @@ import (
 
 // GetEACL reads the extended ACL table from NeoFS system
 // through Container contract call.
-func (c *Client) GetEACL(cnr *cid.ID) (*eacl.Table, error) {
-	if cnr == nil {
-		return nil, errNilArgument
-	}
-
+func (c *Client) GetEACL(cnr cid.ID) (*eacl.Table, error) {
 	binCnr := make([]byte, sha256.Size)
 	cnr.Encode(binCnr)
 

--- a/pkg/morph/client/container/get.go
+++ b/pkg/morph/client/container/get.go
@@ -18,8 +18,8 @@ import (
 
 type containerSource Client
 
-func (x *containerSource) Get(cid *cid.ID) (*container.Container, error) {
-	return Get((*Client)(x), cid)
+func (x *containerSource) Get(cnr cid.ID) (*container.Container, error) {
+	return Get((*Client)(x), cnr)
 }
 
 // AsContainerSource provides container Source interface
@@ -29,9 +29,7 @@ func AsContainerSource(w *Client) core.Source {
 }
 
 // Get marshals container ID, and passes it to Wrapper's Get method.
-//
-// Returns error if cid is nil.
-func Get(c *Client, cnr *cid.ID) (*container.Container, error) {
+func Get(c *Client, cnr cid.ID) (*container.Container, error) {
 	binCnr := make([]byte, sha256.Size)
 	cnr.Encode(binCnr)
 

--- a/pkg/morph/client/container/list.go
+++ b/pkg/morph/client/container/list.go
@@ -14,7 +14,7 @@ import (
 //
 // Returns the identifiers of all NeoFS containers if pointer
 // to user identifier is nil.
-func (c *Client) List(idUser *user.ID) ([]*cid.ID, error) {
+func (c *Client) List(idUser *user.ID) ([]cid.ID, error) {
 	var rawID []byte
 
 	if idUser != nil {
@@ -37,21 +37,21 @@ func (c *Client) List(idUser *user.ID) ([]*cid.ID, error) {
 		return nil, fmt.Errorf("could not get stack item array from stack item (%s): %w", listMethod, err)
 	}
 
-	cidList := make([]*cid.ID, 0, len(res))
+	cidList := make([]cid.ID, 0, len(res))
 	for i := range res {
-		rawCid, err := client.BytesFromStackItem(res[i])
+		rawID, err := client.BytesFromStackItem(res[i])
 		if err != nil {
 			return nil, fmt.Errorf("could not get byte array from stack item (%s): %w", listMethod, err)
 		}
 
 		var id cid.ID
 
-		err = id.Decode(rawCid)
+		err = id.Decode(rawID)
 		if err != nil {
 			return nil, fmt.Errorf("decode container ID: %w", err)
 		}
 
-		cidList = append(cidList, &id)
+		cidList = append(cidList, id)
 	}
 
 	return cidList, nil

--- a/pkg/morph/client/container/load.go
+++ b/pkg/morph/client/container/load.go
@@ -99,7 +99,7 @@ type Estimation struct {
 
 // Estimations is a structure of grouped container load estimation inside Container contract.
 type Estimations struct {
-	ContainerID *cid.ID
+	ContainerID cid.ID
 
 	Values []Estimation
 }
@@ -125,7 +125,7 @@ func (c *Client) GetUsedSpaceEstimations(id EstimationID) (*Estimations, error) 
 		return nil, fmt.Errorf("unexpected stack item count of estimations fields (%s)", getSizeMethod)
 	}
 
-	rawCID, err := client.BytesFromStackItem(prms[0])
+	rawCnr, err := client.BytesFromStackItem(prms[0])
 	if err != nil {
 		return nil, fmt.Errorf("could not get container ID byte array from stack item (%s): %w", getSizeMethod, err)
 	}
@@ -137,15 +137,15 @@ func (c *Client) GetUsedSpaceEstimations(id EstimationID) (*Estimations, error) 
 
 	var cnr cid.ID
 
-	err = cnr.Decode(rawCID)
+	err = cnr.Decode(rawCnr)
 	if err != nil {
 		return nil, fmt.Errorf("decode container ID: %w", err)
 	}
 
 	v2 := new(v2refs.ContainerID)
-	v2.SetValue(rawCID)
+	v2.SetValue(rawCnr)
 	res := &Estimations{
-		ContainerID: &cnr,
+		ContainerID: cnr,
 		Values:      make([]Estimation, 0, len(prms)),
 	}
 

--- a/pkg/morph/client/neofsid/keys.go
+++ b/pkg/morph/client/neofsid/keys.go
@@ -11,11 +11,11 @@ import (
 
 // AccountKeysPrm groups parameters of AccountKeys operation.
 type AccountKeysPrm struct {
-	id *user.ID
+	id user.ID
 }
 
 // SetID sets owner ID.
-func (a *AccountKeysPrm) SetID(id *user.ID) {
+func (a *AccountKeysPrm) SetID(id user.ID) {
 	a.id = id
 }
 

--- a/pkg/services/accounting/morph/executor.go
+++ b/pkg/services/accounting/morph/executor.go
@@ -34,7 +34,7 @@ func (s *morphExecutor) Balance(ctx context.Context, body *accounting.BalanceReq
 		return nil, fmt.Errorf("invalid account: %w", err)
 	}
 
-	amount, err := s.client.BalanceOf(&id)
+	amount, err := s.client.BalanceOf(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/audit/auditor/pdp.go
+++ b/pkg/services/audit/auditor/pdp.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/rand"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 	"go.uber.org/zap"
 )
@@ -82,7 +82,7 @@ func (c *Context) distributeRanges(p *gamePair) {
 	}
 }
 
-func (c *Context) splitPayload(id *oidSDK.ID) []uint64 {
+func (c *Context) splitPayload(id oid.ID) []uint64 {
 	var (
 		prev    uint64
 		size    = c.objectSize(id)

--- a/pkg/services/audit/auditor/pop.go
+++ b/pkg/services/audit/auditor/pop.go
@@ -2,7 +2,7 @@ package auditor
 
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 	"go.uber.org/zap"
 )
@@ -27,7 +27,7 @@ func (c *Context) buildCoverage() {
 
 	// select random member from another storage group
 	// and process all placement vectors
-	c.iterateSGMembersPlacementRand(func(id *oidSDK.ID, ind int, nodes netmap.Nodes) bool {
+	c.iterateSGMembersPlacementRand(func(id oid.ID, ind int, nodes netmap.Nodes) bool {
 		c.processObjectPlacement(id, nodes, replicas[ind].Count())
 		return c.containerCovered()
 	})
@@ -38,7 +38,7 @@ func (c *Context) containerCovered() bool {
 	return c.cnrNodesNum <= len(c.pairedNodes)
 }
 
-func (c *Context) processObjectPlacement(id *oidSDK.ID, nodes netmap.Nodes, replicas uint32) {
+func (c *Context) processObjectPlacement(id oid.ID, nodes netmap.Nodes, replicas uint32) {
 	var (
 		ok      uint32
 		optimal bool
@@ -102,7 +102,7 @@ func (c *Context) processObjectPlacement(id *oidSDK.ID, nodes netmap.Nodes, repl
 	}
 }
 
-func (c *Context) composePair(id *oidSDK.ID, n1, n2 *netmap.Node) {
+func (c *Context) composePair(id oid.ID, n1, n2 *netmap.Node) {
 	c.pairs = append(c.pairs, gamePair{
 		n1: n1,
 		n2: n2,
@@ -117,10 +117,10 @@ func (c *Context) composePair(id *oidSDK.ID, n1, n2 *netmap.Node) {
 	}
 }
 
-func (c *Context) iterateSGMembersPlacementRand(f func(*oidSDK.ID, int, netmap.Nodes) bool) {
+func (c *Context) iterateSGMembersPlacementRand(f func(oid.ID, int, netmap.Nodes) bool) {
 	// iterate over storage groups members for all storage groups (one by one)
 	// with randomly shuffled members
-	c.iterateSGMembersRand(func(id *oidSDK.ID) bool {
+	c.iterateSGMembersRand(func(id oid.ID) bool {
 		// build placement vector for the current object
 		nn, err := c.buildPlacement(id)
 		if err != nil {
@@ -142,8 +142,8 @@ func (c *Context) iterateSGMembersPlacementRand(f func(*oidSDK.ID, int, netmap.N
 	})
 }
 
-func (c *Context) iterateSGMembersRand(f func(*oidSDK.ID) bool) {
-	c.iterateSGInfo(func(members []oidSDK.ID) bool {
+func (c *Context) iterateSGMembersRand(f func(oid.ID) bool) {
+	c.iterateSGInfo(func(members []oid.ID) bool {
 		ln := len(members)
 
 		processed := make(map[uint64]struct{}, ln-1)
@@ -152,7 +152,7 @@ func (c *Context) iterateSGMembersRand(f func(*oidSDK.ID) bool) {
 			ind := nextRandUint64(uint64(ln), processed)
 			processed[ind] = struct{}{}
 
-			if f(&members[ind]) {
+			if f(members[ind]) {
 				return true
 			}
 		}
@@ -161,7 +161,7 @@ func (c *Context) iterateSGMembersRand(f func(*oidSDK.ID) bool) {
 	})
 }
 
-func (c *Context) iterateSGInfo(f func([]oidSDK.ID) bool) {
+func (c *Context) iterateSGInfo(f func([]oid.ID) bool) {
 	c.sgMembersMtx.RLock()
 	defer c.sgMembersMtx.RUnlock()
 

--- a/pkg/services/audit/report.go
+++ b/pkg/services/audit/report.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Report tracks the progress of auditing container data.
@@ -21,9 +21,9 @@ type Reporter interface {
 }
 
 // NewReport creates and returns blank Report instance.
-func NewReport(cid *cid.ID) *Report {
+func NewReport(cnr cid.ID) *Report {
 	var rep Report
-	rep.res.ForContainer(*cid)
+	rep.res.ForContainer(cnr)
 
 	return &rep
 }
@@ -45,19 +45,19 @@ func (r *Report) Complete() {
 }
 
 // PassedPoR updates list of passed storage groups.
-func (r *Report) PassedPoR(sg *oidSDK.ID) {
+func (r *Report) PassedPoR(sg oid.ID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.res.SubmitPassedStorageGroup(*sg)
+	r.res.SubmitPassedStorageGroup(sg)
 }
 
 // FailedPoR updates list of failed storage groups.
-func (r *Report) FailedPoR(sg *oidSDK.ID) {
+func (r *Report) FailedPoR(sg oid.ID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.res.SubmitFailedStorageGroup(*sg)
+	r.res.SubmitFailedStorageGroup(sg)
 }
 
 // SetPlacementCounters sets counters of compliance with placement.

--- a/pkg/services/audit/task.go
+++ b/pkg/services/audit/task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Task groups groups the container audit parameters.
@@ -15,7 +15,7 @@ type Task struct {
 
 	auditContext context.Context
 
-	cid *cid.ID
+	idCnr cid.ID
 
 	cnr *container.Container
 
@@ -23,7 +23,7 @@ type Task struct {
 
 	cnrNodes netmap.ContainerNodes
 
-	sgList []oidSDK.ID
+	sgList []oid.ID
 }
 
 // WithReporter sets audit report writer.
@@ -55,17 +55,17 @@ func (t *Task) AuditContext() context.Context {
 }
 
 // WithContainerID sets identifier of the container under audit.
-func (t *Task) WithContainerID(cid *cid.ID) *Task {
+func (t *Task) WithContainerID(cnr cid.ID) *Task {
 	if t != nil {
-		t.cid = cid
+		t.idCnr = cnr
 	}
 
 	return t
 }
 
 // ContainerID returns identifier of the container under audit.
-func (t *Task) ContainerID() *cid.ID {
-	return t.cid
+func (t *Task) ContainerID() cid.ID {
+	return t.idCnr
 }
 
 // WithContainerStructure sets structure of the container under audit.
@@ -111,7 +111,7 @@ func (t *Task) ContainerNodes() netmap.ContainerNodes {
 }
 
 // WithStorageGroupList sets a list of storage groups from container under audit.
-func (t *Task) WithStorageGroupList(sgList []oidSDK.ID) *Task {
+func (t *Task) WithStorageGroupList(sgList []oid.ID) *Task {
 	if t != nil {
 		t.sgList = sgList
 	}
@@ -120,6 +120,6 @@ func (t *Task) WithStorageGroupList(sgList []oidSDK.ID) *Task {
 }
 
 // StorageGroupList returns list of storage groups from container under audit.
-func (t *Task) StorageGroupList() []oidSDK.ID {
+func (t *Task) StorageGroupList() []oid.ID {
 	return t.sgList
 }

--- a/pkg/services/container/announcement/load/route/placement/calls.go
+++ b/pkg/services/container/announcement/load/route/placement/calls.go
@@ -25,7 +25,7 @@ func (b *Builder) NextStage(a container.UsedSpaceAnnouncement, passed []loadrout
 		return nil, errors.New("missing container in load announcement")
 	}
 
-	placement, err := b.placementBuilder.BuildPlacement(a.Epoch(), &cnr)
+	placement, err := b.placementBuilder.BuildPlacement(a.Epoch(), cnr)
 	if err != nil {
 		return nil, fmt.Errorf("could not build placement %s: %w", cnr, err)
 	}

--- a/pkg/services/container/announcement/load/route/placement/deps.go
+++ b/pkg/services/container/announcement/load/route/placement/deps.go
@@ -8,7 +8,7 @@ import (
 // PlacementBuilder describes interface of NeoFS placement calculator.
 type PlacementBuilder interface {
 	// BuildPlacement must compose and sort (according to a specific algorithm)
-	// storage nodes from the container with identifier cid using network map
+	// storage nodes from the container by its identifier using network map
 	// of particular epoch.
-	BuildPlacement(epoch uint64, cid *cid.ID) ([]netmap.Nodes, error)
+	BuildPlacement(epoch uint64, cnr cid.ID) ([]netmap.Nodes, error)
 }

--- a/pkg/services/container/executor.go
+++ b/pkg/services/container/executor.go
@@ -31,7 +31,12 @@ func NewExecutionService(exec ServiceExecutor) Server {
 }
 
 func (s *executorSvc) Put(ctx context.Context, req *container.PutRequest) (*container.PutResponse, error) {
-	respBody, err := s.exec.Put(ctx, req.GetMetaHeader().GetOrigin().GetSessionToken(), req.GetBody())
+	meta := req.GetMetaHeader()
+	for origin := meta.GetOrigin(); origin != nil; origin = meta.GetOrigin() {
+		meta = origin
+	}
+
+	respBody, err := s.exec.Put(ctx, meta.GetSessionToken(), req.GetBody())
 	if err != nil {
 		return nil, fmt.Errorf("could not execute Put request: %w", err)
 	}
@@ -43,7 +48,12 @@ func (s *executorSvc) Put(ctx context.Context, req *container.PutRequest) (*cont
 }
 
 func (s *executorSvc) Delete(ctx context.Context, req *container.DeleteRequest) (*container.DeleteResponse, error) {
-	respBody, err := s.exec.Delete(ctx, req.GetMetaHeader().GetOrigin().GetSessionToken(), req.GetBody())
+	meta := req.GetMetaHeader()
+	for origin := meta.GetOrigin(); origin != nil; origin = meta.GetOrigin() {
+		meta = origin
+	}
+
+	respBody, err := s.exec.Delete(ctx, meta.GetSessionToken(), req.GetBody())
 	if err != nil {
 		return nil, fmt.Errorf("could not execute Delete request: %w", err)
 	}
@@ -79,7 +89,12 @@ func (s *executorSvc) List(ctx context.Context, req *container.ListRequest) (*co
 }
 
 func (s *executorSvc) SetExtendedACL(ctx context.Context, req *container.SetExtendedACLRequest) (*container.SetExtendedACLResponse, error) {
-	respBody, err := s.exec.SetExtendedACL(ctx, req.GetMetaHeader().GetOrigin().GetSessionToken(), req.GetBody())
+	meta := req.GetMetaHeader()
+	for origin := meta.GetOrigin(); origin != nil; origin = meta.GetOrigin() {
+		meta = origin
+	}
+
+	respBody, err := s.exec.SetExtendedACL(ctx, meta.GetSessionToken(), req.GetBody())
 	if err != nil {
 		return nil, fmt.Errorf("could not execute SetEACL request: %w", err)
 	}

--- a/pkg/services/container/morph/executor.go
+++ b/pkg/services/container/morph/executor.go
@@ -32,7 +32,7 @@ type Reader interface {
 	// List returns a list of container identifiers belonging
 	// to the specified user of NeoFS system. Returns the identifiers
 	// of all NeoFS containers if pointer to owner identifier is nil.
-	List(*user.ID) ([]*cid.ID, error)
+	List(*user.ID) ([]cid.ID, error)
 }
 
 // Writer is an interface of container storage updater.
@@ -119,7 +119,7 @@ func (s *morphExecutor) Delete(_ context.Context, tokV2 *sessionV2.Token, body *
 
 	var rmWitness containercore.RemovalWitness
 
-	rmWitness.SetContainerID(&id)
+	rmWitness.SetContainerID(id)
 	rmWitness.SetSignature(sig)
 	rmWitness.SetSessionToken(tok)
 
@@ -144,7 +144,7 @@ func (s *morphExecutor) Get(ctx context.Context, body *container.GetRequestBody)
 		return nil, fmt.Errorf("invalid container ID: %w", err)
 	}
 
-	cnr, err := s.rdr.Get(&id)
+	cnr, err := s.rdr.Get(id)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (s *morphExecutor) GetExtendedACL(ctx context.Context, body *container.GetE
 		return nil, fmt.Errorf("invalid container ID: %w", err)
 	}
 
-	table, err := s.rdr.GetEACL(&id)
+	table, err := s.rdr.GetEACL(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/control/common_test.go
+++ b/pkg/services/control/common_test.go
@@ -10,15 +10,12 @@ import (
 )
 
 type protoMessage interface {
-	StableMarshal([]byte) ([]byte, error)
+	StableMarshal([]byte) []byte
 	proto.Message
 }
 
 func testStableMarshal(t *testing.T, m1, m2 protoMessage, cmp func(m1, m2 protoMessage) bool) {
-	data, err := m1.StableMarshal(nil)
-	require.NoError(t, err)
-
-	require.NoError(t, proto.Unmarshal(data, m2))
+	require.NoError(t, proto.Unmarshal(m1.StableMarshal(nil), m2))
 
 	require.True(t, cmp(m1, m2))
 }

--- a/pkg/services/control/ir/service.go
+++ b/pkg/services/control/ir/service.go
@@ -76,25 +76,21 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *HealthCheckResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *HealthCheckResponse_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	_, err := proto.EnumMarshal(healthRespBodyHealthStatusFNum, buf, int32(x.HealthStatus))
-	if err != nil {
-		return nil, err
-	}
+	proto.EnumMarshal(healthRespBodyHealthStatusFNum, buf, int32(x.HealthStatus))
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of health check response body
@@ -136,7 +132,7 @@ func (x *HealthCheckResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *HealthCheckResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data

--- a/pkg/services/control/ir/service_test.go
+++ b/pkg/services/control/ir/service_test.go
@@ -9,15 +9,12 @@ import (
 )
 
 type protoMessage interface {
-	StableMarshal([]byte) ([]byte, error)
+	StableMarshal([]byte) []byte
 	proto.Message
 }
 
 func testStableMarshal(t *testing.T, m1, m2 protoMessage, cmp func(m1, m2 protoMessage) bool) {
-	data, err := m1.StableMarshal(nil)
-	require.NoError(t, err)
-
-	require.NoError(t, proto.Unmarshal(data, m2))
+	require.NoError(t, proto.Unmarshal(m1.StableMarshal(nil), m2))
 
 	require.True(t, cmp(m1, m2))
 }

--- a/pkg/services/control/server/gc.go
+++ b/pkg/services/control/server/gc.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 // DeletedObjectHandler is a handler of objects to be removed.
-type DeletedObjectHandler func([]*addressSDK.Address) error
+type DeletedObjectHandler func([]oid.Address) error
 
 // DropObjects marks objects to be removed from the local node.
 //
@@ -26,19 +26,15 @@ func (s *Server) DropObjects(_ context.Context, req *control.DropObjectsRequest)
 	}
 
 	binAddrList := req.GetBody().GetAddressList()
-	addrList := make([]*addressSDK.Address, 0, len(binAddrList))
+	addrList := make([]oid.Address, len(binAddrList))
 
 	for i := range binAddrList {
-		a := addressSDK.NewAddress()
-
-		err := a.Unmarshal(binAddrList[i])
+		err := addrList[i].DecodeString(string(binAddrList[i]))
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument,
 				fmt.Sprintf("invalid binary object address: %v", err),
 			)
 		}
-
-		addrList = append(addrList, a)
 	}
 
 	err := s.delObjHandler(addrList)

--- a/pkg/services/control/service.go
+++ b/pkg/services/control/service.go
@@ -84,37 +84,24 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *HealthCheckResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *HealthCheckResponse_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	var offset int
 
-	n, err = proto.EnumMarshal(healthRespBodyStatusFNum, buf[offset:], int32(x.NetmapStatus))
-	if err != nil {
-		return nil, err
-	}
+	offset = proto.EnumMarshal(healthRespBodyStatusFNum, buf[offset:], int32(x.NetmapStatus))
+	proto.EnumMarshal(healthRespBodyHealthStatusFNum, buf[offset:], int32(x.HealthStatus))
 
-	offset += n
-
-	_, err = proto.EnumMarshal(healthRespBodyHealthStatusFNum, buf[offset:], int32(x.HealthStatus))
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of health check response body
@@ -157,7 +144,7 @@ func (x *HealthCheckResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *HealthCheckResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -240,25 +227,21 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *NetmapSnapshotResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *NetmapSnapshotResponse_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	_, err := proto.NestedStructureMarshal(snapshotRespBodyNetmapFNum, buf, x.Netmap)
-	if err != nil {
-		return nil, err
-	}
+	proto.NestedStructureMarshal(snapshotRespBodyNetmapFNum, buf, x.Netmap)
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of netmap snapshot response body
@@ -300,7 +283,7 @@ func (x *NetmapSnapshotResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *NetmapSnapshotResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -328,25 +311,21 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *SetNetmapStatusRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *SetNetmapStatusRequest_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	_, err := proto.EnumMarshal(setNetmapStatusReqBodyStatusFNum, buf, int32(x.Status))
-	if err != nil {
-		return nil, err
-	}
+	proto.EnumMarshal(setNetmapStatusReqBodyStatusFNum, buf, int32(x.Status))
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of netmap status response body
@@ -388,7 +367,7 @@ func (x *SetNetmapStatusRequest) SetSignature(body *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *SetNetmapStatusRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -404,12 +383,11 @@ func (x *SetNetmapStatusRequest) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *SetNetmapStatusResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *SetNetmapStatusResponse_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of set netmap status response body
@@ -443,7 +421,7 @@ func (x *SetNetmapStatusResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *SetNetmapStatusResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -471,25 +449,21 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *DropObjectsRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *DropObjectsRequest_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	_, err := proto.RepeatedBytesMarshal(addrListReqBodyStatusFNum, buf, x.AddressList)
-	if err != nil {
-		return nil, err
-	}
+	proto.RepeatedBytesMarshal(addrListReqBodyStatusFNum, buf, x.AddressList)
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of "Drop objects" response body
@@ -531,7 +505,7 @@ func (x *DropObjectsRequest) SetSignature(body *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *DropObjectsRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data of "Drop objects" request.
@@ -546,12 +520,11 @@ func (x *DropObjectsRequest) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *DropObjectsResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *DropObjectsResponse_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of "Drop objects" response body
@@ -585,7 +558,7 @@ func (x *DropObjectsResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *DropObjectsResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data of "Drop objects" response.
@@ -600,12 +573,11 @@ func (x *DropObjectsResponse) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *ListShardsRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *ListShardsRequest_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of list shards request body
@@ -639,7 +611,7 @@ func (x *ListShardsRequest) SetSignature(body *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *ListShardsRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -667,34 +639,25 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *ListShardsResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *ListShardsResponse_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	var offset int
 
 	for i := range x.Shards {
-		n, err = proto.NestedStructureMarshal(listShardsRespBodyShardsFNum, buf[offset:], x.Shards[i])
-		if err != nil {
-			return nil, err
-		}
-
-		offset += n
+		offset += proto.NestedStructureMarshal(listShardsRespBodyShardsFNum, buf[offset:], x.Shards[i])
 	}
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of list shards response body
@@ -738,7 +701,7 @@ func (x *ListShardsResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *ListShardsResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -778,44 +741,23 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *SetShardModeRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *SetShardModeRequest_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	offset := proto.BytesMarshal(setShardModeReqBodyShardIDFNum, buf, x.Shard_ID)
+	offset += proto.EnumMarshal(setShardModeReqBodyModeFNum, buf[offset:], int32(x.Mode))
+	proto.BoolMarshal(setShardModeReqBodyResetCounterFNum, buf[offset:], x.ResetErrorCounter)
 
-	n, err = proto.BytesMarshal(setShardModeReqBodyShardIDFNum, buf, x.Shard_ID)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.EnumMarshal(setShardModeReqBodyModeFNum, buf[offset:], int32(x.Mode))
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	_, err = proto.BoolMarshal(setShardModeReqBodyResetCounterFNum, buf[offset:], x.ResetErrorCounter)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of set shard mode response body
@@ -859,7 +801,7 @@ func (x *SetShardModeRequest) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *SetShardModeRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -875,12 +817,11 @@ func (x *SetShardModeRequest) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *SetShardModeResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *SetShardModeResponse_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of the set shard mode response body
@@ -914,7 +855,7 @@ func (x *SetShardModeResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *SetShardModeResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data
@@ -951,44 +892,23 @@ const (
 //
 // If buffer length is less than StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *DumpShardRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *DumpShardRequest_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	offset := proto.BytesMarshal(dumpShardReqBodyShardIDFNum, buf, x.Shard_ID)
+	offset += proto.StringMarshal(dumpShardReqBodyFilepathFNum, buf[offset:], x.Filepath)
+	proto.BoolMarshal(dumpShardReqBodyIgnoreErrorsFNum, buf[offset:], x.IgnoreErrors)
 
-	n, err = proto.BytesMarshal(dumpShardReqBodyShardIDFNum, buf, x.Shard_ID)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(dumpShardReqBodyFilepathFNum, buf[offset:], x.Filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	_, err = proto.BoolMarshal(dumpShardReqBodyIgnoreErrorsFNum, buf[offset:], x.IgnoreErrors)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of the request body in protobuf binary format.
@@ -1031,7 +951,7 @@ func (x *DumpShardRequest) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *DumpShardRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns size of the request signed data in bytes.
@@ -1045,12 +965,11 @@ func (x *DumpShardRequest) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *DumpShardResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *DumpShardResponse_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of the response body
@@ -1084,7 +1003,7 @@ func (x *DumpShardResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *DumpShardResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data.
@@ -1120,44 +1039,23 @@ const (
 //
 // If buffer length is less than StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *RestoreShardRequest_Body) StableMarshal(buf []byte) ([]byte, error) {
+func (x *RestoreShardRequest_Body) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	offset := proto.BytesMarshal(restoreShardReqBodyShardIDFNum, buf, x.Shard_ID)
+	offset += proto.StringMarshal(restoreShardReqBodyFilepathFNum, buf[offset:], x.Filepath)
+	proto.BoolMarshal(restoreShardReqBodyIgnoreErrorsFNum, buf[offset:], x.IgnoreErrors)
 
-	n, err = proto.BytesMarshal(restoreShardReqBodyShardIDFNum, buf, x.Shard_ID)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(restoreShardReqBodyFilepathFNum, buf[offset:], x.Filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	_, err = proto.BoolMarshal(restoreShardReqBodyIgnoreErrorsFNum, buf[offset:], x.IgnoreErrors)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of the request body in protobuf binary format.
@@ -1200,7 +1098,7 @@ func (x *RestoreShardRequest) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *RestoreShardRequest) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns size of the request signed data in bytes.
@@ -1214,12 +1112,11 @@ func (x *RestoreShardRequest) SignedDataSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *RestoreShardResponse_Body) StableMarshal(buf []byte) ([]byte, error) {
-	return buf, nil
+func (x *RestoreShardResponse_Body) StableMarshal(buf []byte) []byte {
+	return buf
 }
 
 // StableSize returns binary size of the response body
@@ -1253,7 +1150,7 @@ func (x *RestoreShardResponse) SetSignature(v *Signature) {
 //
 // Structures with the same field values have the same signed data.
 func (x *RestoreShardResponse) ReadSignedData(buf []byte) ([]byte, error) {
-	return x.GetBody().StableMarshal(buf)
+	return x.GetBody().StableMarshal(buf), nil
 }
 
 // SignedDataSize returns binary size of the signed data.

--- a/pkg/services/control/types.go
+++ b/pkg/services/control/types.go
@@ -52,48 +52,26 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *NodeInfo_Attribute) StableMarshal(buf []byte) ([]byte, error) {
+func (x *NodeInfo_Attribute) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
-
-	n, err = proto.StringMarshal(nodeAttrKeyFNum, buf[offset:], x.Key)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(nodeAttrValueFNum, buf[offset:], x.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
+	offset := proto.StringMarshal(nodeAttrKeyFNum, buf, x.Key)
+	offset += proto.StringMarshal(nodeAttrValueFNum, buf[offset:], x.Value)
 
 	for i := range x.Parents {
-		n, err = proto.StringMarshal(nodeAttrParentsFNum, buf[offset:], x.Parents[i])
-		if err != nil {
-			return nil, err
-		}
-
-		offset += n
+		offset += proto.StringMarshal(nodeAttrParentsFNum, buf[offset:], x.Parents[i])
 	}
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of node attribute
@@ -159,53 +137,28 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *NodeInfo) StableMarshal(buf []byte) ([]byte, error) {
+func (x *NodeInfo) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
-
-	n, err = proto.BytesMarshal(nodePubKeyFNum, buf[offset:], x.PublicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.RepeatedStringMarshal(nodeAddrFNum, buf[offset:], x.Addresses)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
+	offset := proto.BytesMarshal(nodePubKeyFNum, buf, x.PublicKey)
+	offset += proto.RepeatedStringMarshal(nodeAddrFNum, buf[offset:], x.Addresses)
 
 	for i := range x.Attributes {
-		n, err = proto.NestedStructureMarshal(nodeAttrsFNum, buf[offset:], x.Attributes[i])
-		if err != nil {
-			return nil, err
-		}
-
-		offset += n
+		offset += proto.NestedStructureMarshal(nodeAttrsFNum, buf[offset:], x.Attributes[i])
 	}
 
-	_, err = proto.EnumMarshal(nodeStateFNum, buf[offset:], int32(x.State))
-	if err != nil {
-		return nil, err
-	}
+	proto.EnumMarshal(nodeStateFNum, buf[offset:], int32(x.State))
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of node information
@@ -255,41 +208,25 @@ const (
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *Netmap) StableMarshal(buf []byte) ([]byte, error) {
+func (x *Netmap) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
-
-	n, err = proto.UInt64Marshal(netmapEpochFNum, buf[offset:], x.Epoch)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
+	offset := proto.UInt64Marshal(netmapEpochFNum, buf, x.Epoch)
 
 	for i := range x.Nodes {
-		n, err = proto.NestedStructureMarshal(netmapNodesFNum, buf[offset:], x.Nodes[i])
-		if err != nil {
-			return nil, err
-		}
-
-		offset += n
+		offset += proto.NestedStructureMarshal(netmapNodesFNum, buf[offset:], x.Nodes[i])
 	}
 
-	return buf, nil
+	return buf
 }
 
 // StableSize returns binary size of netmap  in protobuf binary format.
@@ -383,63 +320,24 @@ func (x *ShardInfo) StableSize() int {
 //
 // If buffer length is less than x.StableSize(), new buffer is allocated.
 //
-// Returns any error encountered which did not allow writing the data completely.
-// Otherwise, returns the buffer in which the data is written.
+// Returns the buffer in which the data is written.
 //
 // Structures with the same field values have the same binary format.
-func (x *ShardInfo) StableMarshal(buf []byte) ([]byte, error) {
+func (x *ShardInfo) StableMarshal(buf []byte) []byte {
 	if x == nil {
-		return []byte{}, nil
+		return []byte{}
 	}
 
 	if sz := x.StableSize(); len(buf) < sz {
 		buf = make([]byte, sz)
 	}
 
-	var (
-		offset, n int
-		err       error
-	)
+	offset := proto.BytesMarshal(shardInfoIDFNum, buf, x.Shard_ID)
+	offset += proto.StringMarshal(shardInfoMetabaseFNum, buf[offset:], x.MetabasePath)
+	offset += proto.StringMarshal(shardInfoBlobstorFNum, buf[offset:], x.BlobstorPath)
+	offset += proto.StringMarshal(shardInfoWriteCacheFNum, buf[offset:], x.WritecachePath)
+	offset += proto.EnumMarshal(shardInfoModeFNum, buf[offset:], int32(x.Mode))
+	proto.EnumMarshal(shardInfoErrorCountFNum, buf[offset:], int32(x.ErrorCount))
 
-	n, err = proto.BytesMarshal(shardInfoIDFNum, buf[offset:], x.Shard_ID)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(shardInfoMetabaseFNum, buf[offset:], x.MetabasePath)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(shardInfoBlobstorFNum, buf[offset:], x.BlobstorPath)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.StringMarshal(shardInfoWriteCacheFNum, buf[offset:], x.WritecachePath)
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	n, err = proto.EnumMarshal(shardInfoModeFNum, buf[offset:], int32(x.Mode))
-	if err != nil {
-		return nil, err
-	}
-
-	offset += n
-
-	_, err = proto.EnumMarshal(shardInfoErrorCountFNum, buf[offset:], int32(x.ErrorCount))
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return buf
 }

--- a/pkg/services/notificator/deps.go
+++ b/pkg/services/notificator/deps.go
@@ -1,12 +1,14 @@
 package notificator
 
-import objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+import (
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+)
 
 // NotificationSource is a source of object notifications.
 type NotificationSource interface {
 	// Iterate must iterate over all notifications for the
 	// provided epoch and call handler for all of them.
-	Iterate(epoch uint64, handler func(topic string, addr *objectSDKAddress.Address))
+	Iterate(epoch uint64, handler func(topic string, addr oid.Address))
 }
 
 // NotificationWriter notifies all the subscribers
@@ -14,5 +16,5 @@ type NotificationSource interface {
 type NotificationWriter interface {
 	// Notify must notify about an event generated
 	// from an object with a specific topic.
-	Notify(topic string, address *objectSDKAddress.Address)
+	Notify(topic string, address oid.Address)
 }

--- a/pkg/services/notificator/service.go
+++ b/pkg/services/notificator/service.go
@@ -3,7 +3,7 @@ package notificator
 import (
 	"fmt"
 
-	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -74,7 +74,7 @@ func (n *Notificator) ProcessEpoch(epoch uint64) {
 	logger := n.l.With(zap.Uint64("epoch", epoch))
 	logger.Debug("notificator: start processing object notifications")
 
-	n.ns.Iterate(epoch, func(topic string, addr *objectSDKAddress.Address) {
+	n.ns.Iterate(epoch, func(topic string, addr oid.Address) {
 		n.l.Debug("notificator: processing object notification",
 			zap.String("topic", topic),
 			zap.Stringer("address", addr),

--- a/pkg/services/object/acl/acl_test.go
+++ b/pkg/services/object/acl/acl_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	v2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/v2"
-	cidSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
@@ -14,7 +14,7 @@ import (
 
 type emptyEACLSource struct{}
 
-func (e emptyEACLSource) GetEACL(_ *cidSDK.ID) (*eaclSDK.Table, error) {
+func (e emptyEACLSource) GetEACL(_ cid.ID) (*eaclSDK.Table, error) {
 	return nil, nil
 }
 
@@ -40,11 +40,11 @@ func TestStickyCheck(t *testing.T) {
 
 		setSticky(&info, true)
 
-		require.True(t, checker.StickyBitCheck(info, usertest.ID()))
+		require.True(t, checker.StickyBitCheck(info, *usertest.ID()))
 
 		setSticky(&info, false)
 
-		require.True(t, checker.StickyBitCheck(info, usertest.ID()))
+		require.True(t, checker.StickyBitCheck(info, *usertest.ID()))
 	})
 
 	t.Run("owner ID and/or public key emptiness", func(t *testing.T) {
@@ -65,10 +65,10 @@ func TestStickyCheck(t *testing.T) {
 				info.SetSenderKey(nil)
 			}
 
-			var ownerID *user.ID
+			var ownerID user.ID
 
 			if withOwner {
-				ownerID = usertest.ID()
+				ownerID = *usertest.ID()
 			}
 
 			require.Equal(t, expected, checker.StickyBitCheck(info, ownerID))

--- a/pkg/services/object/acl/eacl/types.go
+++ b/pkg/services/object/acl/eacl/types.go
@@ -15,5 +15,5 @@ type Source interface {
 	//
 	// Must return pkg/core/container.ErrEACLNotFound if requested
 	// eACL table is not in source.
-	GetEACL(*cid.ID) (*eacl.Table, error)
+	GetEACL(cid.ID) (*eacl.Table, error)
 }

--- a/pkg/services/object/acl/eacl/v2/localstore.go
+++ b/pkg/services/object/acl/eacl/v2/localstore.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	objectSDKAddress "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type localStorage struct {
 	ls *engine.StorageEngine
 }
 
-func (s *localStorage) Head(addr *objectSDKAddress.Address) (*objectSDK.Object, error) {
+func (s *localStorage) Head(addr oid.Address) (*objectSDK.Object, error) {
 	if s.ls == nil {
 		return nil, io.ErrUnexpectedEOF
 	}

--- a/pkg/services/object/acl/eacl/v2/object.go
+++ b/pkg/services/object/acl/eacl/v2/object.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/acl"
-	cidSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type sysObjHdr struct {
@@ -26,7 +26,7 @@ func u64Value(v uint64) string {
 	return strconv.FormatUint(v, 10)
 }
 
-func headersFromObject(obj *object.Object, cid cidSDK.ID, oid *oidSDK.ID) []eaclSDK.Header {
+func headersFromObject(obj *object.Object, cnr cid.ID, oid *oid.ID) []eaclSDK.Header {
 	var count int
 	for obj := obj; obj != nil; obj = obj.Parent() {
 		count += 9 + len(obj.Attributes())
@@ -35,7 +35,7 @@ func headersFromObject(obj *object.Object, cid cidSDK.ID, oid *oidSDK.ID) []eacl
 	res := make([]eaclSDK.Header, 0, count)
 	for ; obj != nil; obj = obj.Parent() {
 		res = append(res,
-			cidHeader(cid),
+			cidHeader(cnr),
 			// creation epoch
 			sysObjHdr{
 				k: acl.FilterObjectCreationEpoch,

--- a/pkg/services/object/acl/eacl/v2/opts.go
+++ b/pkg/services/object/acl/eacl/v2/opts.go
@@ -2,8 +2,8 @@ package v2
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	cidSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 func WithObjectStorage(v ObjectStorage) Option {
@@ -37,14 +37,14 @@ func WithServiceResponse(resp Response, req Request) Option {
 	}
 }
 
-func WithCID(v cidSDK.ID) Option {
+func WithCID(v cid.ID) Option {
 	return func(c *cfg) {
-		c.cid = v
+		c.cnr = v
 	}
 }
 
-func WithOID(v *oidSDK.ID) Option {
+func WithOID(v *oid.ID) Option {
 	return func(c *cfg) {
-		c.oid = v
+		c.obj = v
 	}
 }

--- a/pkg/services/object/acl/v2/classifier.go
+++ b/pkg/services/object/acl/v2/classifier.go
@@ -7,7 +7,7 @@ import (
 
 	core "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
-	cidSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"go.uber.org/zap"
@@ -27,7 +27,7 @@ type classifyResult struct {
 
 func (c senderClassifier) classify(
 	req MetaWithToken,
-	idCnr cidSDK.ID,
+	idCnr cid.ID,
 	cnr *container.Container) (res *classifyResult, err error) {
 	ownerCnr := cnr.OwnerID()
 	if ownerCnr == nil {

--- a/pkg/services/object/acl/v2/request.go
+++ b/pkg/services/object/acl/v2/request.go
@@ -7,9 +7,9 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	sessionV2 "github.com/nspcc-dev/neofs-api-go/v2/session"
 	"github.com/nspcc-dev/neofs-sdk-go/bearer"
-	containerIDSDK "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	sessionSDK "github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
@@ -21,13 +21,13 @@ type RequestInfo struct {
 	requestRole eaclSDK.Role
 	isInnerRing bool
 	operation   eaclSDK.Operation // put, get, head, etc.
-	cnrOwner    *user.ID          // container owner
+	cnrOwner    user.ID           // container owner
 
-	idCnr containerIDSDK.ID
+	idCnr cid.ID
 
 	// optional for some request
 	// e.g. Put, Search
-	oid *oidSDK.ID
+	obj *oid.ID
 
 	senderKey []byte
 
@@ -54,17 +54,17 @@ func (r RequestInfo) Request() interface{} {
 }
 
 // ContainerOwner returns owner if the container.
-func (r RequestInfo) ContainerOwner() *user.ID {
+func (r RequestInfo) ContainerOwner() user.ID {
 	return r.cnrOwner
 }
 
 // ObjectID return object ID.
-func (r RequestInfo) ObjectID() *oidSDK.ID {
-	return r.oid
+func (r RequestInfo) ObjectID() *oid.ID {
+	return r.obj
 }
 
 // ContainerID return container ID.
-func (r RequestInfo) ContainerID() containerIDSDK.ID {
+func (r RequestInfo) ContainerID() cid.ID {
 	return r.idCnr
 }
 

--- a/pkg/services/object/acl/v2/types.go
+++ b/pkg/services/object/acl/v2/types.go
@@ -16,7 +16,7 @@ type ACLChecker interface {
 	// StickyBitCheck must return true only if sticky bit
 	// is disabled or enabled but request contains correct
 	// owner field.
-	StickyBitCheck(RequestInfo, *user.ID) bool
+	StickyBitCheck(RequestInfo, user.ID) bool
 }
 
 // InnerRingFetcher is an interface that must provide

--- a/pkg/services/object/delete/local.go
+++ b/pkg/services/object/delete/local.go
@@ -2,7 +2,7 @@ package deletesvc
 
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -32,13 +32,11 @@ func (exec *execCtx) formTombstone() (ok bool) {
 		return false
 	}
 
-	id, _ := exec.address().ObjectID()
-
 	exec.tombstone = object.NewTombstone()
 	exec.tombstone.SetExpirationEpoch(
 		exec.svc.netInfo.CurrentEpoch() + tsLifetime,
 	)
-	exec.addMembers([]oidSDK.ID{id})
+	exec.addMembers([]oid.ID{exec.address().Object()})
 
 	exec.log.Debug("forming split info...")
 

--- a/pkg/services/object/delete/prm.go
+++ b/pkg/services/object/delete/prm.go
@@ -2,19 +2,19 @@ package deletesvc
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // TombstoneAddressWriter is an interface of tombstone address setter.
 type TombstoneAddressWriter interface {
-	SetAddress(*addressSDK.Address)
+	SetAddress(address oid.Address)
 }
 
 // Prm groups parameters of Delete service call.
 type Prm struct {
 	common *util.CommonPrm
 
-	addr *addressSDK.Address
+	addr oid.Address
 
 	tombAddrWriter TombstoneAddressWriter
 }
@@ -25,7 +25,7 @@ func (p *Prm) SetCommonParameters(common *util.CommonPrm) {
 }
 
 // WithAddress sets address of the object to be removed.
-func (p *Prm) WithAddress(addr *addressSDK.Address) {
+func (p *Prm) WithAddress(addr oid.Address) {
 	p.addr = addr
 }
 

--- a/pkg/services/object/delete/service.go
+++ b/pkg/services/object/delete/service.go
@@ -7,7 +7,7 @@ import (
 	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"go.uber.org/zap"
 )
@@ -30,7 +30,7 @@ type NetworkInfo interface {
 
 	// Returns user ID of the local storage node. Result must not be nil.
 	// New tombstone objects will have the result as an owner ID if removal is executed w/o a session.
-	LocalNodeID() *user.ID
+	LocalNodeID() user.ID
 }
 
 type cfg struct {
@@ -40,18 +40,18 @@ type cfg struct {
 		// must return (nil, nil) for PHY objects
 		splitInfo(*execCtx) (*object.SplitInfo, error)
 
-		children(*execCtx) ([]oidSDK.ID, error)
+		children(*execCtx) ([]oid.ID, error)
 
 		// must return (nil, nil) for 1st object in chain
-		previous(*execCtx, *oidSDK.ID) (*oidSDK.ID, error)
+		previous(*execCtx, oid.ID) (*oid.ID, error)
 	}
 
 	searcher interface {
-		splitMembers(*execCtx) ([]oidSDK.ID, error)
+		splitMembers(*execCtx) ([]oid.ID, error)
 	}
 
 	placer interface {
-		put(*execCtx) (*oidSDK.ID, error)
+		put(*execCtx) (*oid.ID, error)
 	}
 
 	netInfo NetworkInfo

--- a/pkg/services/object/delete/util.go
+++ b/pkg/services/object/delete/util.go
@@ -7,8 +7,7 @@ import (
 	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put"
 	searchsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/search"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type headSvcWrapper getsvc.Service
@@ -18,10 +17,10 @@ type searchSvcWrapper searchsvc.Service
 type putSvcWrapper putsvc.Service
 
 type simpleIDWriter struct {
-	ids []oidSDK.ID
+	ids []oid.ID
 }
 
-func (w *headSvcWrapper) headAddress(exec *execCtx, addr *addressSDK.Address) (*object.Object, error) {
+func (w *headSvcWrapper) headAddress(exec *execCtx, addr oid.Address) (*object.Object, error) {
 	wr := getsvc.NewSimpleObjectWriter()
 
 	p := getsvc.HeadPrm{}
@@ -53,10 +52,10 @@ func (w *headSvcWrapper) splitInfo(exec *execCtx) (*object.SplitInfo, error) {
 	}
 }
 
-func (w *headSvcWrapper) children(exec *execCtx) ([]oidSDK.ID, error) {
+func (w *headSvcWrapper) children(exec *execCtx) ([]oid.ID, error) {
 	link, _ := exec.splitInfo.Link()
 
-	a := exec.newAddress(&link)
+	a := exec.newAddress(link)
 
 	linking, err := w.headAddress(exec, a)
 	if err != nil {
@@ -66,7 +65,7 @@ func (w *headSvcWrapper) children(exec *execCtx) ([]oidSDK.ID, error) {
 	return linking.Children(), nil
 }
 
-func (w *headSvcWrapper) previous(exec *execCtx, id *oidSDK.ID) (*oidSDK.ID, error) {
+func (w *headSvcWrapper) previous(exec *execCtx, id oid.ID) (*oid.ID, error) {
 	a := exec.newAddress(id)
 
 	h, err := w.headAddress(exec, a)
@@ -82,7 +81,7 @@ func (w *headSvcWrapper) previous(exec *execCtx, id *oidSDK.ID) (*oidSDK.ID, err
 	return nil, nil
 }
 
-func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]oidSDK.ID, error) {
+func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]oid.ID, error) {
 	fs := object.SearchFilters{}
 	fs.AddSplitIDFilter(object.MatchStringEqual, exec.splitInfo.SplitID())
 
@@ -102,13 +101,13 @@ func (w *searchSvcWrapper) splitMembers(exec *execCtx) ([]oidSDK.ID, error) {
 	return wr.ids, nil
 }
 
-func (s *simpleIDWriter) WriteIDs(ids []oidSDK.ID) error {
+func (s *simpleIDWriter) WriteIDs(ids []oid.ID) error {
 	s.ids = append(s.ids, ids...)
 
 	return nil
 }
 
-func (w *putSvcWrapper) put(exec *execCtx) (*oidSDK.ID, error) {
+func (w *putSvcWrapper) put(exec *execCtx) (*oid.ID, error) {
 	streamer, err := (*putsvc.Service)(w).Put(exec.context())
 	if err != nil {
 		return nil, err
@@ -135,5 +134,7 @@ func (w *putSvcWrapper) put(exec *execCtx) (*oidSDK.ID, error) {
 		return nil, err
 	}
 
-	return r.ObjectID(), nil
+	id := r.ObjectID()
+
+	return &id, nil
 }

--- a/pkg/services/object/delete/v2/util.go
+++ b/pkg/services/object/delete/v2/util.go
@@ -1,10 +1,14 @@
 package deletesvc
 
 import (
+	"errors"
+	"fmt"
+
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	deletesvc "github.com/nspcc-dev/neofs-node/pkg/services/object/delete"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type tombstoneBodyWriter struct {
@@ -12,6 +16,20 @@ type tombstoneBodyWriter struct {
 }
 
 func (s *Service) toPrm(req *objectV2.DeleteRequest, respBody *objectV2.DeleteResponseBody) (*deletesvc.Prm, error) {
+	body := req.GetBody()
+
+	addrV2 := body.GetAddress()
+	if addrV2 == nil {
+		return nil, errors.New("missing object address")
+	}
+
+	var addr oid.Address
+
+	err := addr.ReadFromV2(*addrV2)
+	if err != nil {
+		return nil, fmt.Errorf("invalid object address: %w", err)
+	}
+
 	commonPrm, err := util.CommonPrmFromV2(req)
 	if err != nil {
 		return nil, err
@@ -20,8 +38,7 @@ func (s *Service) toPrm(req *objectV2.DeleteRequest, respBody *objectV2.DeleteRe
 	p := new(deletesvc.Prm)
 	p.SetCommonParameters(commonPrm)
 
-	body := req.GetBody()
-	p.WithAddress(addressSDK.NewAddressFromV2(body.GetAddress()))
+	p.WithAddress(addr)
 	p.WithTombstoneAddressTarget(&tombstoneBodyWriter{
 		body: respBody,
 	})
@@ -29,6 +46,9 @@ func (s *Service) toPrm(req *objectV2.DeleteRequest, respBody *objectV2.DeleteRe
 	return p, nil
 }
 
-func (w *tombstoneBodyWriter) SetAddress(addr *addressSDK.Address) {
-	w.body.SetTombstone(addr.ToV2())
+func (w *tombstoneBodyWriter) SetAddress(addr oid.Address) {
+	var addrV2 refs.Address
+	addr.WriteToV2(&addrV2)
+
+	w.body.SetTombstone(&addrV2)
 }

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -6,7 +6,7 @@ import (
 	coreclient "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Prm groups parameters of Get service call.
@@ -44,7 +44,7 @@ type commonPrm struct {
 
 	common *util.CommonPrm
 
-	addr *addressSDK.Address
+	addr oid.Address
 
 	raw bool
 
@@ -111,7 +111,7 @@ func (p *commonPrm) SetRequestForwarder(f RequestForwarder) {
 }
 
 // WithAddress sets object address to be read.
-func (p *commonPrm) WithAddress(addr *addressSDK.Address) {
+func (p *commonPrm) WithAddress(addr oid.Address) {
 	p.addr = addr
 }
 

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -7,8 +7,9 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -38,7 +39,7 @@ type cfg struct {
 	}
 
 	traverserGenerator interface {
-		GenerateTraverser(*addressSDK.Address, uint64) (*placement.Traverser, error)
+		GenerateTraverser(cid.ID, *oid.ID, uint64) (*placement.Traverser, error)
 	}
 
 	currentEpochReceiver interface {

--- a/pkg/services/object/head/prm.go
+++ b/pkg/services/object/head/prm.go
@@ -1,14 +1,14 @@
 package headsvc
 
 import (
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type Prm struct {
-	addr *addressSDK.Address
+	addr oid.Address
 }
 
-func (p *Prm) WithAddress(v *addressSDK.Address) *Prm {
+func (p *Prm) WithAddress(v oid.Address) *Prm {
 	if p != nil {
 		p.addr = v
 	}

--- a/pkg/services/object/head/remote.go
+++ b/pkg/services/object/head/remote.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type ClientConstructor interface {
@@ -54,7 +54,7 @@ func (p *RemoteHeadPrm) WithNodeInfo(v *netmap.NodeInfo) *RemoteHeadPrm {
 }
 
 // WithObjectAddress sets object address.
-func (p *RemoteHeadPrm) WithObjectAddress(v *addressSDK.Address) *RemoteHeadPrm {
+func (p *RemoteHeadPrm) WithObjectAddress(v oid.Address) *RemoteHeadPrm {
 	if p != nil {
 		p.commonHeadPrm = new(Prm).WithAddress(v)
 	}

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -146,7 +146,7 @@ func (t *distributedTarget) iteratePlacement(f func(nodeDesc) error) (*transform
 	id, _ := t.obj.ID()
 
 	traverser, err := placement.NewTraverser(
-		append(t.traversal.opts, placement.ForObject(&id))...,
+		append(t.traversal.opts, placement.ForObject(id))...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("(%T) could not create object placement traverser: %w", t, err)
@@ -236,5 +236,5 @@ loop:
 	id, _ = t.obj.ID()
 
 	return new(transformer.AccessIdentifiers).
-		WithSelfID(&id), nil
+		WithSelfID(id), nil
 }

--- a/pkg/services/object/put/local.go
+++ b/pkg/services/object/put/local.go
@@ -35,5 +35,5 @@ func (t *localTarget) Close() (*transformer.AccessIdentifiers, error) {
 	id, _ := t.obj.ID()
 
 	return new(transformer.AccessIdentifiers).
-		WithSelfID(&id), nil
+		WithSelfID(id), nil
 }

--- a/pkg/services/object/put/res.go
+++ b/pkg/services/object/put/res.go
@@ -1,13 +1,13 @@
 package putsvc
 
 import (
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type PutResponse struct {
-	id *oidSDK.ID
+	id oid.ID
 }
 
-func (r *PutResponse) ObjectID() *oidSDK.ID {
+func (r *PutResponse) ObjectID() oid.ID {
 	return r.id
 }

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -148,7 +148,7 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 	}
 
 	// get container to store the object
-	cnr, err := p.cnrSrc.Get(&idCnr)
+	cnr, err := p.cnrSrc.Get(idCnr)
 	if err != nil {
 		return fmt.Errorf("(%T) could not get container by ID: %w", p, err)
 	}
@@ -162,7 +162,7 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 	if id, ok := prm.hdr.ID(); ok {
 		prm.traverseOpts = append(prm.traverseOpts,
 			// set identifier of the processing object
-			placement.ForObject(&id),
+			placement.ForObject(id),
 		)
 	}
 
@@ -262,11 +262,13 @@ func (p *Streamer) Close() (*PutResponse, error) {
 	}
 
 	id := ids.ParentID()
-	if id == nil {
-		id = ids.SelfID()
+	if id != nil {
+		return &PutResponse{
+			id: *id,
+		}, nil
 	}
 
 	return &PutResponse{
-		id: id,
+		id: ids.SelfID(),
 	}, nil
 }

--- a/pkg/services/object/search/exec.go
+++ b/pkg/services/object/search/exec.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -60,8 +60,8 @@ func (exec execCtx) isLocal() bool {
 	return exec.prm.common.LocalOnly()
 }
 
-func (exec *execCtx) containerID() *cid.ID {
-	return exec.prm.cid
+func (exec *execCtx) containerID() cid.ID {
+	return exec.prm.cnr
 }
 
 func (exec *execCtx) searchFilters() object.SearchFilters {
@@ -100,8 +100,8 @@ func (exec *execCtx) initEpoch() bool {
 	}
 }
 
-func (exec *execCtx) generateTraverser(cid *cid.ID) (*placement.Traverser, bool) {
-	t, err := exec.svc.traverserGenerator.generateTraverser(cid, exec.curProcEpoch)
+func (exec *execCtx) generateTraverser(cnr cid.ID) (*placement.Traverser, bool) {
+	t, err := exec.svc.traverserGenerator.generateTraverser(cnr, exec.curProcEpoch)
 
 	switch {
 	default:
@@ -133,7 +133,7 @@ func (exec execCtx) remoteClient(info client.NodeInfo) (searchClient, bool) {
 	return nil, false
 }
 
-func (exec *execCtx) writeIDList(ids []oidSDK.ID) {
+func (exec *execCtx) writeIDList(ids []oid.ID) {
 	err := exec.prm.writer.WriteIDs(ids)
 
 	switch {

--- a/pkg/services/object/search/prm.go
+++ b/pkg/services/object/search/prm.go
@@ -5,7 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Prm groups parameters of Get service call.
@@ -14,7 +14,7 @@ type Prm struct {
 
 	common *util.CommonPrm
 
-	cid *cid.ID
+	cnr cid.ID
 
 	filters object.SearchFilters
 
@@ -24,12 +24,12 @@ type Prm struct {
 // IDListWriter is an interface of target component
 // to write list of object identifiers.
 type IDListWriter interface {
-	WriteIDs([]oidSDK.ID) error
+	WriteIDs([]oid.ID) error
 }
 
 // RequestForwarder is a callback for forwarding of the
 // original Search requests.
-type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) ([]oidSDK.ID, error)
+type RequestForwarder func(coreclient.NodeInfo, coreclient.MultiAddressClient) ([]oid.ID, error)
 
 // SetCommonParameters sets common parameters of the operation.
 func (p *Prm) SetCommonParameters(common *util.CommonPrm) {
@@ -48,8 +48,8 @@ func (p *Prm) SetRequestForwarder(f RequestForwarder) {
 }
 
 // WithContainerID sets identifier of the container to search the objects.
-func (p *Prm) WithContainerID(id *cid.ID) {
-	p.cid = id
+func (p *Prm) WithContainerID(id cid.ID) {
+	p.cnr = id
 }
 
 // WithSearchFilters sets search filters.

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -22,7 +22,7 @@ type Service struct {
 type Option func(*cfg)
 
 type searchClient interface {
-	searchObjects(*execCtx, client.NodeInfo) ([]oidSDK.ID, error)
+	searchObjects(*execCtx, client.NodeInfo) ([]oid.ID, error)
 }
 
 type ClientConstructor interface {
@@ -33,7 +33,7 @@ type cfg struct {
 	log *logger.Logger
 
 	localStorage interface {
-		search(*execCtx) ([]oidSDK.ID, error)
+		search(*execCtx) ([]oid.ID, error)
 	}
 
 	clientConstructor interface {
@@ -41,7 +41,7 @@ type cfg struct {
 	}
 
 	traverserGenerator interface {
-		generateTraverser(*cid.ID, uint64) (*placement.Traverser, error)
+		generateTraverser(cid.ID, uint64) (*placement.Traverser, error)
 	}
 
 	currentEpochReceiver interface {

--- a/pkg/services/object/search/v2/streamer.go
+++ b/pkg/services/object/search/v2/streamer.go
@@ -4,14 +4,14 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	objectSvc "github.com/nspcc-dev/neofs-node/pkg/services/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type streamWriter struct {
 	stream objectSvc.SearchStream
 }
 
-func (s *streamWriter) WriteIDs(ids []oidSDK.ID) error {
+func (s *streamWriter) WriteIDs(ids []oid.ID) error {
 	r := new(object.SearchResponse)
 
 	body := new(object.SearchResponseBody)

--- a/pkg/services/object/search/v2/util.go
+++ b/pkg/services/object/search/v2/util.go
@@ -19,7 +19,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStream) (*searchsvc.Prm, error) {
@@ -59,7 +59,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 			return nil, err
 		}
 
-		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) ([]oidSDK.ID, error) {
+		p.SetRequestForwarder(groupAddressRequestForwarder(func(addr network.Address, c client.MultiAddressClient, pubkey []byte) ([]oid.ID, error) {
 			var err error
 
 			// once compose and resign forwarding request
@@ -91,7 +91,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 			// code below is copy-pasted from c.SearchObjects implementation,
 			// perhaps it is worth highlighting the utility function in neofs-api-go
 			var (
-				searchResult []oidSDK.ID
+				searchResult []oid.ID
 				resp         = new(objectV2.SearchResponse)
 			)
 
@@ -117,7 +117,7 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 				}
 
 				chunk := resp.GetBody().GetIDList()
-				var id oidSDK.ID
+				var id oid.ID
 
 				for i := range chunk {
 					err = id.ReadFromV2(chunk[i])
@@ -133,17 +133,17 @@ func (s *Service) toPrm(req *objectV2.SearchRequest, stream objectSvc.SearchStre
 		}))
 	}
 
-	p.WithContainerID(&id)
+	p.WithContainerID(id)
 	p.WithSearchFilters(object.NewSearchFiltersFromV2(body.GetFilters()))
 
 	return p, nil
 }
 
-func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) ([]oidSDK.ID, error)) searchsvc.RequestForwarder {
-	return func(info client.NodeInfo, c client.MultiAddressClient) ([]oidSDK.ID, error) {
+func groupAddressRequestForwarder(f func(network.Address, client.MultiAddressClient, []byte) ([]oid.ID, error)) searchsvc.RequestForwarder {
+	return func(info client.NodeInfo, c client.MultiAddressClient) ([]oid.ID, error) {
 		var (
 			firstErr error
-			res      []oidSDK.ID
+			res      []oid.ID
 
 			key = info.PublicKey()
 		)

--- a/pkg/services/object/util/key.go
+++ b/pkg/services/object/util/key.go
@@ -20,7 +20,7 @@ type SessionSource interface {
 	// token has not been created, has been expired
 	// of it is impossible to get information about the
 	// token Get must return nil.
-	Get(owner *user.ID, tokenID []byte) *storage.PrivateToken
+	Get(owner user.ID, tokenID []byte) *storage.PrivateToken
 }
 
 // KeyStorage represents private key storage of the local node.
@@ -62,7 +62,7 @@ func (s *KeyStorage) GetKey(info *SessionInfo) (*ecdsa.PrivateKey, error) {
 			return nil, fmt.Errorf("marshal ID: %w", err)
 		}
 
-		pToken := s.tokenStore.Get(&info.Owner, binID)
+		pToken := s.tokenStore.Get(info.Owner, binID)
 		if pToken != nil {
 			if pToken.ExpiredAt() <= s.networkState.CurrentEpoch() {
 				var errExpired apistatus.SessionTokenExpired

--- a/pkg/services/object_manager/placement/traverser_test.go
+++ b/pkg/services/object_manager/placement/traverser_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ type testBuilder struct {
 	vectors []netmap.Nodes
 }
 
-func (b testBuilder) BuildPlacement(*addressSDK.Address, *netmap.PlacementPolicy) ([]netmap.Nodes, error) {
+func (b testBuilder) BuildPlacement(cid.ID, *oid.ID, *netmap.PlacementPolicy) ([]netmap.Nodes, error) {
 	return b.vectors, nil
 }
 

--- a/pkg/services/object_manager/storagegroup/collect.go
+++ b/pkg/services/object_manager/storagegroup/collect.go
@@ -5,8 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	"github.com/nspcc-dev/tzhash/tz"
 )
@@ -15,19 +14,19 @@ import (
 // with information about members collected via HeadReceiver.
 //
 // Resulting storage group consists of physically stored objects only.
-func CollectMembers(r objutil.HeadReceiver, cnr *cid.ID, members []oidSDK.ID) (*storagegroup.StorageGroup, error) {
+func CollectMembers(r objutil.HeadReceiver, cnr cid.ID, members []oid.ID) (*storagegroup.StorageGroup, error) {
 	var (
 		sumPhySize uint64
-		phyMembers []oidSDK.ID
+		phyMembers []oid.ID
 		phyHashes  [][]byte
-		addr       = addressSDK.NewAddress()
+		addr       oid.Address
 		sg         storagegroup.StorageGroup
 	)
 
-	addr.SetContainerID(*cnr)
+	addr.SetContainer(cnr)
 
 	for i := range members {
-		addr.SetObjectID(members[i])
+		addr.SetObject(members[i])
 
 		if err := objutil.IterateAllSplitLeaves(r, addr, func(leaf *object.Object) {
 			id, ok := leaf.ID()

--- a/pkg/services/object_manager/tombstone/checker.go
+++ b/pkg/services/object_manager/tombstone/checker.go
@@ -7,7 +7,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -19,7 +19,7 @@ type Source interface {
 	//
 	// Tombstone MUST return (nil, nil) if requested tombstone is
 	// missing in the storage for the provided epoch.
-	Tombstone(ctx context.Context, a *addressSDK.Address, epoch uint64) (*object.Object, error)
+	Tombstone(ctx context.Context, a oid.Address, epoch uint64) (*object.Object, error)
 }
 
 // ExpirationChecker is a tombstone source wrapper.
@@ -44,8 +44,8 @@ type ExpirationChecker struct {
 //
 // If a tombstone was successfully fetched (regardless of its expiration)
 // it is cached in the LRU cache.
-func (g *ExpirationChecker) IsTombstoneAvailable(ctx context.Context, a *addressSDK.Address, epoch uint64) bool {
-	addrStr := a.String()
+func (g *ExpirationChecker) IsTombstoneAvailable(ctx context.Context, a oid.Address, epoch uint64) bool {
+	addrStr := a.EncodeToString()
 	log := g.log.With(zap.String("address", addrStr))
 
 	expEpoch, ok := g.cache.Get(addrStr)

--- a/pkg/services/object_manager/tombstone/source/source.go
+++ b/pkg/services/object_manager/tombstone/source/source.go
@@ -10,7 +10,7 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Source represents wrapper over the object service that
@@ -59,13 +59,13 @@ func (h *headerWriter) WriteHeader(o *objectSDK.Object) error {
 // Tombstone checks if the engine stores tombstone.
 // Returns nil, nil if the tombstone has been removed
 // or marked for removal.
-func (s Source) Tombstone(ctx context.Context, a *addressSDK.Address, _ uint64) (*object.Object, error) {
+func (s Source) Tombstone(ctx context.Context, a oid.Address, _ uint64) (*object.Object, error) {
 	var hr headerWriter
 
 	var headPrm getsvc.HeadPrm
 	headPrm.WithAddress(a)
 	headPrm.SetHeaderWriter(&hr)
-	headPrm.SetCommonParameters(&util.CommonPrm{}) //default values are ok for that operation
+	headPrm.SetCommonParameters(&util.CommonPrm{}) // default values are ok for that operation
 
 	err := s.s.Head(ctx, headPrm)
 	switch {

--- a/pkg/services/object_manager/transformer/fmt.go
+++ b/pkg/services/object_manager/transformer/fmt.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
@@ -71,7 +71,7 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 	f.obj.SetCreationEpoch(curEpoch)
 
 	var (
-		parID  *oidSDK.ID
+		parID  *oid.ID
 		parHdr *object.Object
 	)
 
@@ -107,7 +107,7 @@ func (f *formatter) Close() (*AccessIdentifiers, error) {
 	id, _ := f.obj.ID()
 
 	return new(AccessIdentifiers).
-		WithSelfID(&id).
+		WithSelfID(id).
 		WithParentID(parID).
 		WithParent(parHdr), nil
 }

--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/tzhash/tz"
 )
 
@@ -23,7 +23,7 @@ type payloadSizeLimiter struct {
 
 	currentHashers, parentHashers []*payloadChecksumHasher
 
-	previous []oidSDK.ID
+	previous []oid.ID
 
 	chunkWriter io.Writer
 
@@ -189,7 +189,7 @@ func (s *payloadSizeLimiter) release(close bool) (*AccessIdentifiers, error) {
 	}
 
 	// save identifier of the released object
-	s.previous = append(s.previous, *ids.SelfID())
+	s.previous = append(s.previous, ids.SelfID())
 
 	if withParent {
 		// generate and release linking object

--- a/pkg/services/object_manager/transformer/types.go
+++ b/pkg/services/object_manager/transformer/types.go
@@ -4,14 +4,16 @@ import (
 	"io"
 
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // AccessIdentifiers represents group of the object identifiers
 // that are returned after writing the object.
 // Consists of the ID of the stored object and the ID of the parent object.
 type AccessIdentifiers struct {
-	par, self *oidSDK.ID
+	par *oid.ID
+
+	self oid.ID
 
 	parHdr *object.Object
 }
@@ -50,16 +52,12 @@ type ObjectTarget interface {
 type TargetInitializer func() ObjectTarget
 
 // SelfID returns identifier of the written object.
-func (a *AccessIdentifiers) SelfID() *oidSDK.ID {
-	if a != nil {
-		return a.self
-	}
-
-	return nil
+func (a AccessIdentifiers) SelfID() oid.ID {
+	return a.self
 }
 
 // WithSelfID returns AccessIdentifiers with passed self identifier.
-func (a *AccessIdentifiers) WithSelfID(v *oidSDK.ID) *AccessIdentifiers {
+func (a *AccessIdentifiers) WithSelfID(v oid.ID) *AccessIdentifiers {
 	res := a
 	if res == nil {
 		res = new(AccessIdentifiers)
@@ -71,7 +69,7 @@ func (a *AccessIdentifiers) WithSelfID(v *oidSDK.ID) *AccessIdentifiers {
 }
 
 // ParentID return identifier of the parent of the written object.
-func (a *AccessIdentifiers) ParentID() *oidSDK.ID {
+func (a *AccessIdentifiers) ParentID() *oid.ID {
 	if a != nil {
 		return a.par
 	}
@@ -80,7 +78,7 @@ func (a *AccessIdentifiers) ParentID() *oidSDK.ID {
 }
 
 // WithParentID returns AccessIdentifiers with passed parent identifier.
-func (a *AccessIdentifiers) WithParentID(v *oidSDK.ID) *AccessIdentifiers {
+func (a *AccessIdentifiers) WithParentID(v *oid.ID) *AccessIdentifiers {
 	res := a
 	if res == nil {
 		res = new(AccessIdentifiers)

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/placement"
 	"github.com/nspcc-dev/neofs-node/pkg/services/replicator"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
 )
@@ -35,7 +35,7 @@ type Option func(*cfg)
 
 // RedundantCopyCallback is a callback to pass
 // the redundant local copy of the object.
-type RedundantCopyCallback func(*addressSDK.Address)
+type RedundantCopyCallback func(oid.Address)
 
 type cfg struct {
 	headTimeout time.Duration

--- a/pkg/services/policer/process.go
+++ b/pkg/services/policer/process.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ func (p *Policer) Run(ctx context.Context) {
 
 func (p *Policer) shardPolicyWorker(ctx context.Context) {
 	var (
-		addrs  []*addressSDK.Address
+		addrs  []oid.Address
 		cursor *engine.Cursor
 		err    error
 	)
@@ -48,7 +48,7 @@ func (p *Policer) shardPolicyWorker(ctx context.Context) {
 				return
 			default:
 				addr := addrs[i]
-				addrStr := addr.String()
+				addrStr := addr.EncodeToString()
 				err = p.taskPool.Submit(func() {
 					v, ok := p.cache.Get(addrStr)
 					if ok && time.Since(v.(time.Time)) < p.evictDuration {

--- a/pkg/services/policer/queue.go
+++ b/pkg/services/policer/queue.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type jobQueue struct {
 	localStorage *engine.StorageEngine
 }
 
-func (q *jobQueue) Select(cursor *engine.Cursor, count uint32) ([]*addressSDK.Address, *engine.Cursor, error) {
+func (q *jobQueue) Select(cursor *engine.Cursor, count uint32) ([]oid.Address, *engine.Cursor, error) {
 	prm := new(engine.ListWithCursorPrm)
 	prm.WithCursor(cursor)
 	prm.WithCount(count)

--- a/pkg/services/replicator/task.go
+++ b/pkg/services/replicator/task.go
@@ -2,14 +2,14 @@ package replicator
 
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	addressSDK "github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Task represents group of Replicator task parameters.
 type Task struct {
 	quantity uint32
 
-	addr *addressSDK.Address
+	addr oid.Address
 
 	nodes netmap.Nodes
 }
@@ -35,7 +35,7 @@ func (t *Task) WithCopiesNumber(v uint32) *Task {
 }
 
 // WithObjectAddress sets address of local object.
-func (t *Task) WithObjectAddress(v *addressSDK.Address) *Task {
+func (t *Task) WithObjectAddress(v oid.Address) *Task {
 	if t != nil {
 		t.addr = v
 	}

--- a/pkg/services/session/storage/persistent/executor_test.go
+++ b/pkg/services/session/storage/persistent/executor_test.go
@@ -22,7 +22,7 @@ func TestTokenStore(t *testing.T) {
 
 	defer ts.Close()
 
-	owner := usertest.ID()
+	owner := *usertest.ID()
 
 	var ownerV2 refs.OwnerID
 	owner.WriteToV2(&ownerV2)
@@ -66,7 +66,7 @@ func TestTokenStore_Persistent(t *testing.T) {
 	ts, err := NewTokenStore(path)
 	require.NoError(t, err)
 
-	idOwner := usertest.ID()
+	idOwner := *usertest.ID()
 
 	var idOwnerV2 refs.OwnerID
 	idOwner.WriteToV2(&idOwnerV2)
@@ -127,7 +127,7 @@ func TestTokenStore_RemoveOld(t *testing.T) {
 
 	defer ts.Close()
 
-	owner := usertest.ID()
+	owner := *usertest.ID()
 
 	var ownerV2 refs.OwnerID
 	owner.WriteToV2(&ownerV2)

--- a/pkg/services/session/storage/persistent/storage.go
+++ b/pkg/services/session/storage/persistent/storage.go
@@ -83,7 +83,7 @@ func NewTokenStore(path string, opts ...Option) (*TokenStore, error) {
 // Get returns private token corresponding to the given identifiers.
 //
 // Returns nil is there is no element in storage.
-func (s *TokenStore) Get(ownerID *user.ID, tokenID []byte) (t *storage.PrivateToken) {
+func (s *TokenStore) Get(ownerID user.ID, tokenID []byte) (t *storage.PrivateToken) {
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		rootBucket := tx.Bucket(sessionsBucket)
 

--- a/pkg/services/session/storage/temporary/storage.go
+++ b/pkg/services/session/storage/temporary/storage.go
@@ -36,7 +36,7 @@ func NewTokenStore() *TokenStore {
 // Get returns private token corresponding to the given identifiers.
 //
 // Returns nil is there is no element in storage.
-func (s *TokenStore) Get(ownerID *user.ID, tokenID []byte) *storage.PrivateToken {
+func (s *TokenStore) Get(ownerID user.ID, tokenID []byte) *storage.PrivateToken {
 	s.mtx.RLock()
 	t := s.tokens[key{
 		tokenID: base58.Encode(tokenID),


### PR DESCRIPTION
* closes #1408 

Core changes:
 * avoid package-colliding variable naming
 * avoid using pointers to IDs where unnecessary
 * avoid using `idSDK` import alias pattern
 * use `EncodeToString` for protocol string calculation and `String` for
  printing

@fyrchik @carpawell all integration tests are PASS except ACL ones, but they FAIL regardless of current changes. I suggest to merge this PR and fix PR in a separate one.