### PR TITLE
Feat/Stream forwarder requests

### DIFF
--- a/pkg/services/object/get/remote.go
+++ b/pkg/services/object/get/remote.go
@@ -36,8 +36,14 @@ func (exec *execCtx) processNode(ctx context.Context, info client.NodeInfo) bool
 	case err == nil:
 		exec.status = statusOK
 		exec.err = nil
-		exec.collectedObject = obj
-		exec.writeCollectedObject()
+
+		// both object and err are nil only if the original
+		// request was forwarded to another node and the object
+		// has already been streamed to the requesting party
+		if obj != nil {
+			exec.collectedObject = obj
+			exec.writeCollectedObject()
+		}
 	case errors.As(err, &errRemoved):
 		exec.status = statusINHUMED
 		exec.err = errRemoved


### PR DESCRIPTION
Do not hold objects in memory in the forwarded Get/GetRange requests.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>