### PR TITLE
Fix/Panic on write-cache `Delete` operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 ### Changed
 
 ### Fixed
+- Panic on write-cache's `Delete` operation (#1664)
 
 ### Removed
 

--- a/pkg/local_object_storage/writecache/delete.go
+++ b/pkg/local_object_storage/writecache/delete.go
@@ -26,9 +26,9 @@ func (c *cache) Delete(addr oid.Address) error {
 	c.mtx.Lock()
 	for i := range c.mem {
 		if saddr == c.mem[i].addr {
+			c.curMemSize -= uint64(len(c.mem[i].data))
 			copy(c.mem[i:], c.mem[i+1:])
 			c.mem = c.mem[:len(c.mem)-1]
-			c.curMemSize -= uint64(len(c.mem[i].data))
 			c.mtx.Unlock()
 			storagelog.Write(c.log, storagelog.AddressField(saddr), storagelog.OpField("in-mem DELETE"))
 			return nil


### PR DESCRIPTION
If an object is found in the Write-cache and is placed at the end of
the in-memory cache, the memory counter update operation tries to dereference
the index that is out of the sliced array. Moreover, even if panic does not appear,
the counter is updated with the wrong value.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1664. The wrong place for that line has been chosen in #568.