### PR TITLE
Feat/Support `EACL_NOT_FOUND` status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.99.1
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220727202624-6c7a401f776a // indirect
-	github.com/nspcc-dev/neofs-api-go/v2 v2.13.0
+	github.com/nspcc-dev/neofs-api-go/v2 v2.13.1
 	github.com/nspcc-dev/neofs-contract v0.15.3
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220801165707-7a99cc916c8e
 	github.com/nspcc-dev/tzhash v1.6.1
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220727202624-6c7a401f776a h1:ND
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220727202624-6c7a401f776a/go.mod h1:QBE0I30F2kOAISNpT5oks82yF4wkkUq3SCfI3Hqgx/Y=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.0 h1:7BcBiSjmWqJx0SPFlGRYt9ZFbMjucRIz9+Mv8UBLeq8=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.0/go.mod h1:73j09Xa7I2zQbM3HCvAHnDHPYiiWnEHa1d6Z6RDMBLU=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.1 h1:s/xOhWtypsrevlhx4VzqiqFSLipSxLKc09IiFpfShHk=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.1/go.mod h1:73j09Xa7I2zQbM3HCvAHnDHPYiiWnEHa1d6Z6RDMBLU=
 github.com/nspcc-dev/neofs-contract v0.15.3 h1:7+NwyTtxFAnIevz0hR/XxQf6R2Ej2scjVR2bnnJnhBM=
 github.com/nspcc-dev/neofs-contract v0.15.3/go.mod h1:BXVZUZUJxrmmDETglXHI8+5DSgn84B9y5DoSWqEjYCs=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
@@ -460,8 +460,8 @@ github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnB
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6 h1:RgkytZY51qCFL7Bbo2GRAAGHukxM9CpNkkDYr15AOA0=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6/go.mod h1:lis8Maqsac+fwSGsEbqHqsA8ttQxSo3xENLmo4QhcW4=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220801165707-7a99cc916c8e h1:aLRQD3kNibSM49t51KwSgr4n6K1X/yGcV/3J3w1adow=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220801165707-7a99cc916c8e/go.mod h1:Wiw/FcQVxtvuOO70TidxFcQzFcyh8FFwqyCHscmf2rY=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/core/container/storage.go
+++ b/pkg/core/container/storage.go
@@ -43,10 +43,6 @@ func IsErrNotFound(err error) bool {
 	return errors.As(err, new(apistatus.ContainerNotFound))
 }
 
-// ErrEACLNotFound is returned by eACL storage implementations when
-// the requested eACL table is not in the storage.
-var ErrEACLNotFound = errors.New("extended ACL table is not set for this container")
-
 // EACL groups information about the NeoFS container's extended ACL stored in
 // the NeoFS network.
 type EACL struct {

--- a/pkg/morph/client/container/eacl.go
+++ b/pkg/morph/client/container/eacl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
@@ -14,6 +15,8 @@ import (
 
 // GetEACL reads the extended ACL table from NeoFS system
 // through Container contract call.
+//
+// Returns apistatus.EACLNotFound if eACL table is missing in the contract.
 func (c *Client) GetEACL(cnr cid.ID) (*container.EACL, error) {
 	binCnr := make([]byte, sha256.Size)
 	cnr.Encode(binCnr)
@@ -52,7 +55,9 @@ func (c *Client) GetEACL(cnr cid.ID) (*container.EACL, error) {
 	// The absence of a signature in the response can be taken as an eACL absence criterion,
 	// since unsigned table cannot be approved in the storage by design.
 	if len(sig) == 0 {
-		return nil, container.ErrEACLNotFound
+		var errEACLNotFound apistatus.EACLNotFound
+
+		return nil, errEACLNotFound
 	}
 
 	pub, err := client.BytesFromStackItem(arr[2])

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
-	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl"
 	eaclV2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/eacl/v2"
 	v2 "github.com/nspcc-dev/neofs-node/pkg/services/object/acl/v2"
 	bearerSDK "github.com/nspcc-dev/neofs-sdk-go/bearer"
+	"github.com/nspcc-dev/neofs-sdk-go/client"
 	"github.com/nspcc-dev/neofs-sdk-go/container/acl"
 	neofsecdsa "github.com/nspcc-dev/neofs-sdk-go/crypto/ecdsa"
 	eaclSDK "github.com/nspcc-dev/neofs-sdk-go/eacl"
@@ -136,7 +136,7 @@ func (c *Checker) CheckEACL(msg interface{}, reqInfo v2.RequestInfo) error {
 	if bearerTok == nil {
 		eaclInfo, err := c.eaclSrc.GetEACL(cnr)
 		if err != nil {
-			if errors.Is(err, container.ErrEACLNotFound) {
+			if client.IsErrEACLNotFound(err) {
 				return nil
 			}
 			return err

--- a/pkg/services/object/acl/eacl/types.go
+++ b/pkg/services/object/acl/eacl/types.go
@@ -13,7 +13,7 @@ type Source interface {
 	//
 	// GetEACL must return exactly one non-nil value.
 	//
-	// Must return pkg/core/container.ErrEACLNotFound if requested
+	// Must return apistatus.ErrEACLNotFound if requested
 	// eACL table is not in source.
 	GetEACL(cid.ID) (*containercore.EACL, error)
 }


### PR DESCRIPTION
Remove internal `ErrEACLNotFound` error.
Also, update `neofs-api-go` and and `neofs-sdk-library`.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Related to https://github.com/nspcc-dev/neofs-sdk-go/issues/305.