### PR TITLE
Use stdout as default output for neofs-lens

### DIFF
--- a/cmd/neofs-lens/root.go
+++ b/cmd/neofs-lens/root.go
@@ -30,6 +30,8 @@ func entryPoint(cmd *cobra.Command, _ []string) error {
 }
 
 func init() {
+	// use stdout as default output for cmd.Print()
+	command.SetOut(os.Stdout)
 	command.Flags().Bool("version", false, "application version")
 	command.AddCommand(
 		cmdlist.Command,


### PR DESCRIPTION
Propose fix for #1665 