### PR TITLE
Feat/Support signature status codes

### DIFF
--- a/pkg/services/util/sign.go
+++ b/pkg/services/util/sign.go
@@ -185,7 +185,10 @@ func (s *SignService) HandleUnaryRequest(ctx context.Context, req interface{}, h
 
 	// verify request signatures
 	if err = signature.VerifyServiceMessage(req); err != nil {
-		err = fmt.Errorf("could not verify request: %w", err)
+		var sigErr apistatus.SignatureVerification
+		sigErr.SetMessage(err.Error())
+
+		err = sigErr
 	} else {
 		// process request
 		resp, err = handler(ctx, req)


### PR DESCRIPTION
Related to https://github.com/nspcc-dev/neofs-api/issues/200.

- [x] Blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/273.
- [x] Blocked by https://github.com/nspcc-dev/neofs-api-go/pull/405.

I do not like the idea of wrapped errors passed as a message: I do not think that clients should see messages like "something: went: wrong: on: server: side: signature verification failed", so I decided to unwrap common messages (only unsupported scheme for now) and put it as a message directly OR keep the default "signature verification failed" message in other cases.

Also, we could provide more custom errors in the `api-go` or try to cast directly to the [crypto errors](https://github.com/nspcc-dev/neofs-crypto/blob/225b24f7f42dc8ceb77e8706551d57525d880946/ecdsa.go#L16-L24).

@cthulhu-rider, @fyrchik, what do you think?