### PR TITLE
Fix/Non-notary calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Panic on write-cache's `Delete` operation (#1664)
 - Payload duplication in `neofs-cli storagegroup put` (#1706)
+- Contract calls in notary disabled environments (#1743)
 
 ### Removed
 

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -115,6 +115,12 @@ func (c *Client) EnableNotarySupport(opts ...NotaryOption) error {
 	return nil
 }
 
+// IsNotaryEnabled returns true if EnableNotarySupport has been successfully
+// called before.
+func (c *Client) IsNotaryEnabled() bool {
+	return c.notary != nil
+}
+
 // ProbeNotary checks if native `Notary` contract is presented on chain.
 func (c *Client) ProbeNotary() (res bool) {
 	c.switchLock.RLock()

--- a/pkg/morph/client/static.go
+++ b/pkg/morph/client/static.go
@@ -34,7 +34,7 @@ type staticOpts struct {
 //
 // See also TryNotary.
 func (s *StaticClient) WithNotary() bool {
-	return s.tryNotary
+	return s.client.IsNotaryEnabled()
 }
 
 // IsAlpha returns Alphabet status of the client.


### PR DESCRIPTION
Some methods add "IR" suffix to their names in notary enabled envs
because of contract logic. It was broken due to incorrect notary state
reading (tryNotary != notary is enabled).

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Was broken by a mistake in #1224. Could appear only in notary disabled envs in `v0.28.1+` versions, that is why we have not noticed that.