### PR TITLE
Fix/SG put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Panic on write-cache's `Delete` operation (#1664)
+- Payload duplication in `neofs-cli storagegroup put` (#1706)
 
 ### Removed
 

--- a/cmd/neofs-cli/modules/storagegroup/put.go
+++ b/cmd/neofs-cli/modules/storagegroup/put.go
@@ -1,7 +1,6 @@
 package storagegroup
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -113,7 +112,6 @@ func putSG(cmd *cobra.Command, _ []string) {
 	storagegroupSDK.WriteToObject(*sg, obj)
 
 	putPrm.SetHeader(obj)
-	putPrm.SetPayloadReader(bytes.NewReader(obj.Payload()))
 
 	res, err := internalclient.PutObject(putPrm)
 	common.ExitOnErr(cmd, "rpc error: %w", err)


### PR DESCRIPTION
fixes `status: code = 1024 message = duplicated member 8iVk4yKWWSX2CwnrHHmh52f6NekJc3hUTNUXzbAr2dpq` on SN side. The client does not expect having both header with a payload and a non-nil object payload reader with the same payload.