### PR TITLE
Fix/Unlock objects on deletion lock object

### DIFF
--- a/cmd/neofs-cli/internal/client/sdk.go
+++ b/cmd/neofs-cli/internal/client/sdk.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
@@ -60,7 +59,7 @@ func GetSDKClient(key *ecdsa.PrivateKey, addr network.Address) (*client.Client, 
 }
 
 // GetCurrentEpoch returns current epoch.
-func GetCurrentEpoch(endpoint string) (uint64, error) {
+func GetCurrentEpoch(ctx context.Context, endpoint string) (uint64, error) {
 	var addr network.Address
 
 	if err := addr.FromString(endpoint); err != nil {
@@ -76,9 +75,6 @@ func GetCurrentEpoch(endpoint string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
 
 	ni, err := c.NetworkInfo(ctx, client.PrmNetworkInfo{})
 	if err != nil {

--- a/cmd/neofs-cli/internal/common/epoch.go
+++ b/cmd/neofs-cli/internal/common/epoch.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+// ParseEpoch parses epoch argument. Second return value is true if
+// the specified epoch is relative, and false otherwise.
+func ParseEpoch(cmd *cobra.Command, flag string) (uint64, bool, error) {
+	s, _ := cmd.Flags().GetString(flag)
+	if len(s) == 0 {
+		return 0, false, nil
+	}
+
+	relative := s[0] == '+'
+	if relative {
+		s = s[1:]
+	}
+
+	epoch, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, relative, fmt.Errorf("can't parse epoch for %s argument: %w", flag, err)
+	}
+	return epoch, relative, nil
+}

--- a/cmd/neofs-cli/modules/bearer/create.go
+++ b/cmd/neofs-cli/modules/bearer/create.go
@@ -1,9 +1,11 @@
 package bearer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
@@ -69,8 +71,11 @@ func createToken(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if iatRelative || expRelative || nvbRelative {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
 		endpoint, _ := cmd.Flags().GetString(commonflags.RPC)
-		currEpoch, err := internalclient.GetCurrentEpoch(endpoint)
+		currEpoch, err := internalclient.GetCurrentEpoch(ctx, endpoint)
 		if err != nil {
 			return err
 		}

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -1,8 +1,10 @@
 package object
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
@@ -52,9 +54,12 @@ var objectLockCmd = &cobra.Command{
 		common.ExitOnErr(cmd, "Parsing expiration epoch: %w", err)
 
 		if relative {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
 			endpoint, _ := cmd.Flags().GetString(commonflags.RPC)
 
-			currEpoch, err := internalclient.GetCurrentEpoch(endpoint)
+			currEpoch, err := internalclient.GetCurrentEpoch(ctx, endpoint)
 			common.ExitOnErr(cmd, "Request current epoch: %w", err)
 
 			exp += currEpoch

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -36,6 +36,7 @@ func initControlService(c *cfg) {
 		controlSvc.WithDeletedObjectHandler(func(addrList []oid.Address) error {
 			var prm engine.DeletePrm
 			prm.WithAddresses(addrList...)
+			prm.WithForceRemoval()
 
 			_, err := c.cfgObject.cfgLocalStorage.localStorage.Delete(prm)
 

--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -242,9 +242,19 @@ func (v *FormatValidator) ValidateContent(o *object.Object) error {
 			return errors.New("missing ID")
 		}
 
+		// check that LOCK object has correct expiration epoch
+		lockExp, err := expirationEpochAttribute(o)
+		if err != nil {
+			return fmt.Errorf("lock object expiration epoch: %w", err)
+		}
+
+		if currEpoch := v.netState.CurrentEpoch(); lockExp <= currEpoch {
+			return fmt.Errorf("lock object expiration: %d; current: %d", lockExp, currEpoch)
+		}
+
 		var lock object.Lock
 
-		err := lock.Unmarshal(o.Payload())
+		err = lock.Unmarshal(o.Payload())
 		if err != nil {
 			return fmt.Errorf("decode lock payload: %w", err)
 		}

--- a/pkg/local_object_storage/engine/delete.go
+++ b/pkg/local_object_storage/engine/delete.go
@@ -11,6 +11,8 @@ import (
 // DeletePrm groups the parameters of Delete operation.
 type DeletePrm struct {
 	addr []oid.Address
+
+	forceRemoval bool
 }
 
 // DeleteRes groups the resulting values of Delete operation.
@@ -22,6 +24,15 @@ type DeleteRes struct{}
 func (p *DeletePrm) WithAddresses(addr ...oid.Address) {
 	if p != nil {
 		p.addr = append(p.addr, addr...)
+	}
+}
+
+// WithForceRemoval is a Delete option to remove an object despite any
+// restrictions imposed on deleting that object. Expected to be used
+// only in control service.
+func (p *DeletePrm) WithForceRemoval() {
+	if p != nil {
+		p.forceRemoval = true
 	}
 }
 
@@ -65,6 +76,9 @@ func (e *StorageEngine) delete(prm DeletePrm) (DeleteRes, error) {
 
 			var shPrm shard.InhumePrm
 			shPrm.MarkAsGarbage(prm.addr[i])
+			if prm.forceRemoval {
+				shPrm.ForceRemoval()
+			}
 
 			_, err = sh.Inhume(shPrm)
 			if err != nil {

--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -176,3 +176,17 @@ func (e *StorageEngine) processExpiredLocks(ctx context.Context, lockers []oid.A
 		}
 	})
 }
+
+func (e *StorageEngine) processDeletedLocks(ctx context.Context, lockers []oid.Address) {
+	e.iterateOverUnsortedShards(func(sh hashedShard) (stop bool) {
+		sh.HandleDeletedLocks(lockers)
+
+		select {
+		case <-ctx.Done():
+			e.log.Info("interrupt processing the deleted locks by context")
+			return true
+		default:
+			return false
+		}
+	})
+}

--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -15,6 +15,8 @@ import (
 type InhumePrm struct {
 	tombstone *oid.Address
 	addrs     []oid.Address
+
+	forceRemoval bool
 }
 
 // InhumeRes encapsulates results of inhume operation.
@@ -38,6 +40,15 @@ func (p *InhumePrm) WithTarget(tombstone oid.Address, addrs ...oid.Address) {
 func (p *InhumePrm) MarkAsGarbage(addrs ...oid.Address) {
 	if p != nil {
 		p.addrs = addrs
+		p.tombstone = nil
+	}
+}
+
+// WithForceRemoval inhumes objects specified via MarkAsGarbage with GC mark
+// without any object restrictions checks.
+func (p *InhumePrm) WithForceRemoval() {
+	if p != nil {
+		p.forceRemoval = true
 		p.tombstone = nil
 	}
 }
@@ -66,6 +77,9 @@ func (e *StorageEngine) inhume(prm InhumePrm) (InhumeRes, error) {
 	}
 
 	var shPrm shard.InhumePrm
+	if prm.forceRemoval {
+		shPrm.ForceRemoval()
+	}
 
 	for i := range prm.addrs {
 		if prm.tombstone != nil {

--- a/pkg/local_object_storage/engine/lock_test.go
+++ b/pkg/local_object_storage/engine/lock_test.go
@@ -9,6 +9,7 @@ import (
 
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
@@ -133,7 +134,7 @@ func TestLockUserScenario(t *testing.T) {
 	inhumePrm.WithTarget(tombForLockAddr, lockerAddr)
 
 	_, err = e.Inhume(inhumePrm)
-	require.NoError(t, err, new(apistatus.ObjectLocked))
+	require.ErrorIs(t, err, meta.ErrLockObjectRemoval)
 
 	// 5.
 	for i := range chEvents {

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -38,7 +38,7 @@ func (e *StorageEngine) AddShard(opts ...shard.Option) (*shard.ID, error) {
 		shard.WithID(id),
 		shard.WithExpiredTombstonesCallback(e.processExpiredTombstones),
 		shard.WithExpiredLocksCallback(e.processExpiredLocks),
-		shard.WitDeletedLockCallback(e.processDeletedLocks),
+		shard.WithDeletedLockCallback(e.processDeletedLocks),
 	)...)
 
 	if err := sh.UpdateID(); err != nil {

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -38,6 +38,7 @@ func (e *StorageEngine) AddShard(opts ...shard.Option) (*shard.ID, error) {
 		shard.WithID(id),
 		shard.WithExpiredTombstonesCallback(e.processExpiredTombstones),
 		shard.WithExpiredLocksCallback(e.processExpiredLocks),
+		shard.WitDeletedLockCallback(e.processDeletedLocks),
 	)...)
 
 	if err := sh.UpdateID(); err != nil {

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -93,6 +93,10 @@ func Inhume(db *DB, target, tomb oid.Address) error {
 
 var errBreakBucketForEach = errors.New("bucket ForEach break")
 
+// ErrLockObjectRemoval is returned when inhume operation is being
+// performed on lock object, and it is not a forced object removal.
+var ErrLockObjectRemoval = errors.New("lock object removal")
+
 // Inhume marks objects as removed but not removes it from metabase.
 //
 // Allows inhuming non-locked objects only. Returns apistatus.ObjectLocked
@@ -149,7 +153,7 @@ func (db *DB) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 			// `WithForceGCMark` option
 			if !prm.forceRemoval {
 				if isLockObject(tx, cnr, id) {
-					return fmt.Errorf("lock object removal, CID: %s, OID: %s", cnr, id)
+					return ErrLockObjectRemoval
 				}
 
 				lockWasChecked = true

--- a/pkg/local_object_storage/metabase/util.go
+++ b/pkg/local_object_storage/metabase/util.go
@@ -171,3 +171,8 @@ func firstIrregularObjectType(tx *bbolt.Tx, idCnr cid.ID, objs ...[]byte) object
 
 	return object.TypeRegular
 }
+
+// return true if provided object is of LOCK type.
+func isLockObject(tx *bbolt.Tx, idCnr cid.ID, obj oid.ID) bool {
+	return inBucket(tx, bucketNameLockers(idCnr), objectKey(obj))
+}

--- a/pkg/local_object_storage/shard/gc.go
+++ b/pkg/local_object_storage/shard/gc.go
@@ -395,3 +395,15 @@ func (s *Shard) HandleExpiredLocks(lockers []oid.Address) {
 		return
 	}
 }
+
+// HandleDeletedLocks unlocks all objects which were locked by lockers.
+func (s *Shard) HandleDeletedLocks(lockers []oid.Address) {
+	err := s.metaBase.FreeLockedBy(lockers)
+	if err != nil {
+		s.log.Warn("failure to unlock objects",
+			zap.String("error", err.Error()),
+		)
+
+		return
+	}
+}

--- a/pkg/local_object_storage/shard/lock_test.go
+++ b/pkg/local_object_storage/shard/lock_test.go
@@ -33,7 +33,7 @@ func TestShard_Lock(t *testing.T) {
 		shard.WithMetaBaseOptions(
 			meta.WithPath(filepath.Join(rootPath, "meta")),
 		),
-		shard.WitDeletedLockCallback(func(_ context.Context, addresses []oid.Address) {
+		shard.WithDeletedLockCallback(func(_ context.Context, addresses []oid.Address) {
 			sh.HandleDeletedLocks(addresses)
 		}),
 	}

--- a/pkg/local_object_storage/shard/lock_test.go
+++ b/pkg/local_object_storage/shard/lock_test.go
@@ -1,0 +1,128 @@
+package shard_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestShard_Lock(t *testing.T) {
+	var sh *shard.Shard
+
+	rootPath := t.TempDir()
+	opts := []shard.Option{
+		shard.WithLogger(zap.NewNop()),
+		shard.WithBlobStorOptions(
+			[]blobstor.Option{
+				blobstor.WithRootPath(filepath.Join(rootPath, "blob")),
+				blobstor.WithBlobovniczaShallowWidth(2),
+				blobstor.WithBlobovniczaShallowDepth(2),
+			}...,
+		),
+		shard.WithMetaBaseOptions(
+			meta.WithPath(filepath.Join(rootPath, "meta")),
+		),
+		shard.WitDeletedLockCallback(func(_ context.Context, addresses []oid.Address) {
+			sh.HandleDeletedLocks(addresses)
+		}),
+	}
+
+	sh = shard.New(opts...)
+	require.NoError(t, sh.Open())
+	require.NoError(t, sh.Init())
+
+	t.Cleanup(func() {
+		releaseShard(sh, t)
+	})
+
+	cnr := cidtest.ID()
+	obj := generateObjectWithCID(t, cnr)
+	objID, _ := obj.ID()
+
+	lock := generateObjectWithCID(t, cnr)
+	lock.SetType(object.TypeLock)
+	lockID, _ := lock.ID()
+
+	// put the object
+
+	var putPrm shard.PutPrm
+	putPrm.WithObject(obj)
+
+	_, err := sh.Put(putPrm)
+	require.NoError(t, err)
+
+	// lock the object
+
+	err = sh.Lock(cnr, lockID, []oid.ID{objID})
+	require.NoError(t, err)
+
+	putPrm.WithObject(lock)
+	_, err = sh.Put(putPrm)
+	require.NoError(t, err)
+
+	t.Run("inhuming locked objects", func(t *testing.T) {
+		ts := generateObjectWithCID(t, cnr)
+
+		var inhumePrm shard.InhumePrm
+		inhumePrm.WithTarget(objectcore.AddressOf(ts), objectcore.AddressOf(obj))
+
+		_, err = sh.Inhume(inhumePrm)
+		require.ErrorAs(t, err, new(apistatus.ObjectLocked))
+
+		inhumePrm.MarkAsGarbage(objectcore.AddressOf(obj))
+		_, err = sh.Inhume(inhumePrm)
+		require.ErrorAs(t, err, new(apistatus.ObjectLocked))
+	})
+
+	t.Run("inhuming lock objects", func(t *testing.T) {
+		ts := generateObjectWithCID(t, cnr)
+
+		var inhumePrm shard.InhumePrm
+		inhumePrm.WithTarget(objectcore.AddressOf(ts), objectcore.AddressOf(lock))
+
+		_, err = sh.Inhume(inhumePrm)
+		require.Error(t, err)
+
+		inhumePrm.MarkAsGarbage(objectcore.AddressOf(lock))
+		_, err = sh.Inhume(inhumePrm)
+		require.Error(t, err)
+	})
+
+	t.Run("force objects inhuming", func(t *testing.T) {
+		var inhumePrm shard.InhumePrm
+		inhumePrm.MarkAsGarbage(objectcore.AddressOf(lock))
+		inhumePrm.ForceRemoval()
+
+		_, err = sh.Inhume(inhumePrm)
+		require.NoError(t, err)
+
+		// it should be possible to remove
+		// lock object now
+
+		inhumePrm = shard.InhumePrm{}
+		inhumePrm.MarkAsGarbage(objectcore.AddressOf(obj))
+
+		_, err = sh.Inhume(inhumePrm)
+		require.NoError(t, err)
+
+		// check that object has been removed
+
+		var getPrm shard.GetPrm
+		getPrm.WithAddress(objectcore.AddressOf(obj))
+
+		_, err = sh.Get(getPrm)
+		require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
+	})
+
+}

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -38,6 +38,9 @@ type ExpiredTombstonesCallback func(context.Context, []meta.TombstonedObject)
 // ExpiredObjectsCallback is a callback handling list of expired objects.
 type ExpiredObjectsCallback func(context.Context, []oid.Address)
 
+// DeletedLockCallback is a callback handling list of deleted LOCK objects.
+type DeletedLockCallback func(context.Context, []oid.Address)
+
 type cfg struct {
 	m sync.RWMutex
 
@@ -62,6 +65,8 @@ type cfg struct {
 	expiredTombstonesCallback ExpiredTombstonesCallback
 
 	expiredLocksCallback ExpiredObjectsCallback
+
+	deletedLockCallBack DeletedLockCallback
 
 	tsSource TombstoneSource
 }
@@ -226,6 +231,14 @@ func WithMode(v Mode) Option {
 func WithTombstoneSource(v TombstoneSource) Option {
 	return func(c *cfg) {
 		c.tsSource = v
+	}
+}
+
+// WitDeletedLockCallback returns option to specify callback
+// of the deleted LOCK objects handler.
+func WitDeletedLockCallback(v DeletedLockCallback) Option {
+	return func(c *cfg) {
+		c.deletedLockCallBack = v
 	}
 }
 

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -234,9 +234,9 @@ func WithTombstoneSource(v TombstoneSource) Option {
 	}
 }
 
-// WitDeletedLockCallback returns option to specify callback
+// WithDeletedLockCallback returns option to specify callback
 // of the deleted LOCK objects handler.
-func WitDeletedLockCallback(v DeletedLockCallback) Option {
+func WithDeletedLockCallback(v DeletedLockCallback) Option {
 	return func(c *cfg) {
 		c.deletedLockCallBack = v
 	}

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -32,6 +32,8 @@ func (p *Policer) processObject(ctx context.Context, addr oid.Address) {
 		if container.IsErrNotFound(err) {
 			var prm engine.InhumePrm
 			prm.MarkAsGarbage(addr)
+			prm.WithForceRemoval()
+
 			_, err := p.jobQueue.localStorage.Inhume(prm)
 			if err != nil {
 				p.log.Error("could not inhume object with missing container",


### PR DESCRIPTION
Related to #1227.

- Lock object could not exist without expiration.
- Lock object is impossible to delete.
- 2nd has an exception: control service.

Why two new options:
1. Regular removal: `WithTombstoneAddress`/ `WithGCMark`.
2. Removal by control service: `WithForceGCMark` to be able to delete Lock objects and unlock locked objects.
3. Removal of tombstones/expired SGs/expired Locks by GC: `WithGCMark` and `WithoutLockObjectHandling` (the last is kinda optimization, we do not need to check if an object is a Lock object if we know that is it a TS/SG AND we must NOT check whether it is a Lock if we KNOW that we remove expired lock).

Also, I did not want to remove TS/SG/Expired LOCKS with `WithForceGCMark` since it is not forced removal in fact.

Question: does the SE need `WithForceRemoval` option or every `StorageEngine.Delete` call could be considered as a "force removal"?