### PR TITLE
Fix neofs-adm group processing during an update

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -223,7 +223,7 @@ func (c *initializeContext) updateContracts() error {
 			}
 		}
 
-		err = c.addManifestGroup(ctrHash, alphaCs)
+		err = c.addManifestGroup(ctrHash, cs)
 		if err != nil {
 			return fmt.Errorf("can't sign manifest group: %v", err)
 		}


### PR DESCRIPTION
1. Assign the group to all contracts.
2. Assign group to the alphabet ones too.