### PR TITLE
Allow to marshal `control shards list` as JSON

### DIFF
--- a/cmd/neofs-cli/internal/commonflags/json.go
+++ b/cmd/neofs-cli/internal/commonflags/json.go
@@ -1,0 +1,3 @@
+package commonflags
+
+const JSON = "json"

--- a/cmd/neofs-cli/modules/bearer/create.go
+++ b/cmd/neofs-cli/modules/bearer/create.go
@@ -28,7 +28,7 @@ const (
 	expireAtFlag       = "expire-at"
 	ownerFlag          = "owner"
 	outFlag            = "out"
-	jsonFlag           = "json"
+	jsonFlag           = commonflags.JSON
 )
 
 var createCmd = &cobra.Command{

--- a/cmd/neofs-cli/modules/container/get.go
+++ b/cmd/neofs-cli/modules/container/get.go
@@ -80,7 +80,7 @@ func initContainerInfoCmd() {
 	flags.StringVar(&containerID, "cid", "", "container ID")
 	flags.StringVar(&containerPathTo, "to", "", "path to dump encoded container")
 	flags.StringVar(&containerPathFrom, "from", "", "path to file with encoded container")
-	flags.BoolVar(&containerJSON, "json", false, "print or dump container in JSON format")
+	flags.BoolVar(&containerJSON, commonflags.JSON, false, "print or dump container in JSON format")
 }
 
 type stringWriter cobra.Command

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -59,5 +59,5 @@ func initContainerGetEACLCmd() {
 
 	flags.StringVar(&containerID, "cid", "", "container ID")
 	flags.StringVar(&containerPathTo, "to", "", "path to dump encoded container (default: binary encoded)")
-	flags.BoolVar(&containerJSON, "json", false, "encode EACL table in json format")
+	flags.BoolVar(&containerJSON, commonflags.JSON, false, "encode EACL table in json format")
 }

--- a/cmd/neofs-cli/modules/control/snapshot.go
+++ b/cmd/neofs-cli/modules/control/snapshot.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	netmapSnapshotJSONFlag = "json"
+	netmapSnapshotJSONFlag = commonflags.JSON
 )
 
 var snapshotCmd = &cobra.Command{

--- a/cmd/neofs-cli/modules/netmap/nodeinfo.go
+++ b/cmd/neofs-cli/modules/netmap/nodeinfo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const nodeInfoJSONFlag = "json"
+const nodeInfoJSONFlag = commonflags.JSON
 
 var nodeInfoCmd = &cobra.Command{
 	Use:   "nodeinfo",

--- a/cmd/neofs-cli/modules/object/get.go
+++ b/cmd/neofs-cli/modules/object/get.go
@@ -115,7 +115,7 @@ func getObject(cmd *cobra.Command, _ []string) {
 }
 
 func strictOutput(cmd *cobra.Command) bool {
-	toJSON, _ := cmd.Flags().GetBool("json")
+	toJSON, _ := cmd.Flags().GetBool(commonflags.JSON)
 	toProto, _ := cmd.Flags().GetBool("proto")
 	return toJSON || toProto
 }

--- a/cmd/neofs-cli/modules/object/head.go
+++ b/cmd/neofs-cli/modules/object/head.go
@@ -40,7 +40,7 @@ func initObjectHeadCmd() {
 
 	flags.String("file", "", "File to write header to. Default: stdout.")
 	flags.Bool("main-only", false, "Return only main fields")
-	flags.Bool("json", false, "Marshal output in JSON")
+	flags.Bool(commonflags.JSON, false, "Marshal output in JSON")
 	flags.Bool("proto", false, "Marshal output in Protobuf")
 	flags.Bool(rawFlag, false, rawFlagDesc)
 }
@@ -96,7 +96,7 @@ func saveAndPrintHeader(cmd *cobra.Command, obj *object.Object, filename string)
 }
 
 func marshalHeader(cmd *cobra.Command, hdr *object.Object) ([]byte, error) {
-	toJSON, _ := cmd.Flags().GetBool("json")
+	toJSON, _ := cmd.Flags().GetBool(commonflags.JSON)
 	toProto, _ := cmd.Flags().GetBool("proto")
 	switch {
 	case toJSON && toProto:

--- a/cmd/neofs-cli/modules/object/range.go
+++ b/cmd/neofs-cli/modules/object/range.go
@@ -120,7 +120,7 @@ func printSplitInfo(cmd *cobra.Command, info *object.SplitInfo) {
 }
 
 func marshalSplitInfo(cmd *cobra.Command, info *object.SplitInfo) ([]byte, error) {
-	toJSON, _ := cmd.Flags().GetBool("json")
+	toJSON, _ := cmd.Flags().GetBool(commonflags.JSON)
 	toProto, _ := cmd.Flags().GetBool("proto")
 	switch {
 	case toJSON && toProto:

--- a/cmd/neofs-cli/modules/session/create.go
+++ b/cmd/neofs-cli/modules/session/create.go
@@ -19,7 +19,7 @@ import (
 const (
 	lifetimeFlag = "lifetime"
 	outFlag      = "out"
-	jsonFlag     = "json"
+	jsonFlag     = commonflags.JSON
 )
 
 const defaultLifetime = 10

--- a/cmd/neofs-cli/modules/util/convert_eacl.go
+++ b/cmd/neofs-cli/modules/util/convert_eacl.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/spf13/cobra"
 )
 
@@ -23,13 +24,13 @@ func initConvertEACLCmd() {
 	_ = convertEACLCmd.MarkFlagRequired("from")
 
 	flags.String("to", "", "File to dump extended ACL table (default: binary encoded)")
-	flags.Bool("json", false, "Dump extended ACL table in JSON encoding")
+	flags.Bool(commonflags.JSON, false, "Dump extended ACL table in JSON encoding")
 }
 
 func convertEACLTable(cmd *cobra.Command, _ []string) {
 	pathFrom := cmd.Flag("from").Value.String()
 	to := cmd.Flag("to").Value.String()
-	jsonFlag, _ := cmd.Flags().GetBool("json")
+	jsonFlag, _ := cmd.Flags().GetBool(commonflags.JSON)
 
 	table := common.ReadEACL(cmd, pathFrom)
 

--- a/cmd/neofs-cli/modules/util/sign_bearer.go
+++ b/cmd/neofs-cli/modules/util/sign_bearer.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	signBearerJSONFlag = "json"
+	signBearerJSONFlag = commonflags.JSON
 )
 
 var signBearerCmd = &cobra.Command{


### PR DESCRIPTION
Close #1541.

Marshaling with jsonpb has one advantage: we will never forget to add new fields in CLI.
However, the general approach would eventually be done anyway in #1323 .

What do you think? @cthulhu-rider @carpawell 