### PR TITLE
innerring: exit if we cannot bind to the control endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 - Losing request context in eACL response checks (#1595)
+- `neofs-ir` no longer hangs if it cannot bind to the control endpoint (#1643)
 - Do not require `lifetime` flag in `session create` CLI command (#1655)
 
 ### Removed


### PR DESCRIPTION
Close #1641 .

Return listen errors in a synchronous fashion.
Another solution would be to use buffered channel, but this is not
scalable: for each new similar runner we would need to extend the
buffer.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>