### PR TITLE
Fix/Do not force specifying session lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 - Losing request context in eACL response checks (#1595)
+- Do not require `lifetime` flag in `session create` CLI command (#1655)
 
 ### Removed
 

--- a/cmd/neofs-cli/modules/session/create.go
+++ b/cmd/neofs-cli/modules/session/create.go
@@ -42,7 +42,6 @@ func init() {
 	createCmd.Flags().Bool(jsonFlag, false, "output token in JSON")
 	createCmd.Flags().StringP(commonflags.RPC, commonflags.RPCShorthand, commonflags.RPCDefault, commonflags.RPCUsage)
 
-	_ = cobra.MarkFlagRequired(createCmd.Flags(), commonflags.Lifetime)
 	_ = cobra.MarkFlagRequired(createCmd.Flags(), commonflags.WalletPath)
 	_ = cobra.MarkFlagRequired(createCmd.Flags(), outFlag)
 	_ = cobra.MarkFlagRequired(createCmd.Flags(), commonflags.RPC)


### PR DESCRIPTION
We have the default value which is also printed in the help messages but any
call that does not specify that flag leads to an error.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>