### PR TITLE
Fix/Do not handle object concurrently by the policer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 - Do not replicate object twice to the same node (#1410)
+- Concurrent object handling by the Policer (#1411)
 
 ### Removed
 


### PR DESCRIPTION
Put object to the cache before starting handling. That prevents concurrent
object handling when there is a few number of objects and object handling
takes more time that the policer needs for starting that object handling one
more time.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1411.