### PR TITLE
Fix/Do not use `Res` pointers in SE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog for NeoFS Node
 
 ## [Unreleased]
 
+### Changed
+- Replace pointers with raw structures in results for local storage (#1460)
+
 ## [0.28.2] - 2022-06-03
 
 ### Updated

--- a/pkg/local_object_storage/blobovnicza/delete.go
+++ b/pkg/local_object_storage/blobovnicza/delete.go
@@ -29,7 +29,7 @@ func (p *DeletePrm) SetAddress(addr oid.Address) {
 // Returns an error of type apistatus.ObjectNotFound if the object to be deleted is not in blobovnicza.
 //
 // Should not be called in read-only configuration.
-func (b *Blobovnicza) Delete(prm DeletePrm) (*DeleteRes, error) {
+func (b *Blobovnicza) Delete(prm DeletePrm) (DeleteRes, error) {
 	addrKey := addressKey(prm.addr)
 
 	removed := false
@@ -67,8 +67,8 @@ func (b *Blobovnicza) Delete(prm DeletePrm) (*DeleteRes, error) {
 	if err == nil && !removed {
 		var errNotFound apistatus.ObjectNotFound
 
-		return nil, errNotFound
+		return DeleteRes{}, errNotFound
 	}
 
-	return nil, err
+	return DeleteRes{}, err
 }

--- a/pkg/local_object_storage/blobovnicza/get.go
+++ b/pkg/local_object_storage/blobovnicza/get.go
@@ -35,7 +35,7 @@ func (p GetRes) Object() []byte {
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is not
 // presented in Blobovnicza.
-func (b *Blobovnicza) Get(prm GetPrm) (*GetRes, error) {
+func (b *Blobovnicza) Get(prm GetPrm) (GetRes, error) {
 	var (
 		data    []byte
 		addrKey = addressKey(prm.addr)
@@ -58,16 +58,16 @@ func (b *Blobovnicza) Get(prm GetPrm) (*GetRes, error) {
 			return stop, nil
 		})
 	}); err != nil {
-		return nil, err
+		return GetRes{}, err
 	}
 
 	if data == nil {
 		var errNotFound apistatus.ObjectNotFound
 
-		return nil, errNotFound
+		return GetRes{}, errNotFound
 	}
 
-	return &GetRes{
+	return GetRes{
 		obj: data,
 	}, nil
 }

--- a/pkg/local_object_storage/blobovnicza/get.go
+++ b/pkg/local_object_storage/blobovnicza/get.go
@@ -24,7 +24,7 @@ func (p *GetPrm) SetAddress(addr oid.Address) {
 }
 
 // Object returns binary representation of the requested object.
-func (p *GetRes) Object() []byte {
+func (p GetRes) Object() []byte {
 	return p.obj
 }
 

--- a/pkg/local_object_storage/blobovnicza/iterate.go
+++ b/pkg/local_object_storage/blobovnicza/iterate.go
@@ -117,7 +117,7 @@ type IterateRes struct {
 // Returns handler's errors directly. Returns nil after iterating finish.
 //
 // Handler should not retain object data. Handler must not be nil.
-func (b *Blobovnicza) Iterate(prm IteratePrm) (*IterateRes, error) {
+func (b *Blobovnicza) Iterate(prm IteratePrm) (IterateRes, error) {
 	var elem IterationElement
 
 	if err := b.boltDB.View(func(tx *bbolt.Tx) error {
@@ -140,10 +140,10 @@ func (b *Blobovnicza) Iterate(prm IteratePrm) (*IterateRes, error) {
 			})
 		})
 	}); err != nil {
-		return nil, err
+		return IterateRes{}, err
 	}
 
-	return new(IterateRes), nil
+	return IterateRes{}, nil
 }
 
 // IterateObjects is a helper function which iterates over Blobovnicza and passes binary objects to f.

--- a/pkg/local_object_storage/blobovnicza/put.go
+++ b/pkg/local_object_storage/blobovnicza/put.go
@@ -47,7 +47,7 @@ func (p *PutPrm) SetMarshaledObject(data []byte) {
 // Returns ErrFull if blobovnicza is filled.
 //
 // Should not be called in read-only configuration.
-func (b *Blobovnicza) Put(prm PutPrm) (*PutRes, error) {
+func (b *Blobovnicza) Put(prm PutPrm) (PutRes, error) {
 	sz := uint64(len(prm.objData))
 	bucketName := bucketForSize(sz)
 	key := addressKey(prm.addr)
@@ -76,7 +76,7 @@ func (b *Blobovnicza) Put(prm PutPrm) (*PutRes, error) {
 		b.incSize(sz)
 	}
 
-	return nil, err
+	return PutRes{}, err
 }
 
 func addressKey(addr oid.Address) []byte {

--- a/pkg/local_object_storage/blobstor/delete_big.go
+++ b/pkg/local_object_storage/blobstor/delete_big.go
@@ -22,7 +22,7 @@ type DeleteBigRes struct{}
 // to completely remove the object.
 //
 // Returns an error of type apistatus.ObjectNotFound if there is no object to delete.
-func (b *BlobStor) DeleteBig(prm DeleteBigPrm) (*DeleteBigRes, error) {
+func (b *BlobStor) DeleteBig(prm DeleteBigPrm) (DeleteBigRes, error) {
 	err := b.fsTree.Delete(prm.addr)
 	if errors.Is(err, fstree.ErrFileNotFound) {
 		var errNotFound apistatus.ObjectNotFound
@@ -34,5 +34,5 @@ func (b *BlobStor) DeleteBig(prm DeleteBigPrm) (*DeleteBigRes, error) {
 		storagelog.Write(b.log, storagelog.AddressField(prm.addr), storagelog.OpField("fstree DELETE"))
 	}
 
-	return nil, err
+	return DeleteBigRes{}, err
 }

--- a/pkg/local_object_storage/blobstor/delete_small.go
+++ b/pkg/local_object_storage/blobstor/delete_small.go
@@ -18,6 +18,6 @@ type DeleteSmallRes struct{}
 // to completely remove the object.
 //
 // Returns an error of type apistatus.ObjectNotFound if there is no object to delete.
-func (b *BlobStor) DeleteSmall(prm DeleteSmallPrm) (*DeleteSmallRes, error) {
+func (b *BlobStor) DeleteSmall(prm DeleteSmallPrm) (DeleteSmallRes, error) {
 	return b.blobovniczas.delete(prm)
 }

--- a/pkg/local_object_storage/blobstor/exists.go
+++ b/pkg/local_object_storage/blobstor/exists.go
@@ -29,7 +29,7 @@ func (r ExistsRes) Exists() bool {
 //
 // Returns any error encountered that did not allow
 // to completely check object existence.
-func (b *BlobStor) Exists(prm ExistsPrm) (*ExistsRes, error) {
+func (b *BlobStor) Exists(prm ExistsPrm) (ExistsRes, error) {
 	// check presence in shallow dir first (cheaper)
 	exists, err := b.existsBig(prm.addr)
 
@@ -58,9 +58,10 @@ func (b *BlobStor) Exists(prm ExistsPrm) (*ExistsRes, error) {
 	}
 
 	if err != nil {
-		return nil, err
+		return ExistsRes{}, err
 	}
-	return &ExistsRes{exists: exists}, err
+
+	return ExistsRes{exists: exists}, err
 }
 
 // checks if object is presented in shallow dir.

--- a/pkg/local_object_storage/blobstor/get_big.go
+++ b/pkg/local_object_storage/blobstor/get_big.go
@@ -26,31 +26,31 @@ type GetBigRes struct {
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is not
 // presented in shallow dir.
-func (b *BlobStor) GetBig(prm GetBigPrm) (*GetBigRes, error) {
+func (b *BlobStor) GetBig(prm GetBigPrm) (GetBigRes, error) {
 	// get compressed object data
 	data, err := b.fsTree.Get(prm.addr)
 	if err != nil {
 		if errors.Is(err, fstree.ErrFileNotFound) {
 			var errNotFound apistatus.ObjectNotFound
 
-			return nil, errNotFound
+			return GetBigRes{}, errNotFound
 		}
 
-		return nil, fmt.Errorf("could not read object from fs tree: %w", err)
+		return GetBigRes{}, fmt.Errorf("could not read object from fs tree: %w", err)
 	}
 
 	data, err = b.decompressor(data)
 	if err != nil {
-		return nil, fmt.Errorf("could not decompress object data: %w", err)
+		return GetBigRes{}, fmt.Errorf("could not decompress object data: %w", err)
 	}
 
 	// unmarshal the object
 	obj := objectSDK.New()
 	if err := obj.Unmarshal(data); err != nil {
-		return nil, fmt.Errorf("could not unmarshal the object: %w", err)
+		return GetBigRes{}, fmt.Errorf("could not unmarshal the object: %w", err)
 	}
 
-	return &GetBigRes{
+	return GetBigRes{
 		roObject: roObject{
 			obj: obj,
 		},

--- a/pkg/local_object_storage/blobstor/get_range_big.go
+++ b/pkg/local_object_storage/blobstor/get_range_big.go
@@ -28,38 +28,38 @@ type GetRangeBigRes struct {
 //
 // Returns ErrRangeOutOfBounds if the requested object range is out of bounds.
 // Returns an error of type apistatus.ObjectNotFound if object is missing.
-func (b *BlobStor) GetRangeBig(prm GetRangeBigPrm) (*GetRangeBigRes, error) {
+func (b *BlobStor) GetRangeBig(prm GetRangeBigPrm) (GetRangeBigRes, error) {
 	// get compressed object data
 	data, err := b.fsTree.Get(prm.addr)
 	if err != nil {
 		if errors.Is(err, fstree.ErrFileNotFound) {
 			var errNotFound apistatus.ObjectNotFound
 
-			return nil, errNotFound
+			return GetRangeBigRes{}, errNotFound
 		}
 
-		return nil, fmt.Errorf("could not read object from fs tree: %w", err)
+		return GetRangeBigRes{}, fmt.Errorf("could not read object from fs tree: %w", err)
 	}
 
 	data, err = b.decompressor(data)
 	if err != nil {
-		return nil, fmt.Errorf("could not decompress object data: %w", err)
+		return GetRangeBigRes{}, fmt.Errorf("could not decompress object data: %w", err)
 	}
 
 	// unmarshal the object
 	obj := objectSDK.New()
 	if err := obj.Unmarshal(data); err != nil {
-		return nil, fmt.Errorf("could not unmarshal the object: %w", err)
+		return GetRangeBigRes{}, fmt.Errorf("could not unmarshal the object: %w", err)
 	}
 
 	payload := obj.Payload()
 	ln, off := prm.rng.GetLength(), prm.rng.GetOffset()
 
 	if pLen := uint64(len(payload)); pLen < ln+off {
-		return nil, object.ErrRangeOutOfBounds
+		return GetRangeBigRes{}, object.ErrRangeOutOfBounds
 	}
 
-	return &GetRangeBigRes{
+	return GetRangeBigRes{
 		rangeData: rangeData{
 			data: payload[off : off+ln],
 		},

--- a/pkg/local_object_storage/blobstor/get_range_small.go
+++ b/pkg/local_object_storage/blobstor/get_range_small.go
@@ -22,6 +22,6 @@ type GetRangeSmallRes struct {
 //
 // Returns ErrRangeOutOfBounds if the requested object range is out of bounds.
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in blobovnicza(s).
-func (b *BlobStor) GetRangeSmall(prm GetRangeSmallPrm) (*GetRangeSmallRes, error) {
+func (b *BlobStor) GetRangeSmall(prm GetRangeSmallPrm) (GetRangeSmallRes, error) {
 	return b.blobovniczas.getRange(prm)
 }

--- a/pkg/local_object_storage/blobstor/get_small.go
+++ b/pkg/local_object_storage/blobstor/get_small.go
@@ -20,6 +20,6 @@ type GetSmallRes struct {
 // did not allow to completely read the object.
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in blobovnicza(s).
-func (b *BlobStor) GetSmall(prm GetSmallPrm) (*GetSmallRes, error) {
+func (b *BlobStor) GetSmall(prm GetSmallPrm) (GetSmallRes, error) {
 	return b.blobovniczas.get(prm)
 }

--- a/pkg/local_object_storage/blobstor/iterate.go
+++ b/pkg/local_object_storage/blobstor/iterate.go
@@ -56,7 +56,7 @@ func (i *IteratePrm) IgnoreErrors() {
 // did not allow to completely iterate over the storage.
 //
 // If handler returns an error, method wraps and returns it immediately.
-func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
+func (b *BlobStor) Iterate(prm IteratePrm) (IterateRes, error) {
 	var elem IterationElement
 
 	err := b.blobovniczas.iterateBlobovniczas(prm.ignoreErrors, func(p string, blz *blobovnicza.Blobovnicza) error {
@@ -83,7 +83,7 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("blobovniczas iterator failure: %w", err)
+		return IterateRes{}, fmt.Errorf("blobovniczas iterator failure: %w", err)
 	}
 
 	elem.blzID = nil
@@ -106,10 +106,10 @@ func (b *BlobStor) Iterate(prm IteratePrm) (*IterateRes, error) {
 	err = b.fsTree.Iterate(fsPrm)
 
 	if err != nil {
-		return nil, fmt.Errorf("fs tree iterator failure: %w", err)
+		return IterateRes{}, fmt.Errorf("fs tree iterator failure: %w", err)
 	}
 
-	return new(IterateRes), nil
+	return IterateRes{}, nil
 }
 
 // IterateBinaryObjects is a helper function which iterates over BlobStor and passes binary objects to f.

--- a/pkg/local_object_storage/engine/container.go
+++ b/pkg/local_object_storage/engine/container.go
@@ -42,7 +42,7 @@ func (r ListContainersRes) Containers() []cid.ID {
 // ContainerSize returns the sum of estimation container sizes among all shards.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) ContainerSize(prm ContainerSizePrm) (res *ContainerSizeRes, err error) {
+func (e *StorageEngine) ContainerSize(prm ContainerSizePrm) (res ContainerSizeRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.containerSize(prm)
 		return err
@@ -65,12 +65,10 @@ func ContainerSize(e *StorageEngine, id cid.ID) (uint64, error) {
 	return res.Size(), nil
 }
 
-func (e *StorageEngine) containerSize(prm ContainerSizePrm) (*ContainerSizeRes, error) {
+func (e *StorageEngine) containerSize(prm ContainerSizePrm) (res ContainerSizeRes, err error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddEstimateContainerSizeDuration)()
 	}
-
-	res := new(ContainerSizeRes)
 
 	e.iterateOverUnsortedShards(func(sh hashedShard) (stop bool) {
 		size, err := shard.ContainerSize(sh.Shard, prm.cnr)
@@ -86,13 +84,13 @@ func (e *StorageEngine) containerSize(prm ContainerSizePrm) (*ContainerSizeRes, 
 		return false
 	})
 
-	return res, nil
+	return
 }
 
 // ListContainers returns a unique container IDs presented in the engine objects.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) ListContainers(_ ListContainersPrm) (res *ListContainersRes, err error) {
+func (e *StorageEngine) ListContainers(_ ListContainersPrm) (res ListContainersRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.listContainers()
 		return err
@@ -113,7 +111,7 @@ func ListContainers(e *StorageEngine) ([]cid.ID, error) {
 	return res.Containers(), nil
 }
 
-func (e *StorageEngine) listContainers() (*ListContainersRes, error) {
+func (e *StorageEngine) listContainers() (ListContainersRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddListContainersDuration)()
 	}
@@ -142,7 +140,7 @@ func (e *StorageEngine) listContainers() (*ListContainersRes, error) {
 		result = append(result, v)
 	}
 
-	return &ListContainersRes{
+	return ListContainersRes{
 		containers: result,
 	}, nil
 }

--- a/pkg/local_object_storage/engine/container.go
+++ b/pkg/local_object_storage/engine/container.go
@@ -70,7 +70,7 @@ func (e *StorageEngine) containerSize(prm ContainerSizePrm) (*ContainerSizeRes, 
 		defer elapsed(e.metrics.AddEstimateContainerSizeDuration)()
 	}
 
-	var res ContainerSizeRes
+	res := new(ContainerSizeRes)
 
 	e.iterateOverUnsortedShards(func(sh hashedShard) (stop bool) {
 		size, err := shard.ContainerSize(sh.Shard, prm.cnr)
@@ -86,7 +86,7 @@ func (e *StorageEngine) containerSize(prm ContainerSizePrm) (*ContainerSizeRes, 
 		return false
 	})
 
-	return &res, nil
+	return res, nil
 }
 
 // ListContainers returns a unique container IDs presented in the engine objects.

--- a/pkg/local_object_storage/engine/delete.go
+++ b/pkg/local_object_storage/engine/delete.go
@@ -31,7 +31,7 @@ func (p *DeletePrm) WithAddresses(addr ...oid.Address) {
 //
 // Returns apistatus.ObjectLocked if at least one object is locked.
 // In this case no object from the list is marked to be deleted.
-func (e *StorageEngine) Delete(prm DeletePrm) (res *DeleteRes, err error) {
+func (e *StorageEngine) Delete(prm DeletePrm) (res DeleteRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.delete(prm)
 		return err
@@ -40,7 +40,7 @@ func (e *StorageEngine) Delete(prm DeletePrm) (res *DeleteRes, err error) {
 	return
 }
 
-func (e *StorageEngine) delete(prm DeletePrm) (*DeleteRes, error) {
+func (e *StorageEngine) delete(prm DeletePrm) (DeleteRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddDeleteDuration)()
 	}
@@ -80,8 +80,8 @@ func (e *StorageEngine) delete(prm DeletePrm) (*DeleteRes, error) {
 	}
 
 	if locked.is {
-		return nil, locked.err
+		return DeleteRes{}, locked.err
 	}
 
-	return nil, nil
+	return DeleteRes{}, nil
 }

--- a/pkg/local_object_storage/engine/exists.go
+++ b/pkg/local_object_storage/engine/exists.go
@@ -24,7 +24,7 @@ func (e *StorageEngine) exists(addr oid.Address) (bool, error) {
 			e.reportShardError(sh, "could not check existence of object in shard", err)
 		}
 
-		if res != nil && !exists {
+		if !exists {
 			exists = res.Exists()
 		}
 

--- a/pkg/local_object_storage/engine/get.go
+++ b/pkg/local_object_storage/engine/get.go
@@ -31,7 +31,7 @@ func (p *GetPrm) WithAddress(addr oid.Address) {
 }
 
 // Object returns the requested object.
-func (r *GetRes) Object() *objectSDK.Object {
+func (r GetRes) Object() *objectSDK.Object {
 	return r.obj
 }
 

--- a/pkg/local_object_storage/engine/get.go
+++ b/pkg/local_object_storage/engine/get.go
@@ -44,7 +44,7 @@ func (r GetRes) Object() *objectSDK.Object {
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the object has been marked as removed.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) Get(prm GetPrm) (res *GetRes, err error) {
+func (e *StorageEngine) Get(prm GetPrm) (res GetRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.get(prm)
 		return err
@@ -53,7 +53,7 @@ func (e *StorageEngine) Get(prm GetPrm) (res *GetRes, err error) {
 	return
 }
 
-func (e *StorageEngine) get(prm GetPrm) (*GetRes, error) {
+func (e *StorageEngine) get(prm GetPrm) (GetRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddGetDuration)()
 	}
@@ -118,12 +118,12 @@ func (e *StorageEngine) get(prm GetPrm) (*GetRes, error) {
 	})
 
 	if outSI != nil {
-		return nil, objectSDK.NewSplitInfoError(outSI)
+		return GetRes{}, objectSDK.NewSplitInfoError(outSI)
 	}
 
 	if obj == nil {
 		if shardWithMeta.Shard == nil || !shard.IsErrNotFound(outError) {
-			return nil, outError
+			return GetRes{}, outError
 		}
 
 		// If the object is not found but is present in metabase,
@@ -137,13 +137,13 @@ func (e *StorageEngine) get(prm GetPrm) (*GetRes, error) {
 			return err == nil
 		})
 		if obj == nil {
-			return nil, outError
+			return GetRes{}, outError
 		}
 		e.reportShardError(shardWithMeta, "meta info was present, but object is missing",
 			metaError, zap.Stringer("address", prm.addr))
 	}
 
-	return &GetRes{
+	return GetRes{
 		obj: obj,
 	}, nil
 }

--- a/pkg/local_object_storage/engine/head.go
+++ b/pkg/local_object_storage/engine/head.go
@@ -42,7 +42,7 @@ func (p *HeadPrm) WithRaw(raw bool) {
 // Header returns the requested object header.
 //
 // Instance has empty payload.
-func (r *HeadRes) Header() *objectSDK.Object {
+func (r HeadRes) Header() *objectSDK.Object {
 	return r.head
 }
 

--- a/pkg/local_object_storage/engine/head.go
+++ b/pkg/local_object_storage/engine/head.go
@@ -55,7 +55,7 @@ func (r HeadRes) Header() *objectSDK.Object {
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the requested object was inhumed.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) Head(prm HeadPrm) (res *HeadRes, err error) {
+func (e *StorageEngine) Head(prm HeadPrm) (res HeadRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.head(prm)
 		return err
@@ -64,7 +64,7 @@ func (e *StorageEngine) Head(prm HeadPrm) (res *HeadRes, err error) {
 	return
 }
 
-func (e *StorageEngine) head(prm HeadPrm) (*HeadRes, error) {
+func (e *StorageEngine) head(prm HeadPrm) (HeadRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddHeadDuration)()
 	}
@@ -123,14 +123,14 @@ func (e *StorageEngine) head(prm HeadPrm) (*HeadRes, error) {
 	})
 
 	if outSI != nil {
-		return nil, objectSDK.NewSplitInfoError(outSI)
+		return HeadRes{}, objectSDK.NewSplitInfoError(outSI)
 	}
 
 	if head == nil {
-		return nil, outError
+		return HeadRes{}, outError
 	}
 
-	return &HeadRes{
+	return HeadRes{
 		head: head,
 	}, nil
 }

--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -51,7 +51,7 @@ var errInhumeFailure = errors.New("inhume operation failed")
 // if at least one object is locked.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) Inhume(prm InhumePrm) (res *InhumeRes, err error) {
+func (e *StorageEngine) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.inhume(prm)
 		return err
@@ -60,7 +60,7 @@ func (e *StorageEngine) Inhume(prm InhumePrm) (res *InhumeRes, err error) {
 	return
 }
 
-func (e *StorageEngine) inhume(prm InhumePrm) (*InhumeRes, error) {
+func (e *StorageEngine) inhume(prm InhumePrm) (InhumeRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddInhumeDuration)()
 	}
@@ -76,18 +76,18 @@ func (e *StorageEngine) inhume(prm InhumePrm) (*InhumeRes, error) {
 
 		switch e.inhumeAddr(prm.addrs[i], shPrm, true) {
 		case 1:
-			return nil, apistatus.ObjectLocked{}
+			return InhumeRes{}, apistatus.ObjectLocked{}
 		case 0:
 			switch e.inhumeAddr(prm.addrs[i], shPrm, false) {
 			case 1:
-				return nil, apistatus.ObjectLocked{}
+				return InhumeRes{}, apistatus.ObjectLocked{}
 			case 0:
-				return nil, errInhumeFailure
+				return InhumeRes{}, errInhumeFailure
 			}
 		}
 	}
 
-	return new(InhumeRes), nil
+	return InhumeRes{}, nil
 }
 
 // Returns:

--- a/pkg/local_object_storage/engine/list.go
+++ b/pkg/local_object_storage/engine/list.go
@@ -59,7 +59,7 @@ func (l ListWithCursorRes) Cursor() *Cursor {
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func (e *StorageEngine) ListWithCursor(prm ListWithCursorPrm) (*ListWithCursorRes, error) {
+func (e *StorageEngine) ListWithCursor(prm ListWithCursorPrm) (ListWithCursorRes, error) {
 	result := make([]oid.Address, 0, prm.count)
 
 	// 1. Get available shards and sort them.
@@ -71,7 +71,7 @@ func (e *StorageEngine) ListWithCursor(prm ListWithCursorPrm) (*ListWithCursorRe
 	e.mtx.RUnlock()
 
 	if len(shardIDs) == 0 {
-		return nil, ErrEndOfListing
+		return ListWithCursorRes{}, ErrEndOfListing
 	}
 
 	sort.Slice(shardIDs, func(i, j int) bool {
@@ -119,10 +119,10 @@ func (e *StorageEngine) ListWithCursor(prm ListWithCursorPrm) (*ListWithCursorRe
 	}
 
 	if len(result) == 0 {
-		return nil, ErrEndOfListing
+		return ListWithCursorRes{}, ErrEndOfListing
 	}
 
-	return &ListWithCursorRes{
+	return ListWithCursorRes{
 		addrList: result,
 		cursor:   cursor,
 	}, nil

--- a/pkg/local_object_storage/engine/put.go
+++ b/pkg/local_object_storage/engine/put.go
@@ -36,7 +36,7 @@ func (p *PutPrm) WithObject(obj *objectSDK.Object) {
 // Returns an error if executions are blocked (see BlockExecution).
 //
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the object has been marked as removed.
-func (e *StorageEngine) Put(prm PutPrm) (res *PutRes, err error) {
+func (e *StorageEngine) Put(prm PutPrm) (res PutRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.put(prm)
 		return err
@@ -45,7 +45,7 @@ func (e *StorageEngine) Put(prm PutPrm) (res *PutRes, err error) {
 	return
 }
 
-func (e *StorageEngine) put(prm PutPrm) (*PutRes, error) {
+func (e *StorageEngine) put(prm PutPrm) (PutRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddPutDuration)()
 	}
@@ -56,7 +56,7 @@ func (e *StorageEngine) put(prm PutPrm) (*PutRes, error) {
 	// much slower on fast machines for 4 shards.
 	_, err := e.exists(addr)
 	if err != nil {
-		return nil, err
+		return PutRes{}, err
 	}
 
 	var existPrm shard.ExistsPrm
@@ -125,7 +125,7 @@ func (e *StorageEngine) put(prm PutPrm) (*PutRes, error) {
 		err = errPutShard
 	}
 
-	return nil, err
+	return PutRes{}, err
 }
 
 // Put writes provided object to local storage.

--- a/pkg/local_object_storage/engine/range.go
+++ b/pkg/local_object_storage/engine/range.go
@@ -46,7 +46,7 @@ func (p *RngPrm) WithPayloadRange(rng *objectSDK.Range) {
 // Object returns the requested object part.
 //
 // Instance payload contains the requested range of the original object.
-func (r *RngRes) Object() *objectSDK.Object {
+func (r RngRes) Object() *objectSDK.Object {
 	return r.obj
 }
 

--- a/pkg/local_object_storage/engine/range.go
+++ b/pkg/local_object_storage/engine/range.go
@@ -60,7 +60,7 @@ func (r RngRes) Object() *objectSDK.Object {
 // Returns ErrRangeOutOfBounds if the requested object range is out of bounds.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) GetRange(prm RngPrm) (res *RngRes, err error) {
+func (e *StorageEngine) GetRange(prm RngPrm) (res RngRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.getRange(prm)
 		return err
@@ -69,7 +69,7 @@ func (e *StorageEngine) GetRange(prm RngPrm) (res *RngRes, err error) {
 	return
 }
 
-func (e *StorageEngine) getRange(prm RngPrm) (*RngRes, error) {
+func (e *StorageEngine) getRange(prm RngPrm) (RngRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddRangeDuration)()
 	}
@@ -137,12 +137,12 @@ func (e *StorageEngine) getRange(prm RngPrm) (*RngRes, error) {
 	})
 
 	if outSI != nil {
-		return nil, objectSDK.NewSplitInfoError(outSI)
+		return RngRes{}, objectSDK.NewSplitInfoError(outSI)
 	}
 
 	if obj == nil {
 		if shardWithMeta.Shard == nil || !shard.IsErrNotFound(outError) {
-			return nil, outError
+			return RngRes{}, outError
 		}
 
 		// If the object is not found but is present in metabase,
@@ -160,7 +160,7 @@ func (e *StorageEngine) getRange(prm RngPrm) (*RngRes, error) {
 			return err == nil
 		})
 		if obj == nil {
-			return nil, outError
+			return RngRes{}, outError
 		}
 		e.reportShardError(shardWithMeta, "meta info was present, but object is missing",
 			metaError,
@@ -168,7 +168,7 @@ func (e *StorageEngine) getRange(prm RngPrm) (*RngRes, error) {
 		)
 	}
 
-	return &RngRes{
+	return RngRes{
 		obj: obj,
 	}, nil
 }

--- a/pkg/local_object_storage/engine/select.go
+++ b/pkg/local_object_storage/engine/select.go
@@ -42,7 +42,7 @@ func (r SelectRes) AddressList() []oid.Address {
 // Returns any error encountered that did not allow to completely select the objects.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) Select(prm SelectPrm) (res *SelectRes, err error) {
+func (e *StorageEngine) Select(prm SelectPrm) (res SelectRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e._select(prm)
 		return err
@@ -51,7 +51,7 @@ func (e *StorageEngine) Select(prm SelectPrm) (res *SelectRes, err error) {
 	return
 }
 
-func (e *StorageEngine) _select(prm SelectPrm) (*SelectRes, error) {
+func (e *StorageEngine) _select(prm SelectPrm) (SelectRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddSearchDuration)()
 	}
@@ -82,7 +82,7 @@ func (e *StorageEngine) _select(prm SelectPrm) (*SelectRes, error) {
 		return false
 	})
 
-	return &SelectRes{
+	return SelectRes{
 		addrList: addrList,
 	}, outError
 }
@@ -91,7 +91,7 @@ func (e *StorageEngine) _select(prm SelectPrm) (*SelectRes, error) {
 // If limit is zero, then returns all available object addresses.
 //
 // Returns an error if executions are blocked (see BlockExecution).
-func (e *StorageEngine) List(limit uint64) (res *SelectRes, err error) {
+func (e *StorageEngine) List(limit uint64) (res SelectRes, err error) {
 	err = e.execIfNotBlocked(func() error {
 		res, err = e.list(limit)
 		return err
@@ -100,7 +100,7 @@ func (e *StorageEngine) List(limit uint64) (res *SelectRes, err error) {
 	return
 }
 
-func (e *StorageEngine) list(limit uint64) (*SelectRes, error) {
+func (e *StorageEngine) list(limit uint64) (SelectRes, error) {
 	if e.metrics != nil {
 		defer elapsed(e.metrics.AddListObjectsDuration)()
 	}
@@ -131,7 +131,7 @@ func (e *StorageEngine) list(limit uint64) (*SelectRes, error) {
 		return false
 	})
 
-	return &SelectRes{
+	return SelectRes{
 		addrList: addrList,
 	}, nil
 }

--- a/pkg/local_object_storage/engine/select.go
+++ b/pkg/local_object_storage/engine/select.go
@@ -33,7 +33,7 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []oid.Address {
+func (r SelectRes) AddressList() []oid.Address {
 	return r.addrList
 }
 

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -50,7 +50,7 @@ type referenceNumber struct {
 type referenceCounter map[string]*referenceNumber
 
 // Delete removed object records from metabase indexes.
-func (db *DB) Delete(prm DeletePrm) (*DeleteRes, error) {
+func (db *DB) Delete(prm DeletePrm) (DeleteRes, error) {
 	err := db.boltDB.Update(func(tx *bbolt.Tx) error {
 		return db.deleteGroup(tx, prm.addrs)
 	})
@@ -61,7 +61,7 @@ func (db *DB) Delete(prm DeletePrm) (*DeleteRes, error) {
 				storagelog.OpField("metabase DELETE"))
 		}
 	}
-	return nil, err
+	return DeleteRes{}, err
 }
 
 func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []oid.Address) error {

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -61,7 +61,7 @@ func (db *DB) Delete(prm DeletePrm) (*DeleteRes, error) {
 				storagelog.OpField("metabase DELETE"))
 		}
 	}
-	return new(DeleteRes), err
+	return nil, err
 }
 
 func (db *DB) deleteGroup(tx *bbolt.Tx, addrs []oid.Address) error {

--- a/pkg/local_object_storage/metabase/exists.go
+++ b/pkg/local_object_storage/metabase/exists.go
@@ -31,7 +31,7 @@ func (p *ExistsPrm) WithAddress(addr oid.Address) {
 }
 
 // Exists returns the fact that the object is in the metabase.
-func (p *ExistsRes) Exists() bool {
+func (p ExistsRes) Exists() bool {
 	return p.exists
 }
 
@@ -54,9 +54,7 @@ func Exists(db *DB, addr oid.Address) (bool, error) {
 // returns true if addr is in primary index or false if it is not.
 //
 // Returns an error of type apistatus.ObjectAlreadyRemoved if object has been placed in graveyard.
-func (db *DB) Exists(prm ExistsPrm) (res *ExistsRes, err error) {
-	res = new(ExistsRes)
-
+func (db *DB) Exists(prm ExistsPrm) (res ExistsRes, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
 		res.exists, err = db.exists(tx, prm.addr)
 

--- a/pkg/local_object_storage/metabase/get.go
+++ b/pkg/local_object_storage/metabase/get.go
@@ -40,7 +40,7 @@ func (p *GetPrm) WithRaw(raw bool) {
 }
 
 // Header returns the requested object header.
-func (r *GetRes) Header() *objectSDK.Object {
+func (r GetRes) Header() *objectSDK.Object {
 	return r.hdr
 }
 
@@ -75,9 +75,7 @@ func GetRaw(db *DB, addr oid.Address, raw bool) (*objectSDK.Object, error) {
 //
 // Returns an error of type apistatus.ObjectNotFound if object is missing in DB.
 // Returns an error of type apistatus.ObjectAlreadyRemoved if object has been placed in graveyard.
-func (db *DB) Get(prm GetPrm) (res *GetRes, err error) {
-	res = new(GetRes)
-
+func (db *DB) Get(prm GetPrm) (res GetRes, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
 		res.hdr, err = db.get(tx, prm.addr, true, prm.raw)
 

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -66,7 +66,7 @@ var errBreakBucketForEach = errors.New("bucket ForEach break")
 //
 // Allows inhuming non-locked objects only. Returns apistatus.ObjectLocked
 // if at least one object is locked.
-func (db *DB) Inhume(prm InhumePrm) (res *InhumeRes, err error) {
+func (db *DB) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 	err = db.boltDB.Update(func(tx *bbolt.Tx) error {
 		garbageBKT := tx.Bucket(garbageBucketName)
 

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -79,9 +79,8 @@ func ListWithCursor(db *DB, count uint32, cursor *Cursor) ([]oid.Address, *Curso
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func (db *DB) ListWithCursor(prm ListPrm) (res *ListRes, err error) {
+func (db *DB) ListWithCursor(prm ListPrm) (res ListRes, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
-		res = new(ListRes)
 		res.addrList, res.cursor, err = db.listWithCursor(tx, prm.count, prm.cursor)
 		return err
 	})

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -70,7 +70,7 @@ func Put(db *DB, obj *objectSDK.Object, id *blobovnicza.ID) error {
 // Big objects have nil blobovniczaID.
 //
 // Returns an error of type apistatus.ObjectAlreadyRemoved if object has been placed in graveyard.
-func (db *DB) Put(prm PutPrm) (res *PutRes, err error) {
+func (db *DB) Put(prm PutPrm) (res PutRes, err error) {
 	err = db.boltDB.Batch(func(tx *bbolt.Tx) error {
 		return db.put(tx, prm.obj, prm.id, nil)
 	})

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -54,7 +54,7 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []oid.Address {
+func (r SelectRes) AddressList() []oid.Address {
 	return r.addrList
 }
 

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -73,9 +73,7 @@ func Select(db *DB, cnr cid.ID, fs object.SearchFilters) ([]oid.Address, error) 
 }
 
 // Select returns list of addresses of objects that match search filters.
-func (db *DB) Select(prm SelectPrm) (res *SelectRes, err error) {
-	res = new(SelectRes)
-
+func (db *DB) Select(prm SelectPrm) (res SelectRes, err error) {
 	if blindlyProcess(prm.filters) {
 		return res, nil
 	}
@@ -525,8 +523,8 @@ func (db *DB) matchSlowFilters(tx *bbolt.Tx, addr oid.Address, f object.SearchFi
 // groupFilters divides filters in two groups: fast and slow. Fast filters
 // processed by indexes and slow filters processed after by unmarshaling
 // object headers.
-func groupFilters(filters object.SearchFilters) (*filterGroup, error) {
-	res := &filterGroup{
+func groupFilters(filters object.SearchFilters) (filterGroup, error) {
+	res := filterGroup{
 		fastFilters: make(object.SearchFilters, 0, len(filters)),
 		slowFilters: make(object.SearchFilters, 0, len(filters)),
 	}
@@ -536,7 +534,7 @@ func groupFilters(filters object.SearchFilters) (*filterGroup, error) {
 		case v2object.FilterHeaderContainerID: // support deprecated field
 			err := res.cnr.DecodeString(filters[i].Value())
 			if err != nil {
-				return nil, fmt.Errorf("can't parse container id: %w", err)
+				return filterGroup{}, fmt.Errorf("can't parse container id: %w", err)
 			}
 
 			res.withCnrFilter = true

--- a/pkg/local_object_storage/metabase/small.go
+++ b/pkg/local_object_storage/metabase/small.go
@@ -25,7 +25,7 @@ func (p *IsSmallPrm) WithAddress(addr oid.Address) {
 }
 
 // BlobovniczaID returns blobovnicza identifier.
-func (r *IsSmallRes) BlobovniczaID() *blobovnicza.ID {
+func (r IsSmallRes) BlobovniczaID() *blobovnicza.ID {
 	return r.id
 }
 

--- a/pkg/local_object_storage/metabase/small.go
+++ b/pkg/local_object_storage/metabase/small.go
@@ -48,9 +48,7 @@ func IsSmall(db *DB, addr oid.Address) (*blobovnicza.ID, error) {
 // Small objects stored in blobovnicza instances. Big objects stored in FS by
 // shallow path which is calculated from address and therefore it is not
 // indexed in metabase.
-func (db *DB) IsSmall(prm IsSmallPrm) (res *IsSmallRes, err error) {
-	res = new(IsSmallRes)
-
+func (db *DB) IsSmall(prm IsSmallPrm) (res IsSmallRes, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
 		res.id, err = db.isSmall(tx, prm.addr)
 

--- a/pkg/local_object_storage/shard/container.go
+++ b/pkg/local_object_storage/shard/container.go
@@ -20,7 +20,7 @@ func (p *ContainerSizePrm) WithContainerID(cnr cid.ID) {
 	}
 }
 
-func (r *ContainerSizeRes) Size() uint64 {
+func (r ContainerSizeRes) Size() uint64 {
 	return r.size
 }
 

--- a/pkg/local_object_storage/shard/container.go
+++ b/pkg/local_object_storage/shard/container.go
@@ -24,13 +24,13 @@ func (r ContainerSizeRes) Size() uint64 {
 	return r.size
 }
 
-func (s *Shard) ContainerSize(prm ContainerSizePrm) (*ContainerSizeRes, error) {
+func (s *Shard) ContainerSize(prm ContainerSizePrm) (ContainerSizeRes, error) {
 	size, err := s.metaBase.ContainerSize(prm.cnr)
 	if err != nil {
-		return nil, fmt.Errorf("could not get container size: %w", err)
+		return ContainerSizeRes{}, fmt.Errorf("could not get container size: %w", err)
 	}
 
-	return &ContainerSizeRes{
+	return ContainerSizeRes{
 		size: size,
 	}, nil
 }

--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -28,9 +28,9 @@ func (p *DeletePrm) WithAddresses(addr ...oid.Address) {
 
 // Delete removes data from the shard's writeCache, metaBase and
 // blobStor.
-func (s *Shard) Delete(prm DeletePrm) (*DeleteRes, error) {
+func (s *Shard) Delete(prm DeletePrm) (DeleteRes, error) {
 	if s.GetMode() != ModeReadWrite {
-		return nil, ErrReadOnlyMode
+		return DeleteRes{}, ErrReadOnlyMode
 	}
 
 	ln := len(prm.addr)
@@ -63,7 +63,7 @@ func (s *Shard) Delete(prm DeletePrm) (*DeleteRes, error) {
 
 	err := meta.Delete(s.metaBase, prm.addr...)
 	if err != nil {
-		return nil, err // stop on metabase error ?
+		return DeleteRes{}, err // stop on metabase error ?
 	}
 
 	for i := range prm.addr { // delete small object
@@ -93,5 +93,5 @@ func (s *Shard) Delete(prm DeletePrm) (*DeleteRes, error) {
 		}
 	}
 
-	return nil, nil
+	return DeleteRes{}, nil
 }

--- a/pkg/local_object_storage/shard/dump.go
+++ b/pkg/local_object_storage/shard/dump.go
@@ -42,7 +42,7 @@ type DumpRes struct {
 }
 
 // Count return amount of object written.
-func (r *DumpRes) Count() int {
+func (r DumpRes) Count() int {
 	return r.count
 }
 

--- a/pkg/local_object_storage/shard/dump.go
+++ b/pkg/local_object_storage/shard/dump.go
@@ -51,19 +51,19 @@ var ErrMustBeReadOnly = errors.New("shard must be in read-only mode")
 // Dump dumps all objects from the shard to a file or stream.
 //
 // Returns any error encountered.
-func (s *Shard) Dump(prm DumpPrm) (*DumpRes, error) {
+func (s *Shard) Dump(prm DumpPrm) (DumpRes, error) {
 	s.m.RLock()
 	defer s.m.RUnlock()
 
 	if s.info.Mode != ModeReadOnly {
-		return nil, ErrMustBeReadOnly
+		return DumpRes{}, ErrMustBeReadOnly
 	}
 
 	w := prm.stream
 	if w == nil {
 		f, err := os.OpenFile(prm.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 		if err != nil {
-			return nil, err
+			return DumpRes{}, err
 		}
 		defer f.Close()
 
@@ -72,7 +72,7 @@ func (s *Shard) Dump(prm DumpPrm) (*DumpRes, error) {
 
 	_, err := w.Write(dumpMagic)
 	if err != nil {
-		return nil, err
+		return DumpRes{}, err
 	}
 
 	var count int
@@ -98,7 +98,7 @@ func (s *Shard) Dump(prm DumpPrm) (*DumpRes, error) {
 
 		err := s.writeCache.Iterate(iterPrm)
 		if err != nil {
-			return nil, err
+			return DumpRes{}, err
 		}
 	}
 
@@ -125,8 +125,8 @@ func (s *Shard) Dump(prm DumpPrm) (*DumpRes, error) {
 	})
 
 	if _, err := s.blobStor.Iterate(pi); err != nil {
-		return nil, err
+		return DumpRes{}, err
 	}
 
-	return &DumpRes{count: count}, nil
+	return DumpRes{count: count}, nil
 }

--- a/pkg/local_object_storage/shard/exists.go
+++ b/pkg/local_object_storage/shard/exists.go
@@ -37,7 +37,7 @@ func (p ExistsRes) Exists() bool {
 // unambiguously determine the presence of an object.
 //
 // Returns an error of type apistatus.ObjectAlreadyRemoved if object has been marked as removed.
-func (s *Shard) Exists(prm ExistsPrm) (*ExistsRes, error) {
+func (s *Shard) Exists(prm ExistsPrm) (ExistsRes, error) {
 	exists, err := meta.Exists(s.metaBase, prm.addr)
 	if err != nil {
 		// If the shard is in degraded mode, try to consult blobstor directly.
@@ -57,7 +57,7 @@ func (s *Shard) Exists(prm ExistsPrm) (*ExistsRes, error) {
 		}
 	}
 
-	return &ExistsRes{
+	return ExistsRes{
 		ex: exists,
 	}, err
 }

--- a/pkg/local_object_storage/shard/exists.go
+++ b/pkg/local_object_storage/shard/exists.go
@@ -27,7 +27,7 @@ func (p *ExistsPrm) WithAddress(addr oid.Address) *ExistsPrm {
 }
 
 // Exists returns the fact that the object is in the shard.
-func (p *ExistsRes) Exists() bool {
+func (p ExistsRes) Exists() bool {
 	return p.ex
 }
 

--- a/pkg/local_object_storage/shard/get.go
+++ b/pkg/local_object_storage/shard/get.go
@@ -47,12 +47,12 @@ func (p *GetPrm) WithIgnoreMeta(ignore bool) {
 }
 
 // Object returns the requested object.
-func (r *GetRes) Object() *objectSDK.Object {
+func (r GetRes) Object() *objectSDK.Object {
 	return r.obj
 }
 
 // HasMeta returns true if info about the object was found in the metabase.
-func (r *GetRes) HasMeta() bool {
+func (r GetRes) HasMeta() bool {
 	return r.hasMeta
 }
 
@@ -63,7 +63,7 @@ func (r *GetRes) HasMeta() bool {
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in shard.
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the requested object has been marked as removed in shard.
-func (s *Shard) Get(prm GetPrm) (*GetRes, error) {
+func (s *Shard) Get(prm GetPrm) (GetRes, error) {
 	var big, small storFetcher
 
 	big = func(stor *blobstor.BlobStor, _ *blobovnicza.ID) (*objectSDK.Object, error) {
@@ -93,7 +93,7 @@ func (s *Shard) Get(prm GetPrm) (*GetRes, error) {
 
 	obj, hasMeta, err := s.fetchObjectData(prm.addr, prm.skipMeta, big, small)
 
-	return &GetRes{
+	return GetRes{
 		obj:     obj,
 		hasMeta: hasMeta,
 	}, err

--- a/pkg/local_object_storage/shard/get_test.go
+++ b/pkg/local_object_storage/shard/get_test.go
@@ -111,7 +111,7 @@ func testShardGet(t *testing.T, hasWriteCache bool) {
 	})
 }
 
-func testGet(t *testing.T, sh *shard.Shard, getPrm shard.GetPrm, hasWriteCache bool) (*shard.GetRes, error) {
+func testGet(t *testing.T, sh *shard.Shard, getPrm shard.GetPrm, hasWriteCache bool) (shard.GetRes, error) {
 	res, err := sh.Get(getPrm)
 	if hasWriteCache {
 		require.Eventually(t, func() bool {

--- a/pkg/local_object_storage/shard/head.go
+++ b/pkg/local_object_storage/shard/head.go
@@ -39,7 +39,7 @@ func (p *HeadPrm) WithRaw(raw bool) {
 }
 
 // Object returns the requested object header.
-func (r *HeadRes) Object() *objectSDK.Object {
+func (r HeadRes) Object() *objectSDK.Object {
 	return r.obj
 }
 
@@ -49,19 +49,19 @@ func (r *HeadRes) Object() *objectSDK.Object {
 //
 // Returns an error of type apistatus.ObjectNotFound if object is missing in Shard.
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the requested object has been marked as removed in shard.
-func (s *Shard) Head(prm HeadPrm) (*HeadRes, error) {
+func (s *Shard) Head(prm HeadPrm) (HeadRes, error) {
 	// object can be saved in write-cache (if enabled) or in metabase
 
 	if s.hasWriteCache() {
 		// try to read header from write-cache
 		header, err := s.writeCache.Head(prm.addr)
 		if err == nil {
-			return &HeadRes{
+			return HeadRes{
 				obj: header,
 			}, nil
 		} else if !writecache.IsErrNotFound(err) {
 			// in this case we think that object is presented in write-cache, but corrupted
-			return nil, fmt.Errorf("could not read header from write-cache: %w", err)
+			return HeadRes{}, fmt.Errorf("could not read header from write-cache: %w", err)
 		}
 
 		// otherwise object seems to be flushed to metabase
@@ -73,10 +73,10 @@ func (s *Shard) Head(prm HeadPrm) (*HeadRes, error) {
 
 	res, err := s.metaBase.Get(headParams)
 	if err != nil {
-		return nil, err
+		return HeadRes{}, err
 	}
 
-	return &HeadRes{
+	return HeadRes{
 		obj: res.Header(),
 	}, nil
 }

--- a/pkg/local_object_storage/shard/head_test.go
+++ b/pkg/local_object_storage/shard/head_test.go
@@ -80,7 +80,7 @@ func testShardHead(t *testing.T, hasWriteCache bool) {
 	})
 }
 
-func testHead(t *testing.T, sh *shard.Shard, headPrm shard.HeadPrm, hasWriteCache bool) (*shard.HeadRes, error) {
+func testHead(t *testing.T, sh *shard.Shard, headPrm shard.HeadPrm, hasWriteCache bool) (shard.HeadRes, error) {
 	res, err := sh.Head(headPrm)
 	if hasWriteCache {
 		require.Eventually(t, func() bool {

--- a/pkg/local_object_storage/shard/inhume.go
+++ b/pkg/local_object_storage/shard/inhume.go
@@ -75,5 +75,5 @@ func (s *Shard) Inhume(prm InhumePrm) (*InhumeRes, error) {
 		return nil, fmt.Errorf("metabase inhume: %w", err)
 	}
 
-	return new(InhumeRes), nil
+	return nil, nil
 }

--- a/pkg/local_object_storage/shard/inhume.go
+++ b/pkg/local_object_storage/shard/inhume.go
@@ -46,9 +46,9 @@ func (p *InhumePrm) MarkAsGarbage(addr ...oid.Address) {
 // if at least one object is locked.
 //
 // Returns ErrReadOnlyMode error if shard is in "read-only" mode.
-func (s *Shard) Inhume(prm InhumePrm) (*InhumeRes, error) {
+func (s *Shard) Inhume(prm InhumePrm) (InhumeRes, error) {
 	if s.GetMode() != ModeReadWrite {
-		return nil, ErrReadOnlyMode
+		return InhumeRes{}, ErrReadOnlyMode
 	}
 
 	if s.hasWriteCache() {
@@ -72,8 +72,8 @@ func (s *Shard) Inhume(prm InhumePrm) (*InhumeRes, error) {
 			zap.String("error", err.Error()),
 		)
 
-		return nil, fmt.Errorf("metabase inhume: %w", err)
+		return InhumeRes{}, fmt.Errorf("metabase inhume: %w", err)
 	}
 
-	return nil, nil
+	return InhumeRes{}, nil
 }

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -119,7 +119,6 @@ func (s *Shard) ListWithCursor(prm ListWithCursorPrm) (*ListWithCursorRes, error
 	var metaPrm meta.ListPrm
 	metaPrm.WithCount(prm.count)
 	metaPrm.WithCursor(prm.cursor)
-
 	res, err := s.metaBase.ListWithCursor(metaPrm)
 	if err != nil {
 		return nil, fmt.Errorf("could not get list of objects: %w", err)

--- a/pkg/local_object_storage/shard/list.go
+++ b/pkg/local_object_storage/shard/list.go
@@ -24,7 +24,7 @@ type ListContainersRes struct {
 	containers []cid.ID
 }
 
-func (r *ListContainersRes) Containers() []cid.ID {
+func (r ListContainersRes) Containers() []cid.ID {
 	return r.containers
 }
 
@@ -63,13 +63,12 @@ func (r ListWithCursorRes) Cursor() *Cursor {
 }
 
 // List returns all objects physically stored in the Shard.
-func (s *Shard) List() (*SelectRes, error) {
+func (s *Shard) List() (res SelectRes, err error) {
 	lst, err := s.metaBase.Containers()
 	if err != nil {
-		return nil, fmt.Errorf("can't list stored containers: %w", err)
+		return res, fmt.Errorf("can't list stored containers: %w", err)
 	}
 
-	res := new(SelectRes)
 	filters := object.NewSearchFilters()
 	filters.AddPhyFilter()
 
@@ -89,13 +88,13 @@ func (s *Shard) List() (*SelectRes, error) {
 	return res, nil
 }
 
-func (s *Shard) ListContainers(_ ListContainersPrm) (*ListContainersRes, error) {
+func (s *Shard) ListContainers(_ ListContainersPrm) (ListContainersRes, error) {
 	containers, err := s.metaBase.Containers()
 	if err != nil {
-		return nil, fmt.Errorf("could not get list of containers: %w", err)
+		return ListContainersRes{}, fmt.Errorf("could not get list of containers: %w", err)
 	}
 
-	return &ListContainersRes{
+	return ListContainersRes{
 		containers: containers,
 	}, nil
 }
@@ -115,16 +114,16 @@ func ListContainers(s *Shard) ([]cid.ID, error) {
 //
 // Returns ErrEndOfListing if there are no more objects to return or count
 // parameter set to zero.
-func (s *Shard) ListWithCursor(prm ListWithCursorPrm) (*ListWithCursorRes, error) {
+func (s *Shard) ListWithCursor(prm ListWithCursorPrm) (ListWithCursorRes, error) {
 	var metaPrm meta.ListPrm
 	metaPrm.WithCount(prm.count)
 	metaPrm.WithCursor(prm.cursor)
 	res, err := s.metaBase.ListWithCursor(metaPrm)
 	if err != nil {
-		return nil, fmt.Errorf("could not get list of objects: %w", err)
+		return ListWithCursorRes{}, fmt.Errorf("could not get list of objects: %w", err)
 	}
 
-	return &ListWithCursorRes{
+	return ListWithCursorRes{
 		addrList: res.AddressList(),
 		cursor:   res.Cursor(),
 	}, nil

--- a/pkg/local_object_storage/shard/move.go
+++ b/pkg/local_object_storage/shard/move.go
@@ -24,9 +24,9 @@ func (p *ToMoveItPrm) WithAddress(addr oid.Address) {
 
 // ToMoveIt calls metabase.ToMoveIt method to mark object as relocatable to
 // another shard.
-func (s *Shard) ToMoveIt(prm ToMoveItPrm) (*ToMoveItRes, error) {
+func (s *Shard) ToMoveIt(prm ToMoveItPrm) (ToMoveItRes, error) {
 	if s.GetMode() != ModeReadWrite {
-		return nil, ErrReadOnlyMode
+		return ToMoveItRes{}, ErrReadOnlyMode
 	}
 
 	err := meta.ToMoveIt(s.metaBase, prm.addr)
@@ -36,5 +36,5 @@ func (s *Shard) ToMoveIt(prm ToMoveItPrm) (*ToMoveItRes, error) {
 		)
 	}
 
-	return new(ToMoveItRes), nil
+	return ToMoveItRes{}, nil
 }

--- a/pkg/local_object_storage/shard/put.go
+++ b/pkg/local_object_storage/shard/put.go
@@ -55,7 +55,6 @@ func (s *Shard) Put(prm PutPrm) (*PutRes, error) {
 		res *blobstor.PutRes
 	)
 
-	// res == nil if there is no writeCache or writeCache.Put has been failed
 	if res, err = s.blobStor.Put(putPrm); err != nil {
 		return nil, fmt.Errorf("could not put object to BLOB storage: %w", err)
 	}

--- a/pkg/local_object_storage/shard/put.go
+++ b/pkg/local_object_storage/shard/put.go
@@ -52,7 +52,7 @@ func (s *Shard) Put(prm PutPrm) (PutRes, error) {
 
 	var (
 		err error
-		res *blobstor.PutRes
+		res blobstor.PutRes
 	)
 
 	if res, err = s.blobStor.Put(putPrm); err != nil {

--- a/pkg/local_object_storage/shard/range.go
+++ b/pkg/local_object_storage/shard/range.go
@@ -66,7 +66,7 @@ func (r RngRes) HasMeta() bool {
 // Returns ErrRangeOutOfBounds if the requested object range is out of bounds.
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing.
 // Returns an error of type apistatus.ObjectAlreadyRemoved if the requested object has been marked as removed in shard.
-func (s *Shard) GetRange(prm RngPrm) (*RngRes, error) {
+func (s *Shard) GetRange(prm RngPrm) (RngRes, error) {
 	var big, small storFetcher
 
 	rng := object.NewRange()
@@ -108,7 +108,7 @@ func (s *Shard) GetRange(prm RngPrm) (*RngRes, error) {
 
 	obj, hasMeta, err := s.fetchObjectData(prm.addr, prm.skipMeta, big, small)
 
-	return &RngRes{
+	return RngRes{
 		obj:     obj,
 		hasMeta: hasMeta,
 	}, err

--- a/pkg/local_object_storage/shard/range.go
+++ b/pkg/local_object_storage/shard/range.go
@@ -49,12 +49,12 @@ func (p *RngPrm) WithIgnoreMeta(ignore bool) {
 // Object returns the requested object part.
 //
 // Instance payload contains the requested range of the original object.
-func (r *RngRes) Object() *object.Object {
+func (r RngRes) Object() *object.Object {
 	return r.obj
 }
 
 // HasMeta returns true if info about the object was found in the metabase.
-func (r *RngRes) HasMeta() bool {
+func (r RngRes) HasMeta() bool {
 	return r.hasMeta
 }
 

--- a/pkg/local_object_storage/shard/restore.go
+++ b/pkg/local_object_storage/shard/restore.go
@@ -44,12 +44,12 @@ type RestoreRes struct {
 }
 
 // Count return amount of object written.
-func (r *RestoreRes) Count() int {
+func (r RestoreRes) Count() int {
 	return r.count
 }
 
 // FailCount return amount of object skipped.
-func (r *RestoreRes) FailCount() int {
+func (r RestoreRes) FailCount() int {
 	return r.failed
 }
 

--- a/pkg/local_object_storage/shard/select.go
+++ b/pkg/local_object_storage/shard/select.go
@@ -35,7 +35,7 @@ func (p *SelectPrm) WithFilters(fs object.SearchFilters) {
 }
 
 // AddressList returns list of addresses of the selected objects.
-func (r *SelectRes) AddressList() []oid.Address {
+func (r SelectRes) AddressList() []oid.Address {
 	return r.addrList
 }
 

--- a/pkg/local_object_storage/shard/select.go
+++ b/pkg/local_object_storage/shard/select.go
@@ -43,13 +43,13 @@ func (r SelectRes) AddressList() []oid.Address {
 //
 // Returns any error encountered that
 // did not allow to completely select the objects.
-func (s *Shard) Select(prm SelectPrm) (*SelectRes, error) {
+func (s *Shard) Select(prm SelectPrm) (SelectRes, error) {
 	addrList, err := meta.Select(s.metaBase, prm.cnr, prm.filters)
 	if err != nil {
-		return nil, fmt.Errorf("could not select objects from metabase: %w", err)
+		return SelectRes{}, fmt.Errorf("could not select objects from metabase: %w", err)
 	}
 
-	return &SelectRes{
+	return SelectRes{
 		addrList: addrList,
 	}, nil
 }


### PR DESCRIPTION
Based on and blocked by #1418.

Benchmark of the `meta.Get`:

Comparing just `*Res` -> `Res`:
```
name               old time/op    new time/op    delta
Get/1_objects-8      9.69µs ±13%    9.68µs ± 7%    ~     (p=0.954 n=10+10)
Get/10_objects-8      102µs ±10%     100µs ± 4%    ~     (p=0.393 n=10+10)
Get/100_objects-8    1.00ms ±10%    1.03ms ±13%    ~     (p=0.280 n=10+10)

name               old alloc/op   new alloc/op   delta
Get/1_objects-8      3.22kB ± 0%    3.22kB ± 0%  -0.25%  (p=0.000 n=9+9)
Get/10_objects-8     33.5kB ± 1%    33.4kB ± 1%  -0.38%  (p=0.010 n=9+10)
Get/100_objects-8     336kB ± 0%     335kB ± 0%    ~     (p=0.059 n=9+9)

name               old allocs/op  new allocs/op  delta
Get/1_objects-8        55.0 ± 0%      54.0 ± 0%  -1.82%  (p=0.000 n=9+9)
Get/10_objects-8        576 ± 1%       565 ± 1%  -1.88%  (p=0.001 n=10+10)
Get/100_objects-8     5.80k ± 0%     5.70k ± 0%  -1.71%  (p=0.000 n=9+9)
```

Comparing `Get(Prm) *Res` -> `Get(Prm, *Res)`:
```
name               old time/op    new time/op    delta
Get/1_objects-8      9.69µs ±13%    9.87µs ±21%    ~     (p=0.842 n=10+9)
Get/10_objects-8      102µs ±10%      99µs ± 5%    ~     (p=0.211 n=10+9)
Get/100_objects-8    1.00ms ±10%    1.00ms ± 5%    ~     (p=0.579 n=10+10)

name               old alloc/op   new alloc/op   delta
Get/1_objects-8      3.22kB ± 0%    3.22kB ± 0%  -0.25%  (p=0.000 n=9+9)
Get/10_objects-8     33.5kB ± 1%    33.5kB ± 1%    ~     (p=0.170 n=9+10)
Get/100_objects-8     336kB ± 0%     334kB ± 0%  -0.37%  (p=0.000 n=9+9)

name               old allocs/op  new allocs/op  delta
Get/1_objects-8        55.0 ± 0%      54.0 ± 0%  -1.82%  (p=0.000 n=9+9)
Get/10_objects-8        576 ± 1%       570 ± 0%  -1.02%  (p=0.026 n=10+8)
Get/100_objects-8     5.80k ± 0%     5.69k ± 0%  -1.75%  (p=0.000 n=9+9)
```

Seems almost equal but I do not like creating `Res` struct on the caller side and do not see real use cases when that could help much.