### PR TITLE
Feat/Add health metrics

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -103,7 +103,7 @@ type cfg struct {
 
 	cfgNotifications cfgNotifications
 
-	metricsCollector *metrics.StorageMetrics
+	metricsCollector *metrics.NodeMetrics
 
 	workers []worker
 
@@ -322,7 +322,7 @@ func initCfg(path string) *cfg {
 	user.IDFromKey(&c.ownerIDFromKey, key.PrivateKey.PublicKey)
 
 	if metricsconfig.Enabled(c.appCfg) {
-		c.metricsCollector = metrics.NewStorageMetrics()
+		c.metricsCollector = metrics.NewNodeMetrics()
 		netState.metrics = c.metricsCollector
 	}
 

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -69,6 +69,10 @@ func (c *cfg) NetmapStatus() control.NetmapStatus {
 
 func (c *cfg) setHealthStatus(st control.HealthStatus) {
 	c.healthStatus.Store(int32(st))
+
+	if c.metricsCollector != nil {
+		c.metricsCollector.SetHealth(int32(st))
+	}
 }
 
 func (c *cfg) HealthStatus() control.HealthStatus {

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -31,7 +31,7 @@ type networkState struct {
 
 	nodeInfo atomic.Value // *netmapSDK.NodeInfo
 
-	metrics *metrics.StorageMetrics
+	metrics *metrics.NodeMetrics
 }
 
 func newNetworkState() *networkState {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,18 +4,22 @@ import "github.com/prometheus/client_golang/prometheus"
 
 const namespace = "neofs_node"
 
-type StorageMetrics struct {
+type NodeMetrics struct {
 	objectServiceMetrics
 	engineMetrics
+	stateMetrics
 	epoch prometheus.Gauge
 }
 
-func NewStorageMetrics() *StorageMetrics {
+func NewNodeMetrics() *NodeMetrics {
 	objectService := newObjectServiceMetrics()
 	objectService.register()
 
 	engine := newEngineMetrics()
 	engine.register()
+
+	state := newStateMetrics()
+	state.register()
 
 	epoch := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -25,14 +29,15 @@ func NewStorageMetrics() *StorageMetrics {
 	})
 	prometheus.MustRegister(epoch)
 
-	return &StorageMetrics{
+	return &NodeMetrics{
 		objectServiceMetrics: objectService,
 		engineMetrics:        engine,
+		stateMetrics:         state,
 		epoch:                epoch,
 	}
 }
 
 // SetEpoch updates epoch metric.
-func (m *StorageMetrics) SetEpoch(epoch uint64) {
+func (m *NodeMetrics) SetEpoch(epoch uint64) {
 	m.epoch.Set(float64(epoch))
 }

--- a/pkg/metrics/state.go
+++ b/pkg/metrics/state.go
@@ -1,0 +1,28 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const stateSubsystem = "state"
+
+type stateMetrics struct {
+	healthCheck prometheus.Gauge
+}
+
+func newStateMetrics() stateMetrics {
+	return stateMetrics{
+		healthCheck: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: stateSubsystem,
+			Name:      "health",
+			Help:      "Current Node state",
+		}),
+	}
+}
+
+func (m stateMetrics) register() {
+	prometheus.MustRegister(m.healthCheck)
+}
+
+func (m stateMetrics) SetHealth(s int32) {
+	m.healthCheck.Set(float64(s))
+}


### PR DESCRIPTION
`neofs_node_state_health` metric name. Values have the same meaning as in [control enum](https://github.com/nspcc-dev/neofs-node/blob/198beae703289b7a62bbd38b89cb30ea7a1f87f2/pkg/services/control/types.pb.go#L83).