### PR TITLE
Fix/OOM on `GetRange` request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Do not replicate object twice to the same node (#1410)
 - Concurrent object handling by the Policer (#1411)
 - Attaching API version to the forwarded requests (#1581)
+- Node OOM panics on `GetRange` request with extremely huge range length (#1590)
 
 ### Removed
 

--- a/pkg/services/object/get/v2/util.go
+++ b/pkg/services/object/get/v2/util.go
@@ -250,7 +250,8 @@ func (s *Service) toRangePrm(req *objectV2.GetRangeRequest, stream objectSvc.Get
 				return nil, fmt.Errorf("could not create Get payload range stream: %w", err)
 			}
 
-			payload := make([]byte, 0, body.GetRange().GetLength())
+			// allocate memory only after receiving a successful response
+			var payload []byte
 
 			resp := new(objectV2.GetRangeResponse)
 
@@ -283,6 +284,10 @@ func (s *Service) toRangePrm(req *objectV2.GetRangeRequest, stream objectSvc.Get
 				case nil:
 					return nil, fmt.Errorf("unexpected range type %T", v)
 				case *objectV2.GetRangePartChunk:
+					if payload == nil {
+						payload = make([]byte, 0, body.GetRange().GetLength())
+					}
+
 					payload = append(payload, v.GetChunk()...)
 				case *objectV2.SplitInfo:
 					si := object.NewSplitInfoFromV2(v)


### PR DESCRIPTION
This is the fastest solution that does work as planned. I thought about forwarding and responding via streams but decided to just fix OOM error in that PR and change request forwarding in a separate PR (if needed) after some discussion.

#### What also could be done: 
1. Do not allocate memory more than `MaxObjectSize` (another node could somehow respond with OK status on `GetRange` with *incredibly huge* range length).
2. Forward requests and stream the response (not copy the whole object in memory). This will require changing all the forwarding approaches (`Get`/`GetRange`).

NOTE: PR also fixes status handling after the #1581, so #1581 should not be added to *any* release without that PR. Since we do not handle statuses but also do not get raw errs via RPC calls (version is attached to the requests after #1581) we end up at [that line](https://github.com/nspcc-dev/neofs-node/blob/fdf62e85625aadb55f0884b27ed504b13efe90da/pkg/services/object/get/v2/util.go#L138): 
```
2022-07-07T15:28:51.856Z	debug	get/remote.go:33	remote call failed	{"component": "Object.Get service", "request": "GET", "address": "JD1vUeEvvsb33gTKF69tuciPxVi3h8EEVhqCYo6tc2rm/4cgqEM7pcnBPc5JGJqPfbBPxoVdC9stemCCjRaZXX6m3", "raw": false, "local": false, "with session": true, "with bearer": false, "error": "unexpected object part <nil>"}
```