### PR TITLE
[#1647] writecache: Open DB in sync mode

### DIFF
--- a/pkg/local_object_storage/writecache/util.go
+++ b/pkg/local_object_storage/writecache/util.go
@@ -12,7 +12,6 @@ import (
 func OpenDB(p string, ro bool) (*bbolt.DB, error) {
 	return bbolt.Open(filepath.Join(p, dbName), os.ModePerm, &bbolt.Options{
 		NoFreelistSync: true,
-		NoSync:         true,
 		ReadOnly:       ro,
 		Timeout:        100 * time.Millisecond,
 	})


### PR DESCRIPTION
Close #1647.

Initially, `Sync: false` was provided because we can already lose
objects cached in memory. However, future changes in writecache will
remove inmemory cache and speed up it via other means.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>