### PR TITLE
blobovnicza: determine db size via `os.Stat`

### DIFF
--- a/pkg/local_object_storage/blobovnicza/blobovnicza.go
+++ b/pkg/local_object_storage/blobovnicza/blobovnicza.go
@@ -13,9 +13,9 @@ import (
 
 // Blobovnicza represents the implementation of NeoFS Blobovnicza.
 type Blobovnicza struct {
-	*cfg
+	cfg
 
-	filled *atomic.Uint64
+	filled atomic.Uint64
 
 	boltDB *bbolt.DB
 }
@@ -41,8 +41,8 @@ type boltDBCfg struct {
 	boltOptions *bbolt.Options
 }
 
-func defaultCfg() *cfg {
-	return &cfg{
+func defaultCfg(с *cfg) {
+	*с = cfg{
 		boltDBCfg: boltDBCfg{
 			perm: os.ModePerm, // 0777
 			boltOptions: &bbolt.Options{
@@ -57,16 +57,15 @@ func defaultCfg() *cfg {
 
 // New creates and returns a new Blobovnicza instance.
 func New(opts ...Option) *Blobovnicza {
-	c := defaultCfg()
+	var b Blobovnicza
+
+	defaultCfg(&b.cfg)
 
 	for i := range opts {
-		opts[i](c)
+		opts[i](&b.cfg)
 	}
 
-	return &Blobovnicza{
-		cfg:    c,
-		filled: atomic.NewUint64(0),
-	}
+	return &b
 }
 
 // WithPath returns option to set system path to Blobovnicza.

--- a/pkg/local_object_storage/blobstor/blobovnicza_test.go
+++ b/pkg/local_object_storage/blobstor/blobovnicza_test.go
@@ -40,7 +40,11 @@ func TestBlobovniczas(t *testing.T) {
 
 	c := defaultCfg()
 
-	var width, depth, szLim uint64 = 2, 2, 2 << 10
+	var width, depth uint64 = 2, 2
+
+	// sizeLim must be big enough, to hold at least multiple pages.
+	// 32 KiB is the initial size after all by-size buckets are created.
+	var szLim uint64 = 32*1024 + 1
 
 	for _, opt := range []Option{
 		WithLogger(l),
@@ -77,7 +81,7 @@ func TestBlobovniczas(t *testing.T) {
 
 		// save object in blobovnicza
 		id, err := b.put(addr, d)
-		require.NoError(t, err)
+		require.NoError(t, err, i)
 
 		// get w/ blobovnicza ID
 		prm := new(GetSmallPrm)


### PR DESCRIPTION
Currently we use `(*bbolt.Bucket).Stats().KeyN` for estimating database
size. However, it iterates over all pages in bucket and thus heavily
depends on the bucket size. This commit replaces initial size estimation
with a single `os.Stat` call.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>