### PR TITLE
Do not use base58 encoded keys in the metabase

### DIFF
--- a/pkg/local_object_storage/metabase/VERSION.md
+++ b/pkg/local_object_storage/metabase/VERSION.md
@@ -84,6 +84,15 @@ This file describes changes between the metabase versions.
   - Key: split ID
   - Value: list of object IDs
 
+# History
+
+## Version 2
+
+- Container ID is encoded as 32-byte slice
+- Object ID is encoded as 32-byte slice
+- Object ID is encoded as 64-byte slice, container ID + object ID
+- Bucket naming scheme is changed:
+  - container ID + suffix -> 1-byte prefix + container ID
 
 ## Version 1
 

--- a/pkg/local_object_storage/metabase/counter.go
+++ b/pkg/local_object_storage/metabase/counter.go
@@ -125,6 +125,7 @@ func syncCounter(tx *bbolt.Tx, force bool) error {
 
 	graveyardBKT := tx.Bucket(graveyardBucketName)
 	garbageBKT := tx.Bucket(garbageBucketName)
+	key := make([]byte, addressKeySize)
 
 	err = iteratePhyObjects(tx, func(cnr cid.ID, obj oid.ID) error {
 		phyCounter++
@@ -134,7 +135,7 @@ func syncCounter(tx *bbolt.Tx, force bool) error {
 
 		// check if an object is available: not with GCMark
 		// and not covered with a tombstone
-		if inGraveyardWithKey(addressKey(addr), graveyardBKT, garbageBKT) == 0 {
+		if inGraveyardWithKey(addressKey(addr, key), graveyardBKT, garbageBKT) == 0 {
 			logicCounter++
 		}
 

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -174,7 +174,7 @@ func (db *DB) iterateDeletedObj(tx *bbolt.Tx, h kvHandler, offset *oid.Address) 
 	if offset == nil {
 		k, v = c.First()
 	} else {
-		rawAddr := addressKey(*offset)
+		rawAddr := addressKey(*offset, make([]byte, addressKeySize))
 
 		k, v = c.Seek(rawAddr)
 		if bytes.Equal(k, rawAddr) {
@@ -222,6 +222,8 @@ func graveFromKV(k, v []byte) (res TombstonedObject, err error) {
 //
 // Returns any error appeared during deletion process.
 func (db *DB) DropGraves(tss []TombstonedObject) error {
+	buf := make([]byte, addressKeySize)
+
 	return db.boltDB.Update(func(tx *bbolt.Tx) error {
 		bkt := tx.Bucket(graveyardBucketName)
 		if bkt == nil {
@@ -229,7 +231,7 @@ func (db *DB) DropGraves(tss []TombstonedObject) error {
 		}
 
 		for _, ts := range tss {
-			err := bkt.Delete(addressKey(ts.Address()))
+			err := bkt.Delete(addressKey(ts.Address(), buf))
 			if err != nil {
 				return err
 			}

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -113,7 +113,7 @@ func (db *DB) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 
 		if prm.tomb != nil {
 			bkt = graveyardBKT
-			tombKey := addressKey(*prm.tomb)
+			tombKey := addressKey(*prm.tomb, make([]byte, addressKeySize))
 
 			// it is forbidden to have a tomb-on-tomb in NeoFS,
 			// so graveyard keys must not be addresses of tombstones
@@ -131,6 +131,7 @@ func (db *DB) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 			value = zeroValue
 		}
 
+		buf := make([]byte, addressKeySize)
 		for i := range prm.target {
 			id := prm.target[i].Object()
 			cnr := prm.target[i].Container()
@@ -153,9 +154,8 @@ func (db *DB) Inhume(prm InhumePrm) (res InhumeRes, err error) {
 				lockWasChecked = true
 			}
 
-			targetKey := addressKey(prm.target[i])
-
-			obj, err := db.get(tx, prm.target[i], false, true, currEpoch)
+			obj, err := db.get(tx, prm.target[i], buf, false, true, currEpoch)
+			targetKey := addressKey(prm.target[i], buf)
 			if err == nil {
 				if inGraveyardWithKey(targetKey, graveyardBKT, garbageBKT) == 0 {
 					// object is available, decrement the

--- a/pkg/local_object_storage/metabase/movable.go
+++ b/pkg/local_object_storage/metabase/movable.go
@@ -52,13 +52,16 @@ func (db *DB) ToMoveIt(prm ToMoveItPrm) (res ToMoveItRes, err error) {
 	db.modeMtx.RLock()
 	defer db.modeMtx.RUnlock()
 
+	key := make([]byte, addressKeySize)
+	key = addressKey(prm.addr, key)
+
 	err = db.boltDB.Update(func(tx *bbolt.Tx) error {
 		toMoveIt, err := tx.CreateBucketIfNotExists(toMoveItBucketName)
 		if err != nil {
 			return err
 		}
 
-		return toMoveIt.Put(addressKey(prm.addr), zeroValue)
+		return toMoveIt.Put(key, zeroValue)
 	})
 
 	return
@@ -69,13 +72,16 @@ func (db *DB) DoNotMove(prm DoNotMovePrm) (res DoNotMoveRes, err error) {
 	db.modeMtx.RLock()
 	defer db.modeMtx.RUnlock()
 
+	key := make([]byte, addressKeySize)
+	key = addressKey(prm.addr, key)
+
 	err = db.boltDB.Update(func(tx *bbolt.Tx) error {
 		toMoveIt := tx.Bucket(toMoveItBucketName)
 		if toMoveIt == nil {
 			return nil
 		}
 
-		return toMoveIt.Delete(addressKey(prm.addr))
+		return toMoveIt.Delete(key)
 	})
 
 	return

--- a/pkg/local_object_storage/metabase/shard_id.go
+++ b/pkg/local_object_storage/metabase/shard_id.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	shardInfoBucket = []byte(invalidBase58String + "i")
+	shardInfoBucket = []byte{shardInfoPrefix}
 	shardIDKey      = []byte("id")
 )
 

--- a/pkg/local_object_storage/metabase/storage_id.go
+++ b/pkg/local_object_storage/metabase/storage_id.go
@@ -39,12 +39,13 @@ func (db *DB) StorageID(prm StorageIDPrm) (res StorageIDRes, err error) {
 }
 
 func (db *DB) storageID(tx *bbolt.Tx, addr oid.Address) ([]byte, error) {
-	smallBucket := tx.Bucket(smallBucketName(addr.Container()))
+	key := make([]byte, bucketKeySize)
+	smallBucket := tx.Bucket(smallBucketName(addr.Container(), key))
 	if smallBucket == nil {
 		return nil, nil
 	}
 
-	storageID := smallBucket.Get(objectKey(addr.Object()))
+	storageID := smallBucket.Get(objectKey(addr.Object(), key))
 	if storageID == nil {
 		return nil, nil
 	}

--- a/pkg/local_object_storage/metabase/version.go
+++ b/pkg/local_object_storage/metabase/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 // version contains current metabase version.
-const version = 1
+const version = 2
 
 var versionKey = []byte("version")
 


### PR DESCRIPTION
Close #1482 .

```
name                        old time/op    new time/op    delta
Select/string_equal-8         8.87µs ± 5%    2.92µs ± 7%  -67.05%  (p=0.000 n=10+10)
Select/string_not_equal-8     4.95ms ±11%    1.34ms ± 9%  -73.04%  (p=0.000 n=10+10)
Select/common_prefix-8        55.5µs ± 6%    15.5µs ± 9%  -72.08%  (p=0.000 n=9+10)
Select/unknown-8              3.32µs ± 9%    0.85µs ± 8%  -74.46%  (p=0.000 n=10+10)
Put/parallel-8                1.27ms ±12%    1.13ms ±19%  -11.07%  (p=0.009 n=10+10)
Put/sequential-8              4.55ms ±14%    4.32ms ±12%     ~     (p=0.190 n=10+10)
ListWithCursor/1_item-8       4.96µs ±16%    3.25µs ± 7%  -34.32%  (p=0.000 n=10+10)
ListWithCursor/10_items-8     15.4µs ±14%     6.5µs ± 8%  -57.47%  (p=0.000 n=10+10)
ListWithCursor/100_items-8     119µs ± 8%      37µs ± 4%  -69.08%  (p=0.000 n=9+8)
Get/1_objects-8               8.46µs ±15%    3.96µs ±17%  -53.15%  (p=0.000 n=9+10)
Get/10_objects-8              92.8µs ±12%    41.8µs ±12%  -54.98%  (p=0.000 n=10+9)
Get/100_objects-8              944µs ±12%     415µs ± 8%  -56.05%  (p=0.000 n=10+9)

name                        old alloc/op   new alloc/op   delta
Put/parallel-8                 133kB ±17%     135kB ±10%     ~     (p=0.631 n=10+10)
Put/sequential-8               174kB ± 4%     186kB ± 4%   +6.74%  (p=0.000 n=10+9)
ListWithCursor/1_item-8       1.91kB ± 0%    1.49kB ± 0%  -21.80%  (p=0.000 n=10+10)
ListWithCursor/10_items-8     5.50kB ± 0%    2.77kB ± 0%  -49.59%  (p=0.002 n=8+10)
ListWithCursor/100_items-8    41.5kB ± 0%    15.7kB ± 0%  -62.20%  (p=0.000 n=10+10)
Get/1_objects-8               2.83kB ± 0%    2.16kB ± 0%  -23.73%  (p=0.000 n=9+10)
Get/10_objects-8              29.6kB ± 2%    22.7kB ± 0%  -23.16%  (p=0.000 n=10+10)
Get/100_objects-8              295kB ± 1%     227kB ± 0%  -23.20%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
Put/parallel-8                   478 ± 1%       343 ± 2%  -28.18%  (p=0.000 n=10+10)
Put/sequential-8                 811 ± 1%       670 ± 1%  -17.37%  (p=0.000 n=10+10)
ListWithCursor/1_item-8         34.0 ± 0%      27.0 ± 0%  -20.59%  (p=0.000 n=10+10)
ListWithCursor/10_items-8        100 ± 0%        51 ± 0%  -49.00%  (p=0.000 n=10+10)
ListWithCursor/100_items-8       758 ± 0%       290 ± 0%  -61.74%  (p=0.000 n=10+10)
Get/1_objects-8                 48.0 ± 0%      36.0 ± 0%  -25.00%  (p=0.000 n=9+10)
Get/10_objects-8                 506 ± 1%       389 ± 0%  -23.09%  (p=0.000 n=10+10)
Get/100_objects-8              5.07k ± 1%     3.89k ± 0%  -23.24%  (p=0.000 n=10+10)
```