### PR TITLE
[#1307] neofs-adm: Add tests for `morph init` command

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/generate_test.go
+++ b/cmd/neofs-adm/internal/modules/morph/generate_test.go
@@ -58,16 +58,7 @@ func TestGenerateAlphabet(t *testing.T) {
 		require.Error(t, generateAlphabetCreds(cmd, nil))
 	})
 
-	buf.Reset()
-	v.Set(alphabetWalletsFlag, walletDir)
-	require.NoError(t, cmd.Flags().Set(alphabetSizeFlag, strconv.FormatUint(size, 10)))
-	for i := uint64(0); i < size; i++ {
-		buf.WriteString(strconv.FormatUint(i, 10) + "\r")
-	}
-
-	const groupPassword = "grouppass"
-	buf.WriteString(groupPassword + "\r")
-	require.NoError(t, generateAlphabetCreds(cmd, nil))
+	testGenerateAlphabet(t, buf, v, size, walletDir)
 
 	for i := uint64(0); i < size; i++ {
 		p := filepath.Join(walletDir, innerring.GlagoliticLetter(i).String()+".json")
@@ -93,7 +84,7 @@ func TestGenerateAlphabet(t *testing.T) {
 		w, err := wallet.NewWalletFromFile(p)
 		require.NoError(t, err, "contract wallet doesn't exist")
 		require.Equal(t, 1, len(w.Accounts), "contract wallet must have 1 accout")
-		require.NoError(t, w.Accounts[0].Decrypt(groupPassword, keys.NEP2ScryptParams()))
+		require.NoError(t, w.Accounts[0].Decrypt(testContractPassword, keys.NEP2ScryptParams()))
 	})
 }
 
@@ -116,4 +107,18 @@ func newTempDir(t *testing.T) string {
 		require.NoError(t, os.RemoveAll(dir))
 	})
 	return dir
+}
+
+const testContractPassword = "grouppass"
+
+func testGenerateAlphabet(t *testing.T, buf *bytes.Buffer, v *viper.Viper, size uint64, walletDir string) {
+	buf.Reset()
+	v.Set(alphabetWalletsFlag, walletDir)
+	require.NoError(t, generateAlphabetCmd.Flags().Set(alphabetSizeFlag, strconv.FormatUint(size, 10)))
+	for i := uint64(0); i < size; i++ {
+		buf.WriteString(strconv.FormatUint(i, 10) + "\r")
+	}
+
+	buf.WriteString(testContractPassword + "\r")
+	require.NoError(t, generateAlphabetCreds(generateAlphabetCmd, nil))
 }

--- a/cmd/neofs-adm/internal/modules/morph/initialize_test.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_test.go
@@ -1,0 +1,73 @@
+package morph
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/config"
+	"github.com/nspcc-dev/neo-go/pkg/vm"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestInitialize(t *testing.T) {
+	// This test needs neofs-contract tarball, so it is skipped by default.
+	// It is here for performing local testing after the changes.
+	t.Skip()
+
+	const contractsPath = "../../../../../../neofs-contract/neofs-contract-v0.15.2.tar.gz"
+	const committeeSize = 7
+	const validatorCount = committeeSize
+
+	walletDir := newTempDir(t)
+	buf := setupTestTerminal(t)
+	v := viper.GetViper()
+
+	testGenerateAlphabet(t, buf, v, committeeSize, walletDir)
+
+	var pubs []string
+	for i := 0; i < committeeSize; i++ {
+		p := filepath.Join(walletDir, innerring.GlagoliticLetter(i).String()+".json")
+		w, err := wallet.NewWalletFromFile(p)
+		require.NoError(t, err, "wallet doesn't exist")
+		for _, acc := range w.Accounts {
+			if acc.Label == singleAccountName {
+				pub, ok := vm.ParseSignatureContract(acc.Contract.Script)
+				require.True(t, ok)
+				pubs = append(pubs, hex.EncodeToString(pub))
+				continue
+			}
+		}
+	}
+
+	cfg := config.Config{}
+	cfg.ProtocolConfiguration.ValidatorsCount = validatorCount
+	cfg.ProtocolConfiguration.SecondsPerBlock = 1
+	cfg.ProtocolConfiguration.StandbyCommittee = pubs // sorted by glagolic letters
+	cfg.ProtocolConfiguration.P2PSigExtensions = true
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	protoPath := filepath.Join(walletDir, "proto.yml")
+	require.NoError(t, ioutil.WriteFile(protoPath, data, os.ModePerm))
+
+	v.Set(protoConfigPath, protoPath)
+	// Set to the path or remove the next statement to download from the network.
+	require.NoError(t, initCmd.Flags().Set(contractsInitFlag, contractsPath))
+	for i := 0; i < committeeSize; i++ {
+		v.Set("credentials."+innerring.GlagoliticLetter(i).String(), strconv.FormatUint(uint64(i), 10))
+	}
+	v.Set("credentials.contract", testContractPassword)
+	v.Set(localDumpFlag, filepath.Join(walletDir, "out"))
+	v.Set(alphabetWalletsFlag, walletDir)
+	v.Set(epochDurationInitFlag, 1)
+	v.Set(maxObjectSizeInitFlag, 1024)
+	require.NoError(t, initializeSideChainCmd(initCmd, nil))
+}


### PR DESCRIPTION
Close #1307.

Our integration tests currently do not support creating multiple-node committee. This test helps to quickly check `morph init` while doing some refactoring or local changes.

We can write more tests, however `morph init` is the biggest command and the task was about coverting at least it. New tests can be added when needed.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>