### PR TITLE
[#1481] pilorama: Fix `TreeApply`

### DIFF
--- a/pkg/local_object_storage/pilorama/forest_test.go
+++ b/pkg/local_object_storage/pilorama/forest_test.go
@@ -354,16 +354,17 @@ func testForestTreeApply(t *testing.T, constructor func(t testing.TB) Forest) {
 		testMeta(t, s, cid, treeID, 11, 10, meta)
 
 		testApply(t, s, 10, TrashID, Meta{Time: 2, Items: []KeyValue{{"parent", []byte{2}}}})
-		testMeta(t, s, cid, treeID, 11, 0, Meta{})
+		testMeta(t, s, cid, treeID, 11, 10, meta)
 	})
 	t.Run("add a child to non-existent parent, then add a parent", func(t *testing.T) {
 		s := constructor(t)
 
-		testApply(t, s, 11, 10, Meta{Time: 1, Items: []KeyValue{{"child", []byte{3}}}})
-		testMeta(t, s, cid, treeID, 11, 0, Meta{})
+		meta := Meta{Time: 1, Items: []KeyValue{{"child", []byte{3}}}}
+		testApply(t, s, 11, 10, meta)
+		testMeta(t, s, cid, treeID, 11, 10, meta)
 
 		testApply(t, s, 10, 0, Meta{Time: 2, Items: []KeyValue{{"grand", []byte{1}}}})
-		testMeta(t, s, cid, treeID, 11, 0, Meta{})
+		testMeta(t, s, cid, treeID, 11, 10, meta)
 	})
 }
 

--- a/pkg/local_object_storage/pilorama/inmemory.go
+++ b/pkg/local_object_storage/pilorama/inmemory.go
@@ -86,11 +86,7 @@ func (s *state) do(op *Move) LogMove {
 		},
 	}
 
-	_, parentInTree := s.tree.infoMap[op.Parent]
-	shouldPut := !s.tree.isAncestor(op.Child, op.Parent) &&
-		!(op.Parent != 0 && op.Parent != TrashID && !parentInTree)
-	shouldRemove := op.Parent == TrashID
-
+	shouldPut := !s.tree.isAncestor(op.Child, op.Parent)
 	p, ok := s.tree.infoMap[op.Child]
 	if ok {
 		lm.HasOld = true
@@ -98,14 +94,6 @@ func (s *state) do(op *Move) LogMove {
 	}
 
 	if !shouldPut {
-		return lm
-	}
-
-	if shouldRemove {
-		if ok {
-			s.removeChild(op.Child, p.Parent)
-		}
-		delete(s.tree.infoMap, op.Child)
 		return lm
 	}
 


### PR DESCRIPTION
Close #1481 .

Current implementation prevents invalid operations to become valid at
some later point (consider adding a child to the non-existent parent and
then adding the parent). This seems to diverge from the paper algorithm
and complicates implementation. Make it simpler.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>