### PR TITLE
neofs-adm: clean tx hash list after awaiting

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -359,6 +359,7 @@ loop:
 		}
 	}
 
+	c.Hashes = c.Hashes[:0]
 	return retErr
 }
 


### PR DESCRIPTION
Do not query application log for the same transaction more than once.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>