### PR TITLE
Feat/Object count metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Added
+- Objects counter metric (#1712)
 
 ### Changed
 - `neofs-cli object put`'s object ID output has changed from "ID" to "OID" (#1296)
@@ -17,6 +18,7 @@ Changelog for NeoFS Node
 ### Updated
 
 ### Updating from v0.31.0
+Storage Node now collects object count prometheus metrics: `neofs_node_object_counter`. 
 
 ## [0.31.0] - 2022-08-04 - Baengnyeongdo (백령도, 白翎島)
 

--- a/pkg/local_object_storage/engine/metrics.go
+++ b/pkg/local_object_storage/engine/metrics.go
@@ -16,6 +16,8 @@ type MetricRegister interface {
 	AddRangeDuration(d time.Duration)
 	AddSearchDuration(d time.Duration)
 	AddListObjectsDuration(d time.Duration)
+
+	AddToObjectCounter(shardID string, delta int)
 }
 
 func elapsed(addFunc func(d time.Duration)) func() {

--- a/pkg/local_object_storage/engine/metrics.go
+++ b/pkg/local_object_storage/engine/metrics.go
@@ -17,6 +17,7 @@ type MetricRegister interface {
 	AddSearchDuration(d time.Duration)
 	AddListObjectsDuration(d time.Duration)
 
+	SetObjectCounter(shardID string, v uint64)
 	AddToObjectCounter(shardID string, delta int)
 }
 

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -22,6 +22,10 @@ type metricsWithID struct {
 	mw MetricRegister
 }
 
+func (m metricsWithID) SetObjectCounter(v uint64) {
+	m.mw.SetObjectCounter(m.id, v)
+}
+
 func (m metricsWithID) AddToObjectCounter(delta int) {
 	m.mw.AddToObjectCounter(m.id, delta)
 }

--- a/pkg/local_object_storage/metabase/VERSION.md
+++ b/pkg/local_object_storage/metabase/VERSION.md
@@ -31,7 +31,7 @@ This file describes changes between the metabase versions.
   - Keys and values
     - `id` -> shard id as bytes
     - `version` -> metabase version as little-endian uint64
-    - `counter` -> shard's object counter as little-endian uint64
+    - `phy_counter` -> shard's physical object counter as little-endian uint64
 
 ### Unique index buckets
 - Buckets containing objects of REGULAR type
@@ -83,10 +83,6 @@ This file describes changes between the metabase versions.
   - Key: split ID
   - Value: list of object IDs
 
-
-## Version 2
-
-- Added shard's object counter to the info bucket 
 
 ## Version 1
 

--- a/pkg/local_object_storage/metabase/VERSION.md
+++ b/pkg/local_object_storage/metabase/VERSION.md
@@ -31,6 +31,7 @@ This file describes changes between the metabase versions.
   - Keys and values
     - `id` -> shard id as bytes
     - `version` -> metabase version as little-endian uint64
+    - `counter` -> shard's object counter as little-endian uint64
 
 ### Unique index buckets
 - Buckets containing objects of REGULAR type
@@ -83,7 +84,9 @@ This file describes changes between the metabase versions.
   - Value: list of object IDs
 
 
-# History
+## Version 2
+
+- Added shard's object counter to the info bucket 
 
 ## Version 1
 

--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -80,6 +80,7 @@ func (db *DB) init(reset bool) error {
 		string(graveyardBucketName):       {},
 		string(toMoveItBucketName):        {},
 		string(garbageBucketName):         {},
+		string(shardInfoBucket):           {},
 	}
 
 	return db.boltDB.Update(func(tx *bbolt.Tx) error {

--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -106,6 +106,11 @@ func (db *DB) init(reset bool) error {
 		}
 
 		if !reset {
+			err = syncCounter(tx)
+			if err != nil {
+				return fmt.Errorf("could not sync object counter: %w", err)
+			}
+
 			return nil
 		}
 

--- a/pkg/local_object_storage/metabase/counter.go
+++ b/pkg/local_object_storage/metabase/counter.go
@@ -1,0 +1,59 @@
+package meta
+
+import (
+	"encoding/binary"
+
+	"go.etcd.io/bbolt"
+)
+
+var shardCounterKey = []byte("counter")
+
+// ObjectCounter returns object count that metabase has
+// tracked since it was opened and initialized.
+//
+// Returns only the errors that do not allow reading counter
+// in Bolt database.
+func (db *DB) ObjectCounter() (counter uint64, err error) {
+	err = db.boltDB.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(shardInfoBucket)
+		if b != nil {
+			data := b.Get(shardCounterKey)
+			if len(data) == 8 {
+				counter = binary.LittleEndian.Uint64(data)
+			}
+		}
+
+		return nil
+	})
+
+	return
+}
+
+// updateCounter updates the object counter. Tx MUST be writable.
+// If inc == `true`, increases the counter, decreases otherwise.
+func (db *DB) updateCounter(tx *bbolt.Tx, delta uint64, inc bool) error {
+	b := tx.Bucket(shardInfoBucket)
+	if b == nil {
+		return nil
+	}
+
+	var counter uint64
+
+	data := b.Get(shardCounterKey)
+	if len(data) == 8 {
+		counter = binary.LittleEndian.Uint64(data)
+	}
+
+	if inc {
+		counter += delta
+	} else if counter <= delta {
+		counter = 0
+	} else {
+		counter -= delta
+	}
+
+	newCounter := make([]byte, 8)
+	binary.LittleEndian.PutUint64(newCounter, counter)
+
+	return b.Put(shardCounterKey, newCounter)
+}

--- a/pkg/local_object_storage/metabase/counter.go
+++ b/pkg/local_object_storage/metabase/counter.go
@@ -2,11 +2,14 @@ package meta
 
 import (
 	"encoding/binary"
+	"fmt"
 
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
 
-var shardCounterKey = []byte("counter")
+var objectCounterKey = []byte("phy_counter")
 
 // ObjectCounter returns object count that metabase has
 // tracked since it was opened and initialized.
@@ -17,7 +20,7 @@ func (db *DB) ObjectCounter() (counter uint64, err error) {
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(shardInfoBucket)
 		if b != nil {
-			data := b.Get(shardCounterKey)
+			data := b.Get(objectCounterKey)
 			if len(data) == 8 {
 				counter = binary.LittleEndian.Uint64(data)
 			}
@@ -39,7 +42,7 @@ func (db *DB) updateCounter(tx *bbolt.Tx, delta uint64, inc bool) error {
 
 	var counter uint64
 
-	data := b.Get(shardCounterKey)
+	data := b.Get(objectCounterKey)
 	if len(data) == 8 {
 		counter = binary.LittleEndian.Uint64(data)
 	}
@@ -55,5 +58,42 @@ func (db *DB) updateCounter(tx *bbolt.Tx, delta uint64, inc bool) error {
 	newCounter := make([]byte, 8)
 	binary.LittleEndian.PutUint64(newCounter, counter)
 
-	return b.Put(shardCounterKey, newCounter)
+	return b.Put(objectCounterKey, newCounter)
+}
+
+// syncCounter updates object counter according to metabase state:
+// it counts all the physically stored objects using internal indexes.
+// Tx MUST be writable.
+//
+// Does nothing if counter not empty.
+func syncCounter(tx *bbolt.Tx) error {
+	var counter uint64
+
+	b, err := tx.CreateBucketIfNotExists(shardInfoBucket)
+	if err != nil {
+		return fmt.Errorf("could not get shard info bucket: %w", err)
+	}
+
+	data := b.Get(objectCounterKey)
+	if len(data) == 8 {
+		return nil
+	}
+
+	err = iteratePhyObjects(tx, func(_ cid.ID, _ oid.ID) error {
+		counter++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("count not iterate objects: %w", err)
+	}
+
+	data = make([]byte, 8)
+	binary.LittleEndian.PutUint64(data, counter)
+
+	err = b.Put(objectCounterKey, data)
+	if err != nil {
+		return fmt.Errorf("could not update object counter: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/local_object_storage/metabase/counter_test.go
+++ b/pkg/local_object_storage/metabase/counter_test.go
@@ -1,0 +1,133 @@
+package meta_test
+
+import (
+	"testing"
+
+	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	"github.com/stretchr/testify/require"
+)
+
+const objCount = 10
+
+func TestCounter_Default(t *testing.T) {
+	db := newDB(t)
+
+	c, err := db.ObjectCounter()
+	require.NoError(t, err)
+	require.Zero(t, c)
+}
+
+func TestCounter(t *testing.T) {
+	db := newDB(t)
+
+	var c uint64
+	var err error
+
+	oo := make([]*object.Object, 0, objCount)
+	for i := 0; i < objCount; i++ {
+		oo = append(oo, generateObject(t))
+	}
+
+	var prm meta.PutPrm
+
+	for i := 0; i < objCount; i++ {
+		prm.SetObject(oo[i])
+
+		_, err = db.Put(prm)
+		require.NoError(t, err)
+
+		c, err = db.ObjectCounter()
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(i+1), c)
+	}
+}
+
+func TestCounter_Dec(t *testing.T) {
+	db := newDB(t)
+	oo := putObjs(t, db, objCount, false)
+
+	var err error
+	var c uint64
+
+	var prm meta.DeletePrm
+	for i := objCount - 1; i >= 0; i-- {
+		prm.SetAddresses(objectcore.AddressOf(oo[i]))
+
+		_, err = db.Delete(prm)
+		require.NoError(t, err)
+
+		c, err = db.ObjectCounter()
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(i), c)
+	}
+}
+
+func TestCounter_PutSplit(t *testing.T) {
+	db := newDB(t)
+
+	parObj := generateObject(t)
+	var err error
+	var c uint64
+
+	// put objects and check that parent info
+	// does not affect the counter
+	for i := 0; i < objCount; i++ {
+		o := generateObject(t)
+		if i < objCount/2 { // half of the objs will have the parent
+			o.SetParent(parObj)
+		}
+
+		require.NoError(t, putBig(db, o))
+
+		c, err = db.ObjectCounter()
+		require.NoError(t, err)
+		require.Equal(t, uint64(i+1), c)
+	}
+}
+
+func TestCounter_DeleteSplit(t *testing.T) {
+	db := newDB(t)
+	oo := putObjs(t, db, objCount, true)
+
+	// delete objects that have parent info
+	// and check that it does not affect
+	// the counter
+	for i, o := range oo {
+		require.NoError(t, metaDelete(db, objectcore.AddressOf(o)))
+
+		c, err := db.ObjectCounter()
+		require.NoError(t, err)
+		require.Equal(t, uint64(objCount-i-1), c)
+	}
+}
+
+func putObjs(t *testing.T, db *meta.DB, count int, withParent bool) []*object.Object {
+	var prm meta.PutPrm
+	var err error
+	parent := generateObject(t)
+
+	oo := make([]*object.Object, 0, count)
+	for i := 0; i < count; i++ {
+		o := generateObject(t)
+		if withParent {
+			o.SetParent(parent)
+		}
+
+		oo = append(oo, o)
+
+		prm.SetObject(o)
+		_, err = db.Put(prm)
+		require.NoError(t, err)
+
+		c, err := db.ObjectCounter()
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(i+1), c)
+	}
+
+	return oo
+}

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -14,6 +14,7 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
+	"go.uber.org/zap"
 )
 
 type (
@@ -139,6 +140,14 @@ func (db *DB) put(
 		err = changeContainerSize(tx, cnr, obj.PayloadSize(), true)
 		if err != nil {
 			return err
+		}
+	}
+
+	if !isParent {
+		err = db.updateCounter(tx, 1, true)
+		if err != nil {
+			db.log.Error("could not increase object counter: %w",
+				zap.Error(err))
 		}
 	}
 

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -14,7 +14,6 @@ import (
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
-	"go.uber.org/zap"
 )
 
 type (
@@ -146,8 +145,7 @@ func (db *DB) put(
 	if !isParent {
 		err = db.updateCounter(tx, 1, true)
 		if err != nil {
-			db.log.Error("could not increase object counter: %w",
-				zap.Error(err))
+			return fmt.Errorf("could not increase object counter: %w", err)
 		}
 	}
 

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -120,6 +120,8 @@ func (s *Shard) Init() error {
 		}
 	}
 
+	s.updateObjectCounter()
+
 	s.gc = &gc{
 		gcCfg:       s.gcCfg,
 		remover:     s.removeGarbage,

--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -65,10 +65,12 @@ func (s *Shard) Delete(prm DeletePrm) (DeleteRes, error) {
 	var delPrm meta.DeletePrm
 	delPrm.SetAddresses(prm.addr...)
 
-	_, err := s.metaBase.Delete(delPrm)
+	res, err := s.metaBase.Delete(delPrm)
 	if err != nil {
 		return DeleteRes{}, err // stop on metabase error ?
 	}
+
+	s.decObjectCounterBy(res.RemovedObjects())
 
 	for i := range prm.addr { // delete small object
 		var delPrm common.DeletePrm

--- a/pkg/local_object_storage/shard/put.go
+++ b/pkg/local_object_storage/shard/put.go
@@ -73,6 +73,8 @@ func (s *Shard) Put(prm PutPrm) (PutRes, error) {
 			// since the object has been successfully written to BlobStor
 			return PutRes{}, fmt.Errorf("could not put object to metabase: %w", err)
 		}
+
+		s.incObjectCounter()
 	}
 
 	return PutRes{}, nil

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -47,6 +47,8 @@ type DeletedLockCallback func(context.Context, []oid.Address)
 
 // MetricsWriter is an interface that must store shard's metrics.
 type MetricsWriter interface {
+	// SetObjectCounter must set object counter.
+	SetObjectCounter(v uint64)
 	// AddToObjectCounter must update object counter. Negative
 	// parameter must decrease the counter.
 	AddToObjectCounter(delta int)
@@ -290,6 +292,21 @@ func (s *Shard) fillInfo() {
 	}
 	if s.pilorama != nil {
 		s.cfg.info.PiloramaInfo = s.pilorama.DumpInfo()
+	}
+}
+
+func (s *Shard) updateObjectCounter() {
+	if s.cfg.metricsWriter != nil && !s.GetMode().NoMetabase() {
+		c, err := s.metaBase.ObjectCounter()
+		if err != nil {
+			s.log.Warn("meta: object counter read",
+				zap.Error(err),
+			)
+
+			return
+		}
+
+		s.cfg.metricsWriter.SetObjectCounter(c)
 	}
 }
 

--- a/pkg/metrics/object.go
+++ b/pkg/metrics/object.go
@@ -274,3 +274,7 @@ func (m objectServiceMetrics) AddGetPayload(ln int) {
 func (m objectServiceMetrics) AddToObjectCounter(shardID string, delta int) {
 	m.shardMetrics.With(prometheus.Labels{shardIDLabelKey: shardID}).Add(float64(delta))
 }
+
+func (m objectServiceMetrics) SetObjectCounter(shardID string, v uint64) {
+	m.shardMetrics.With(prometheus.Labels{shardIDLabelKey: shardID}).Set(float64(v))
+}


### PR DESCRIPTION
```
# HELP neofs_node_object_counter Objects counters per shards
# TYPE neofs_node_object_counter gauge
neofs_node_object_counter{shard="A1AJ1cgEdGGYC2kGTGQxQJ"} 5
neofs_node_object_counter{shard="S9b69efduvCprPU4FWKirH"} 3
```

Does not contain the node's total object count since on the shard level it is quite easy to control objects but on the SE level it is not always clear whether a shard contains an object or not:
1. GC works on the shard level
2. SE's `Delete` always calls shard's `Inhume` not `Delete`

It is possible to solve (e.g. some SE'e atomic counter that could be passed to every shard) but IMO it is easier to calculate on a metric collector side.