### PR TITLE
Fix/Use OID/CID from the request in eACL checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changelog for NeoFS Node
 
 ### Fixed
 
+- Losing request context in eACL response checks (#1595)
+
 ### Removed
 
 ### Updated


### PR DESCRIPTION
Also, try to fetch object header info from the local storage to find as much
object info as possible for the requests which do not assume returning
object header as a response.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1595. @fyrchik, @alexvanin, please, double-check that solution. The main idea is to always use cid and oid from the request as a descriptor of the object being streamed. I do not know how to check if the streamed object really has that bytes that a node is streaming and if it really should be checked. Also, i do not if it is ok to just answer `ALLOW` if it is impossible to fetch the header from the local storage for streamed requests; but seems that solution was considered as working according to reading some other previous commits.