### PR TITLE
Feat/Support `OUT_OF_RANGE` status

### DIFF
--- a/pkg/core/object/errors.go
+++ b/pkg/core/object/errors.go
@@ -1,7 +1,0 @@
-package object
-
-import "errors"
-
-// ErrRangeOutOfBounds is a basic error of violation of the boundaries of the
-// payload of an object.
-var ErrRangeOutOfBounds = errors.New("payload range is out of bounds")

--- a/pkg/local_object_storage/blobstor/errors.go
+++ b/pkg/local_object_storage/blobstor/errors.go
@@ -1,0 +1,11 @@
+package blobstor
+
+import (
+	"errors"
+
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+)
+
+func isErrOutOfRange(err error) bool {
+	return errors.As(err, new(apistatus.ObjectOutOfRange))
+}

--- a/pkg/local_object_storage/blobstor/get_range_big.go
+++ b/pkg/local_object_storage/blobstor/get_range_big.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
@@ -56,7 +55,9 @@ func (b *BlobStor) GetRangeBig(prm GetRangeBigPrm) (GetRangeBigRes, error) {
 	ln, off := prm.rng.GetLength(), prm.rng.GetOffset()
 
 	if pLen := uint64(len(payload)); pLen < ln+off {
-		return GetRangeBigRes{}, object.ErrRangeOutOfBounds
+		var errOutOfRange apistatus.ObjectOutOfRange
+
+		return GetRangeBigRes{}, errOutOfRange
 	}
 
 	return GetRangeBigRes{

--- a/pkg/local_object_storage/engine/error_test.go
+++ b/pkg/local_object_storage/engine/error_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/stretchr/testify/require"
@@ -184,7 +185,7 @@ func TestBlobstorFailback(t *testing.T) {
 		require.Equal(t, objs[i].Payload()[1:11], rngRes.Object().Payload())
 
 		_, err = e.GetRange(RngPrm{addr: addr, off: errSmallSize + 10, ln: 1})
-		require.ErrorIs(t, err, object.ErrRangeOutOfBounds)
+		require.ErrorAs(t, err, &apistatus.ObjectOutOfRange{})
 	}
 
 	checkShardState(t, e, id[0], 4, shard.ModeDegraded)

--- a/pkg/local_object_storage/shard/errors.go
+++ b/pkg/local_object_storage/shard/errors.go
@@ -17,3 +17,9 @@ func IsErrNotFound(err error) bool {
 func IsErrRemoved(err error) bool {
 	return errors.As(err, new(apistatus.ObjectAlreadyRemoved))
 }
+
+// IsErrOutOfRange checks if an error returned by Shard GetRange method
+// corresponds to exceeding the object bounds.
+func IsErrOutOfRange(err error) bool {
+	return errors.As(err, new(apistatus.ObjectOutOfRange))
+}

--- a/pkg/local_object_storage/shard/get.go
+++ b/pkg/local_object_storage/shard/get.go
@@ -1,10 +1,8 @@
 package shard
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobovnicza"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
@@ -129,7 +127,7 @@ func (s *Shard) fetchObjectData(addr oid.Address, skipMeta bool, big, small stor
 
 	if skipMeta || err != nil {
 		res, err = small(s.blobStor, nil)
-		if err == nil || errors.Is(err, object.ErrRangeOutOfBounds) {
+		if err == nil || IsErrOutOfRange(err) {
 			return res, false, err
 		}
 		res, err = big(s.blobStor, nil)

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -1,7 +1,7 @@
 package getsvc
 
 import (
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
@@ -93,8 +93,11 @@ func (exec *execCtx) initFromChild(obj oid.ID) (prev *oid.ID, children []oid.ID)
 		parSize := par.PayloadSize()
 
 		if seekOff+seekLen > parSize {
+			var errOutOfRange apistatus.ObjectOutOfRange
+
+			exec.err = errOutOfRange
 			exec.status = statusOutOfRange
-			exec.err = object.ErrRangeOutOfBounds
+
 			return
 		}
 

--- a/pkg/services/object/get/local.go
+++ b/pkg/services/object/get/local.go
@@ -3,7 +3,6 @@ package getsvc
 import (
 	"errors"
 
-	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.uber.org/zap"
@@ -16,6 +15,7 @@ func (exec *execCtx) executeLocal() {
 
 	var errSplitInfo *objectSDK.SplitInfoError
 	var errRemoved apistatus.ObjectAlreadyRemoved
+	var errOutOfRange apistatus.ObjectOutOfRange
 
 	switch {
 	default:
@@ -36,8 +36,8 @@ func (exec *execCtx) executeLocal() {
 		exec.status = statusVIRTUAL
 		mergeSplitInfo(exec.splitInfo(), errSplitInfo.SplitInfo())
 		exec.err = objectSDK.NewSplitInfoError(exec.infoSplit)
-	case errors.Is(err, object.ErrRangeOutOfBounds):
+	case errors.As(err, &errOutOfRange):
 		exec.status = statusOutOfRange
-		exec.err = object.ErrRangeOutOfBounds
+		exec.err = errOutOfRange
 	}
 }

--- a/pkg/services/object/get/remote.go
+++ b/pkg/services/object/get/remote.go
@@ -22,6 +22,7 @@ func (exec *execCtx) processNode(ctx context.Context, info client.NodeInfo) bool
 
 	var errSplitInfo *objectSDK.SplitInfoError
 	var errRemoved *apistatus.ObjectAlreadyRemoved
+	var errOutOfRange *apistatus.ObjectOutOfRange
 
 	switch {
 	default:
@@ -41,6 +42,9 @@ func (exec *execCtx) processNode(ctx context.Context, info client.NodeInfo) bool
 	case errors.As(err, &errRemoved):
 		exec.status = statusINHUMED
 		exec.err = errRemoved
+	case errors.As(err, &errOutOfRange):
+		exec.status = statusOutOfRange
+		exec.err = errOutOfRange
 	case errors.As(err, &errSplitInfo):
 		exec.status = statusVIRTUAL
 		mergeSplitInfo(exec.splitInfo(), errSplitInfo.SplitInfo())


### PR DESCRIPTION
Replace `ErrRangeOutOfBounds` error from `pkg/core/object` package with
`ObjectOutOfRange` from `apistatus` package. That error is returned by
storage node's server as NeoFS API statuses.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

- [x] Blocked by https://github.com/nspcc-dev/neofs-api-go/pull/407;
- [x] Blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/282.