### PR TITLE
Filter version tags for version calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL = bash
 
 REPO ?= $(shell go list -m)
-VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || cat VERSION 2>/dev/null || echo "develop")
+VERSION ?= $(shell git describe --tags --dirty --match "v*" --always 2>/dev/null || cat VERSION 2>/dev/null || echo "develop")
 
 HUB_IMAGE ?= nspccdev/neofs
 HUB_TAG ?= "$(shell echo ${VERSION} | sed 's/^v//')"


### PR DESCRIPTION
**Summary:** only tags that start with "v" will be accounted for in VERSION calculation.

**Motivation:** this allows us to use any custom tags along with tags that denote releases
