### PR TITLE
Fix/Remove "trust" from non-reputation logs

### DIFF
--- a/pkg/services/container/announcement/load/controller/calls.go
+++ b/pkg/services/container/announcement/load/controller/calls.go
@@ -163,9 +163,9 @@ func (c *commonContext) freeAnnouncement() {
 	c.ctrl.announceMtx.Unlock()
 
 	if stopped {
-		c.log.Debug("trust announcement successfully interrupted")
+		c.log.Debug("announcement successfully interrupted")
 	} else {
-		c.log.Debug("trust announcement is not started or already interrupted")
+		c.log.Debug("announcement is not started or already interrupted")
 	}
 }
 
@@ -254,9 +254,9 @@ func (c *commonContext) freeReport() {
 	c.ctrl.reportMtx.Unlock()
 
 	if stopped {
-		c.log.Debug("trust announcement successfully interrupted")
+		c.log.Debug("announcement successfully interrupted")
 	} else {
-		c.log.Debug("trust announcement is not started or already interrupted")
+		c.log.Debug("announcement is not started or already interrupted")
 	}
 }
 


### PR DESCRIPTION
Were added by a mistake in #1210.