### PR TITLE
morph/client: perform RPC switch and restore in one step

### DIFF
--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -54,9 +54,11 @@ type Client struct {
 
 	cfg cfg
 
-	endpoints *endpoints
+	endpoints endpoints
 
-	// switching between rpc endpoint lock
+	// switchLock protects endpoints, inactive, and subscription-related fields.
+	// It is taken exclusively during endpoint switch and locked in shared mode
+	// on every normal call.
 	switchLock *sync.RWMutex
 
 	// channel for ws notifications

--- a/pkg/morph/client/constructor.go
+++ b/pkg/morph/client/constructor.go
@@ -111,7 +111,7 @@ func New(key *keys.PrivateKey, endpoint string, opts ...Option) (*Client, error)
 		// they will be used in switch process, otherwise
 		// inactive mode will be enabled
 		cli.client = cfg.singleCli
-		cli.endpoints = newEndpoints(cfg.extraEndpoints)
+		cli.endpoints.init(cfg.extraEndpoints)
 	} else {
 		ws, err := newWSClient(*cfg, endpoint)
 		if err != nil {
@@ -124,7 +124,7 @@ func New(key *keys.PrivateKey, endpoint string, opts ...Option) (*Client, error)
 		}
 
 		cli.client = ws
-		cli.endpoints = newEndpoints(append([]string{endpoint}, cfg.extraEndpoints...))
+		cli.endpoints.init(append([]string{endpoint}, cfg.extraEndpoints...))
 	}
 
 	go cli.notificationLoop()

--- a/pkg/morph/client/fee.go
+++ b/pkg/morph/client/fee.go
@@ -9,21 +9,12 @@ import "github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 type customFees map[string]fixedn.Fixed8
 
 // setFeeForMethod sets fee for the operation executed using specified contract method.
-func (x *customFees) setFeeForMethod(method string, fee fixedn.Fixed8) {
-	m := *x
-	if m == nil {
-		m = make(map[string]fixedn.Fixed8, 1)
-		*x = m
+func (x *fees) setFeeForMethod(method string, fee fixedn.Fixed8) {
+	if x.customFees == nil {
+		x.customFees = make(map[string]fixedn.Fixed8, 1)
 	}
 
-	m[method] = fee
-}
-
-// returns customized for the operation executed using specified contract method.
-// Returns false if fee is not customized.
-func (x customFees) feeForMethod(method string) (fixedn.Fixed8, bool) {
-	v, ok := x[method]
-	return v, ok
+	x.customFees[method] = fee
 }
 
 // fees represents source of per-operation fees.
@@ -33,19 +24,17 @@ func (x customFees) feeForMethod(method string) (fixedn.Fixed8, bool) {
 type fees struct {
 	defaultFee fixedn.Fixed8
 
-	customFees
-}
-
-// sets default fee for all operations.
-func (x *fees) setDefault(fee fixedn.Fixed8) {
-	x.defaultFee = fee
+	// customFees represents source of customized per-operation fees.
+	customFees map[string]fixedn.Fixed8
 }
 
 // returns fee for the operation executed using specified contract method.
 // Returns customized value if it is set. Otherwise, returns default value.
 func (x fees) feeForMethod(method string) fixedn.Fixed8 {
-	if fee, ok := x.customFees.feeForMethod(method); ok {
-		return fee
+	if x.customFees != nil {
+		if fee, ok := x.customFees[method]; ok {
+			return fee
+		}
 	}
 
 	return x.defaultFee

--- a/pkg/morph/client/fee_test.go
+++ b/pkg/morph/client/fee_test.go
@@ -17,7 +17,7 @@ func TestFees(t *testing.T) {
 		def = fixedn.Fixed8(13)
 	)
 
-	v.setDefault(def)
+	v.defaultFee = def
 
 	fee = v.feeForMethod(method)
 	require.True(t, fee.Equal(def))

--- a/pkg/morph/client/notifications.go
+++ b/pkg/morph/client/notifications.go
@@ -204,15 +204,11 @@ func (c *Client) UnsubscribeAll() error {
 
 // restoreSubscriptions restores subscriptions according to
 // cached information about them.
-func (c *Client) restoreSubscriptions() bool {
+func (c *Client) restoreSubscriptions(endpoint string) bool {
 	var (
-		err         error
-		id          string
-		endpoint, _ = c.endpoints.current()
+		err error
+		id  string
 	)
-
-	c.switchLock.Lock()
-	defer c.switchLock.Unlock()
 
 	// new block events restoration
 	if c.subscribedToNewBlocks {

--- a/pkg/morph/client/static.go
+++ b/pkg/morph/client/static.go
@@ -63,7 +63,7 @@ func NewStatic(client *Client, scriptHash util.Uint160, fee fixedn.Fixed8, opts 
 		scScriptHash: scriptHash,
 	}
 
-	c.fees.setDefault(fee)
+	c.fees.defaultFee = fee
 
 	for i := range opts {
 		opts[i](&c.staticOpts)


### PR DESCRIPTION
Otherwise we could switch infinitely if subscription restore has failed.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>