### PR TITLE
innerring: log errors in processors

### DIFF
--- a/pkg/innerring/processors/alphabet/process_emit.go
+++ b/pkg/innerring/processors/alphabet/process_emit.go
@@ -29,7 +29,7 @@ func (ap *Processor) processEmit() {
 	// there is no signature collecting, so we don't need extra fee
 	err := ap.morphClient.Invoke(contract, 0, emitMethod)
 	if err != nil {
-		ap.log.Warn("can't invoke alphabet emit method")
+		ap.log.Warn("can't invoke alphabet emit method", zap.String("error", err.Error()))
 
 		return
 	}
@@ -62,7 +62,7 @@ func (ap *Processor) processEmit() {
 
 		key, err := keys.NewPublicKeyFromBytes(keyBytes, elliptic.P256())
 		if err != nil {
-			ap.log.Warn("can't convert node public key to address",
+			ap.log.Warn("can't parse node public key",
 				zap.String("error", err.Error()))
 
 			continue

--- a/pkg/innerring/processors/settlement/basic/collect.go
+++ b/pkg/innerring/processors/settlement/basic/collect.go
@@ -29,7 +29,8 @@ func (inc *IncomeSettlementContext) Collect() {
 	cnrEstimations, err := inc.estimations.Estimations(inc.epoch)
 	if err != nil {
 		inc.log.Error("can't fetch container size estimations",
-			zap.Uint64("epoch", inc.epoch))
+			zap.Uint64("epoch", inc.epoch),
+			zap.String("error", err.Error()))
 
 		return
 	}
@@ -42,7 +43,7 @@ func (inc *IncomeSettlementContext) Collect() {
 			inc.log.Warn("can't fetch container info",
 				zap.Uint64("epoch", inc.epoch),
 				zap.Stringer("container_id", cnrEstimations[i].ContainerID),
-			)
+				zap.String("error", err.Error()))
 
 			continue
 		}
@@ -52,7 +53,7 @@ func (inc *IncomeSettlementContext) Collect() {
 			inc.log.Debug("can't fetch container info",
 				zap.Uint64("epoch", inc.epoch),
 				zap.Stringer("container_id", cnrEstimations[i].ContainerID),
-			)
+				zap.String("error", err.Error()))
 
 			continue
 		}


### PR DESCRIPTION
Log errors for network operations. The only places where we are not
interested in errors are `Submit` in pool and unmarshaling.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>