### PR TITLE
Fix/Do not replicate object twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog for NeoFS Node
 
 ### Fixed
 
+- Do not replicate object twice to the same node (#1410)
+
 ### Removed
 
 ### Updated

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -217,8 +217,6 @@ func initObjectService(c *cfg) {
 		),
 	)
 
-	c.workers = append(c.workers, repl)
-
 	pol := policer.New(
 		policer.WithLogger(c.log),
 		policer.WithLocalStorage(ls),

--- a/pkg/services/replicator/process.go
+++ b/pkg/services/replicator/process.go
@@ -9,39 +9,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func (p *Replicator) Run(ctx context.Context) {
-	defer func() {
-		close(p.ch)
-		p.log.Info("routine stopped")
-	}()
-
-	p.ch = make(chan *Task, p.taskCap)
-
-	p.log.Info("process routine",
-		zap.Uint32("task queue capacity", p.taskCap),
-		zap.Duration("put timeout", p.putTimeout),
-	)
-
-	for {
-		select {
-		case <-ctx.Done():
-			p.log.Warn("context is done",
-				zap.String("error", ctx.Err().Error()),
-			)
-
-			return
-		case task, ok := <-p.ch:
-			if !ok {
-				p.log.Warn("trigger channel is closed")
-
-				return
-			}
-
-			p.HandleTask(ctx, task)
-		}
-	}
-}
-
 // HandleTask executes replication task inside invoking goroutine.
 func (p *Replicator) HandleTask(ctx context.Context, task *Task) {
 	defer func() {

--- a/pkg/services/replicator/process.go
+++ b/pkg/services/replicator/process.go
@@ -9,8 +9,17 @@ import (
 	"go.uber.org/zap"
 )
 
+// TaskResult is a replication result interface.
+type TaskResult interface {
+	// SubmitSuccessfulReplication must save successful
+	// replication result. ID is a netmap identification
+	// of a node that accepted the replica.
+	SubmitSuccessfulReplication(id uint64)
+}
+
 // HandleTask executes replication task inside invoking goroutine.
-func (p *Replicator) HandleTask(ctx context.Context, task *Task) {
+// Passes all the nodes that accepted the replication to the TaskResult.
+func (p *Replicator) HandleTask(ctx context.Context, task *Task, res TaskResult) {
 	defer func() {
 		p.log.Debug("finish work",
 			zap.Uint32("amount of unfinished replicas", task.quantity),
@@ -55,6 +64,8 @@ func (p *Replicator) HandleTask(ctx context.Context, task *Task) {
 			log.Debug("object successfully replicated")
 
 			task.quantity--
+
+			res.SubmitSuccessfulReplication(task.nodes[i].ID)
 		}
 	}
 }

--- a/pkg/services/replicator/replicator.go
+++ b/pkg/services/replicator/replicator.go
@@ -13,16 +13,12 @@ import (
 // local objects to remote nodes.
 type Replicator struct {
 	*cfg
-
-	ch chan *Task
 }
 
 // Option is an option for Policer constructor.
 type Option func(*cfg)
 
 type cfg struct {
-	taskCap uint32
-
 	putTimeout time.Duration
 
 	log *logger.Logger

--- a/pkg/services/replicator/task.go
+++ b/pkg/services/replicator/task.go
@@ -14,17 +14,6 @@ type Task struct {
 	nodes netmap.Nodes
 }
 
-// AddTask pushes replication task to Replicator queue.
-//
-// If task queue is full, log message is written.
-func (p *Replicator) AddTask(t *Task) {
-	select {
-	case p.ch <- t:
-	default:
-		p.log.Warn("task queue is full")
-	}
-}
-
 // WithCopiesNumber sets number of copies to replicate.
 func (t *Task) WithCopiesNumber(v uint32) *Task {
 	if t != nil {


### PR DESCRIPTION
If placement contains two vectors with intersecting nodes it was possible to
send the object to the nodes twice.
Also optimizes requests: do not ask about storing the object twice from the
same node.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1410.