### PR TITLE
neofs-cli: save object with proper permissions

### DIFF
--- a/cmd/neofs-cli/modules/object/get.go
+++ b/cmd/neofs-cli/modules/object/get.go
@@ -53,7 +53,7 @@ func getObject(cmd *cobra.Command, _ []string) {
 	if filename == "" {
 		out = os.Stdout
 	} else {
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			common.ExitOnErr(cmd, "", fmt.Errorf("can't open file '%s': %w", filename, err))
 		}

--- a/cmd/neofs-cli/modules/object/get.go
+++ b/cmd/neofs-cli/modules/object/get.go
@@ -53,7 +53,7 @@ func getObject(cmd *cobra.Command, _ []string) {
 	if filename == "" {
 		out = os.Stdout
 	} else {
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			common.ExitOnErr(cmd, "", fmt.Errorf("can't open file '%s': %w", filename, err))
 		}


### PR DESCRIPTION
Close #1719.

`curl` uses 0644, for example.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>