### PR TITLE
Fix/Return homomorphic hashing

### DIFF
--- a/pkg/services/object_manager/transformer/transformer.go
+++ b/pkg/services/object_manager/transformer/transformer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oidSDK "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/tzhash/tz"
 )
 
 type payloadSizeLimiter struct {
@@ -151,19 +152,19 @@ func payloadHashersForObject(obj *object.Object, withoutHomomorphicHash bool) []
 
 	if !withoutHomomorphicHash {
 		hashers = append(hashers, &payloadChecksumHasher{
-			hasher: sha256.New(),
+			hasher: tz.New(),
 			checksumWriter: func(cs []byte) {
-				if ln := len(cs); ln != sha256.Size {
-					panic(fmt.Sprintf("wrong checksum length: expected %d, has %d", sha256.Size, ln))
+				if ln := len(cs); ln != tz.Size {
+					panic(fmt.Sprintf("wrong checksum length: expected %d, has %d", tz.Size, ln))
 				}
 
-				csSHA := [sha256.Size]byte{}
-				copy(csSHA[:], cs)
+				csTZ := [tz.Size]byte{}
+				copy(csTZ[:], cs)
 
 				checksum := checksum.New()
-				checksum.SetSHA256(csSHA)
+				checksum.SetTillichZemor(csTZ)
 
-				obj.SetPayloadChecksum(checksum)
+				obj.SetPayloadHomomorphicHash(checksum)
 			},
 		})
 	}


### PR DESCRIPTION
I decided to refactor that part right before the merge (and after all tests) and ctrl-c/ctrl-v played a trick on me.

NOTE: required to be picked on other branches, e.g. experimental branch has another [version](https://github.com/nspcc-dev/neofs-node/commit/040565da1ae98a477aac529fdd2cac9b688659de#diff-dba0a1e839a813f39cf74ce3e090a058155c7985f37bef9b9694010e9ded722aL160) (calc SHA but set homomorphic). I have no idea how that happened, mb rebasing problems.