### PR TITLE
shard: Turn `ModeDegraded` on metabase opening failure

### DIFF
--- a/pkg/local_object_storage/blobstor/control.go
+++ b/pkg/local_object_storage/blobstor/control.go
@@ -1,5 +1,10 @@
 package blobstor
 
+import (
+	"errors"
+	"fmt"
+)
+
 // Open opens BlobStor.
 func (b *BlobStor) Open() error {
 	b.log.Debug("opening...")
@@ -7,13 +12,23 @@ func (b *BlobStor) Open() error {
 	return nil
 }
 
+// ErrInitBlobovniczas is returned when blobovnicza initialization fails.
+var ErrInitBlobovniczas = errors.New("failure on blobovnicza initialization stage")
+
 // Init initializes internal data structures and system resources.
 //
 // If BlobStor is already initialized, no action is taken.
+//
+// Returns wrapped ErrInitBlobovniczas on blobovnicza tree's initializaiton failure.
 func (b *BlobStor) Init() error {
 	b.log.Debug("initializing...")
 
-	return b.blobovniczas.init()
+	err := b.blobovniczas.init()
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInitBlobovniczas, err)
+	}
+
+	return nil
 }
 
 // Close releases all internal resources of BlobStor.

--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -82,5 +82,9 @@ func (db *DB) init(reset bool) error {
 
 // Close closes boltDB instance.
 func (db *DB) Close() error {
-	return db.boltDB.Close()
+	if db.boltDB != nil {
+		return db.boltDB.Close()
+	}
+
+	return nil
 }

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -178,11 +178,7 @@ func (s *Shard) Close() error {
 		components = append(components, s.writeCache)
 	}
 
-	components = append(components, s.pilorama, s.blobStor)
-
-	if s.GetMode() != ModeDegraded {
-		components = append(components, s.metaBase)
-	}
+	components = append(components, s.pilorama, s.blobStor, s.metaBase)
 
 	for _, component := range components {
 		if err := component.Close(); err != nil {


### PR DESCRIPTION
Make `Shard` to work in degraded mode if metabase is unavailable on
opening stage.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #1549

About 9bf46d99818bf6f5218535fb9f555e48356d9cab: I don't think it makes sense to define `ModeDisabled` shard mode now since `StorageEngine` can't work with it. Maybe we can implement private behavior on `Shard` side when it fails all the calls if `Init` was failed, smth like `errNotInitialized`.