### PR TITLE
writecache: provide timeout to `bbolt.Open`

### DIFF
--- a/pkg/local_object_storage/writecache/util.go
+++ b/pkg/local_object_storage/writecache/util.go
@@ -3,6 +3,7 @@ package writecache
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"go.etcd.io/bbolt"
 )
@@ -13,5 +14,6 @@ func OpenDB(p string, ro bool) (*bbolt.DB, error) {
 		NoFreelistSync: true,
 		NoSync:         true,
 		ReadOnly:       ro,
+		Timeout:        100 * time.Millisecond,
 	})
 }


### PR DESCRIPTION
Refs #1503 .
Metabase and blobovnicza are already good.
Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>