### PR TITLE
Upgrade NeoFS SDK Go with changed container sessions

### DIFF
--- a/cmd/neofs-cli/modules/container/create.go
+++ b/cmd/neofs-cli/modules/container/create.go
@@ -98,7 +98,6 @@ It will be stored in sidechain when inner ring will accepts it.`,
 
 			issuer := tok.Issuer()
 			cnr.SetOwnerID(&issuer)
-			cnr.SetSessionToken(tok)
 		} else {
 			var idOwner user.ID
 			user.IDFromKey(&idOwner, key.PublicKey)
@@ -113,13 +112,16 @@ It will be stored in sidechain when inner ring will accepts it.`,
 		cnr.SetBasicACL(basicACL)
 		cnr.SetAttributes(attributes)
 		cnr.SetNonceUUID(nonce)
-		cnr.SetSessionToken(tok)
 
 		cli := internalclient.GetSDKClientByFlag(cmd, key, commonflags.RPC)
 
 		var putPrm internalclient.PutContainerPrm
 		putPrm.SetClient(cli)
 		putPrm.SetContainer(*cnr)
+
+		if tok != nil {
+			putPrm.WithinSession(*tok)
+		}
 
 		res, err := internalclient.PutContainer(putPrm)
 		common.ExitOnErr(cmd, "rpc error: %w", err)

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -3,7 +3,6 @@ package container
 import (
 	"os"
 
-	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
@@ -29,21 +28,9 @@ var getExtendedACLCmd = &cobra.Command{
 
 		eaclTable := res.EACL()
 
-		sig := eaclTable.Signature()
-
-		// TODO(@cthulhu-rider): #1387 avoid type conversion
-		var sigV2 refs.Signature
-		sig.WriteToV2(&sigV2)
-
 		if containerPathTo == "" {
 			cmd.Println("eACL: ")
 			common.PrettyPrintJSON(cmd, eaclTable, "eACL")
-
-			var sigV2 refs.Signature
-			sig.WriteToV2(&sigV2)
-
-			cmd.Println("Signature:")
-			common.PrettyPrintJSON(cmd, &sigV2, "signature")
 
 			return
 		}
@@ -59,9 +46,6 @@ var getExtendedACLCmd = &cobra.Command{
 		}
 
 		cmd.Println("dumping data to file:", containerPathTo)
-
-		cmd.Println("Signature:")
-		common.PrettyPrintJSON(cmd, &sigV2, "signature")
 
 		err = os.WriteFile(containerPathTo, data, 0644)
 		common.ExitOnErr(cmd, "could not write eACL to file: %w", err)

--- a/cmd/neofs-cli/modules/container/set_eacl.go
+++ b/cmd/neofs-cli/modules/container/set_eacl.go
@@ -32,7 +32,6 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 		}
 
 		eaclTable.SetCID(id)
-		eaclTable.SetSessionToken(tok)
 
 		pk := key.GetOrGenerate(cmd)
 		cli := internalclient.GetSDKClientByFlag(cmd, pk, commonflags.RPC)
@@ -40,6 +39,10 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 		var setEACLPrm internalclient.SetEACLPrm
 		setEACLPrm.SetClient(cli)
 		setEACLPrm.SetTable(*eaclTable)
+
+		if tok != nil {
+			setEACLPrm.WithinSession(*tok)
+		}
 
 		_, err := internalclient.SetEACL(setEACLPrm)
 		common.ExitOnErr(cmd, "rpc error: %w", err)

--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -10,9 +10,7 @@ import (
 	cntClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl"
 	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put"
-	containerSDK "github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
 	netmapSDK "github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
@@ -147,13 +145,13 @@ func newCachedContainerStorage(v container.Source) *ttlContainerStorage {
 
 // Get returns container value from the cache. If value is missing in the cache
 // or expired, then it returns value from side chain and updates the cache.
-func (s *ttlContainerStorage) Get(cnr cid.ID) (*containerSDK.Container, error) {
+func (s *ttlContainerStorage) Get(cnr cid.ID) (*container.Container, error) {
 	val, err := (*ttlNetCache)(s).get(cnr.EncodeToString())
 	if err != nil {
 		return nil, err
 	}
 
-	return val.(*containerSDK.Container), nil
+	return val.(*container.Container), nil
 }
 
 type ttlEACLStorage ttlNetCache
@@ -180,13 +178,13 @@ func newCachedEACLStorage(v eacl.Source) *ttlEACLStorage {
 
 // GetEACL returns eACL value from the cache. If value is missing in the cache
 // or expired, then it returns value from side chain and updates cache.
-func (s *ttlEACLStorage) GetEACL(cnr cid.ID) (*eaclSDK.Table, error) {
+func (s *ttlEACLStorage) GetEACL(cnr cid.ID) (*container.EACL, error) {
 	val, err := (*ttlNetCache)(s).get(cnr.EncodeToString())
 	if err != nil {
 		return nil, err
 	}
 
-	return val.(*eaclSDK.Table), nil
+	return val.(*container.EACL), nil
 }
 
 // InvalidateEACL removes cached eACL value.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220601120906-3bec6657f5c5 // indirect
 	github.com/nspcc-dev/neofs-api-go/v2 v2.12.3-0.20220620114558-454b5c0ed7e9
 	github.com/nspcc-dev/neofs-contract v0.15.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599
 	github.com/nspcc-dev/tzhash v1.5.2
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721 h1:5Al3dddr0SG3ONhfglTyc2GSnQS0vMmygCD00vLo/jU=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220616082321-e986f4780721/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599 h1:EkwWrbzImpqtNJa8IZIsfk/EqbmPwpd0DfdenrJLSbc=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.4.0.20220621170307-721df386c599/go.mod h1:k58jgszGX3pws2yiOXu9m0i32BzRgi1T6Bpd/L1KrJU=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/core/container/storage.go
+++ b/pkg/core/container/storage.go
@@ -6,7 +6,22 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
+	"github.com/nspcc-dev/neofs-sdk-go/eacl"
+	"github.com/nspcc-dev/neofs-sdk-go/session"
 )
+
+// Container groups information about the NeoFS container stored in the NeoFS network.
+type Container struct {
+	// Container structure.
+	Value *container.Container
+
+	// Signature of the Value.
+	Signature neofscrypto.Signature
+
+	// Session within which Value was created. Nil means session absence.
+	Session *session.Container
+}
 
 // Source is an interface that wraps
 // basic container receiving method.
@@ -19,7 +34,7 @@ type Source interface {
 	//
 	// Implementations must not retain the container pointer and modify
 	// the container through it.
-	Get(cid.ID) (*container.Container, error)
+	Get(cid.ID) (*Container, error)
 }
 
 // IsErrNotFound checks if the error returned by Source.Get corresponds
@@ -31,3 +46,16 @@ func IsErrNotFound(err error) bool {
 // ErrEACLNotFound is returned by eACL storage implementations when
 // the requested eACL table is not in the storage.
 var ErrEACLNotFound = errors.New("extended ACL table is not set for this container")
+
+// EACL groups information about the NeoFS container's extended ACL stored in
+// the NeoFS network.
+type EACL struct {
+	// Extended ACL structure.
+	Value *eacl.Table
+
+	// Signature of the Value.
+	Signature neofscrypto.Signature
+
+	// Session within which Value was set. Nil means session absence.
+	Session *session.Container
+}

--- a/pkg/innerring/processors/audit/process.go
+++ b/pkg/innerring/processors/audit/process.go
@@ -60,7 +60,7 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 			continue
 		}
 
-		policy := cnr.PlacementPolicy()
+		policy := cnr.Value.PlacementPolicy()
 		if policy == nil {
 			log.Error("missing placement policy in container, ignore",
 				zap.Stringer("cid", containers[i]),
@@ -108,7 +108,7 @@ func (ap *Processor) processStartAudit(epoch uint64) {
 			WithAuditContext(auditCtx).
 			WithContainerID(containers[i]).
 			WithStorageGroupList(storageGroups).
-			WithContainerStructure(cnr).
+			WithContainerStructure(cnr.Value).
 			WithContainerNodes(nodes).
 			WithNetworkMap(nm)
 

--- a/pkg/innerring/processors/container/process_container.go
+++ b/pkg/innerring/processors/container/process_container.go
@@ -169,7 +169,7 @@ func (cp *Processor) checkDeleteContainer(e *containerEvent.Delete) error {
 		return fmt.Errorf("could not receive the container: %w", err)
 	}
 
-	ownerContainer := cnr.OwnerID()
+	ownerContainer := cnr.Value.OwnerID()
 	if ownerContainer == nil {
 		return errors.New("missing container owner")
 	}

--- a/pkg/innerring/processors/container/process_eacl.go
+++ b/pkg/innerring/processors/container/process_eacl.go
@@ -52,7 +52,7 @@ func (cp *Processor) checkSetEACL(e container.SetEACL) error {
 	}
 
 	// ACL extensions can be disabled by basic ACL, check it
-	basicACL := cnr.BasicACL()
+	basicACL := cnr.Value.BasicACL()
 	const finalBitMask = 1 << 28
 
 	// Temp solution: NeoFS SDK is going to provide convenient interface to do this soon.
@@ -61,7 +61,7 @@ func (cp *Processor) checkSetEACL(e container.SetEACL) error {
 		return errors.New("ACL extension disabled by container basic ACL")
 	}
 
-	ownerContainer := cnr.OwnerID()
+	ownerContainer := cnr.Value.OwnerID()
 	if ownerContainer == nil {
 		return errors.New("missing container owner")
 	}

--- a/pkg/innerring/settlement.go
+++ b/pkg/innerring/settlement.go
@@ -123,7 +123,7 @@ func (s settlementDeps) ContainerInfo(cid cid.ID) (common.ContainerInfo, error) 
 		return nil, fmt.Errorf("could not get container from storage: %w", err)
 	}
 
-	return (*containerWrapper)(cnr), nil
+	return (*containerWrapper)(cnr.Value), nil
 }
 
 func (s settlementDeps) buildContainer(e uint64, cid cid.ID) ([][]netmapAPI.NodeInfo, *netmapAPI.NetMap, error) {
@@ -147,7 +147,7 @@ func (s settlementDeps) buildContainer(e uint64, cid cid.ID) ([][]netmapAPI.Node
 		return nil, nil, fmt.Errorf("could not get container from sidechain: %w", err)
 	}
 
-	policy := cnr.PlacementPolicy()
+	policy := cnr.Value.PlacementPolicy()
 	if policy == nil {
 		return nil, nil, errors.New("missing placement policy in container")
 	}

--- a/pkg/services/container/morph/executor_test.go
+++ b/pkg/services/container/morph/executor_test.go
@@ -10,10 +10,8 @@ import (
 	containerCore "github.com/nspcc-dev/neofs-node/pkg/core/container"
 	containerSvc "github.com/nspcc-dev/neofs-node/pkg/services/container"
 	containerSvcMorph "github.com/nspcc-dev/neofs-node/pkg/services/container/morph"
-	containerSDK "github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +20,7 @@ type mock struct {
 	containerSvcMorph.Reader
 }
 
-func (m mock) Put(_ *containerSDK.Container) (*cid.ID, error) {
+func (m mock) Put(_ containerCore.Container) (*cid.ID, error) {
 	return new(cid.ID), nil
 }
 
@@ -30,7 +28,7 @@ func (m mock) Delete(_ containerCore.RemovalWitness) error {
 	return nil
 }
 
-func (m mock) PutEACL(_ *eacl.Table) error {
+func (m mock) PutEACL(_ containerCore.EACL) error {
 	return nil
 }
 

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -148,7 +148,7 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 
 	bearerTok := reqInfo.Bearer()
 	if bearerTok == nil {
-		pTable, err := c.eaclSrc.GetEACL(cnr)
+		eaclInfo, err := c.eaclSrc.GetEACL(cnr)
 		if err != nil {
 			if errors.Is(err, container.ErrEACLNotFound) {
 				return nil
@@ -156,7 +156,7 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 			return err
 		}
 
-		table = *pTable
+		table = *eaclInfo.Value
 	} else {
 		table = bearerTok.EACLTable()
 	}

--- a/pkg/services/object/acl/acl_test.go
+++ b/pkg/services/object/acl/acl_test.go
@@ -3,6 +3,7 @@ package acl
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	v2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/v2"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -14,7 +15,7 @@ import (
 
 type emptyEACLSource struct{}
 
-func (e emptyEACLSource) GetEACL(_ cid.ID) (*eaclSDK.Table, error) {
+func (e emptyEACLSource) GetEACL(_ cid.ID) (*container.EACL, error) {
 	return nil, nil
 }
 

--- a/pkg/services/object/acl/eacl/types.go
+++ b/pkg/services/object/acl/eacl/types.go
@@ -1,8 +1,8 @@
 package eacl
 
 import (
+	containercore "github.com/nspcc-dev/neofs-node/pkg/core/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 )
 
 // Source is the interface that wraps
@@ -15,5 +15,5 @@ type Source interface {
 	//
 	// Must return pkg/core/container.ErrEACLNotFound if requested
 	// eACL table is not in source.
-	GetEACL(cid.ID) (*eacl.Table, error)
+	GetEACL(cid.ID) (*containercore.EACL, error)
 }

--- a/pkg/services/object/acl/v2/service.go
+++ b/pkg/services/object/acl/v2/service.go
@@ -506,7 +506,7 @@ func (b Service) findRequestInfo(req MetaWithToken, idCnr cid.ID, op eaclSDK.Ope
 	cnr, err := b.containers.Get(idCnr) // fetch actual container
 	if err != nil {
 		return info, err
-	} else if cnr.OwnerID() == nil {
+	} else if cnr.Value.OwnerID() == nil {
 		return info, errors.New("missing owner in container descriptor")
 	}
 
@@ -526,7 +526,7 @@ func (b Service) findRequestInfo(req MetaWithToken, idCnr cid.ID, op eaclSDK.Ope
 	}
 
 	// find request role and key
-	res, err := b.c.classify(req, idCnr, cnr)
+	res, err := b.c.classify(req, idCnr, cnr.Value)
 	if err != nil {
 		return info, err
 	}
@@ -535,11 +535,11 @@ func (b Service) findRequestInfo(req MetaWithToken, idCnr cid.ID, op eaclSDK.Ope
 		return info, ErrUnknownRole
 	}
 
-	info.basicACL = cnr.BasicACL()
+	info.basicACL = cnr.Value.BasicACL()
 	info.requestRole = res.role
 	info.isInnerRing = res.isIR
 	info.operation = op
-	info.cnrOwner = *cnr.OwnerID()
+	info.cnrOwner = *cnr.Value.OwnerID()
 	info.idCnr = idCnr
 
 	// it is assumed that at the moment the key will be valid,

--- a/pkg/services/object/put/streamer.go
+++ b/pkg/services/object/put/streamer.go
@@ -156,7 +156,7 @@ func (p *Streamer) preparePrm(prm *PutInitPrm) error {
 	// add common options
 	prm.traverseOpts = append(prm.traverseOpts,
 		// set processing container
-		placement.ForContainer(cnr),
+		placement.ForContainer(cnr.Value),
 	)
 
 	if id, ok := prm.hdr.ID(); ok {

--- a/pkg/services/object/util/placement.go
+++ b/pkg/services/object/util/placement.go
@@ -147,7 +147,7 @@ func (g *TraverserGenerator) GenerateTraverser(idCnr cid.ID, idObj *oid.ID, epoc
 
 	traverseOpts = append(traverseOpts,
 		// set processing container
-		placement.ForContainer(cnr),
+		placement.ForContainer(cnr.Value),
 
 		// set placement builder
 		placement.UseBuilder(builder),

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -44,7 +44,7 @@ func (p *Policer) processObject(ctx context.Context, addr oid.Address) {
 		return
 	}
 
-	policy := cnr.PlacementPolicy()
+	policy := cnr.Value.PlacementPolicy()
 	if policy == nil {
 		p.log.Error("missing placement policy in container",
 			zap.Stringer("cid", idCnr),


### PR DESCRIPTION
After recent changes in NeoFS SDK Go library session tokens aren't
embedded into `container.Container` and `eacl.Table` structures.

Group value, session token and signature in a structure for container
and eACL.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>