### PR TITLE
Fix/Separate deploying contract and NNS updating transaction

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/deploy.go
@@ -95,11 +95,6 @@ func deployContractCmd(cmd *cobra.Command, args []string) error {
 			cs.Manifest.Name)
 	}
 
-	err = c.addManifestGroup(cs.Hash, cs)
-	if err != nil {
-		return fmt.Errorf("can't sign manifest group: %v", err)
-	}
-
 	w := io.NewBufBinWriter()
 	if err := emitDeploymentArguments(w.BinWriter, args); err != nil {
 		return err

--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -116,9 +116,12 @@ func newInitializeContext(cmd *cobra.Command, v *viper.Viper) (*initializeContex
 		return nil, err
 	}
 
-	w, err := openContractWallet(v, cmd, walletDir)
-	if err != nil {
-		return nil, err
+	var w *wallet.Wallet
+	if cmd.Name() != "deploy" {
+		w, err = openContractWallet(v, cmd, walletDir)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var c Client


### PR DESCRIPTION
Deploy contract in one transaction and register NNS record in another to
prevent GAS limit exceeding due to the fact that registration always takes
10+ GAS.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1675.