### PR TITLE
services/tree: allow to drop trees from the database

### DIFF
--- a/cmd/neofs-node/tree.go
+++ b/cmd/neofs-node/tree.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	treeconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/tree"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/pilorama"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+	containerEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
 	"github.com/nspcc-dev/neofs-node/pkg/services/tree"
+	"go.uber.org/zap"
 )
 
 func initTreeService(c *cfg) {
@@ -31,6 +36,19 @@ func initTreeService(c *cfg) {
 	c.workers = append(c.workers, newWorkerFromFunc(func(ctx context.Context) {
 		c.treeService.Start(ctx)
 	}))
+
+	subscribeToContainerRemoval(c, func(e event.Event) {
+		ev := e.(containerEvent.DeleteSuccess)
+
+		// This is executed asynchronously, so we don't care about the operation taking some time.
+		err := c.treeService.DropTree(context.Background(), ev.ID, "")
+		if err != nil && !errors.Is(err, pilorama.ErrTreeNotFound) {
+			// Ignore pilorama.ErrTreeNotFound but other errors, including shard.ErrReadOnly, should be logged.
+			c.log.Error("container removal event received, but trees weren't removed",
+				zap.Stringer("cid", ev.ID),
+				zap.String("error", err.Error()))
+		}
+	})
 
 	c.onShutdown(c.treeService.Shutdown)
 }

--- a/pkg/local_object_storage/pilorama/boltdb.go
+++ b/pkg/local_object_storage/pilorama/boltdb.go
@@ -3,6 +3,7 @@ package pilorama
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -577,6 +578,17 @@ func (t *boltForest) TreeGetOpLog(cid cidSDK.ID, treeID string, height uint64) (
 	})
 
 	return lm, err
+}
+
+// TreeDrop implements the pilorama.Forest interface.
+func (t *boltForest) TreeDrop(cid cidSDK.ID, treeID string) error {
+	return t.db.Batch(func(tx *bbolt.Tx) error {
+		err := tx.DeleteBucket(bucketName(cid, treeID))
+		if errors.Is(err, bbolt.ErrBucketNotFound) {
+			return ErrTreeNotFound
+		}
+		return err
+	})
 }
 
 func (t *boltForest) getPathPrefix(bTree *bbolt.Bucket, attr string, path []string) (int, Node, error) {

--- a/pkg/local_object_storage/pilorama/forest.go
+++ b/pkg/local_object_storage/pilorama/forest.go
@@ -179,3 +179,15 @@ func (f *memoryForest) TreeGetOpLog(cid cidSDK.ID, treeID string, height uint64)
 	}
 	return s.operations[n].Move, nil
 }
+
+// TreeDrop implements the pilorama.Forest interface.
+func (f *memoryForest) TreeDrop(cid cidSDK.ID, treeID string) error {
+	fullID := cid.String() + "/" + treeID
+	_, ok := f.treeMap[fullID]
+	if !ok {
+		return ErrTreeNotFound
+	}
+
+	delete(f.treeMap, fullID)
+	return nil
+}

--- a/pkg/local_object_storage/pilorama/forest_test.go
+++ b/pkg/local_object_storage/pilorama/forest_test.go
@@ -167,6 +167,39 @@ func testForestTreeGetChildren(t *testing.T, s Forest) {
 	})
 }
 
+func TestForest_TreeDrop(t *testing.T) {
+	for i := range providers {
+		t.Run(providers[i].name, func(t *testing.T) {
+			testForestTreeDrop(t, providers[i].construct(t))
+		})
+	}
+}
+
+func testForestTreeDrop(t *testing.T, s Forest) {
+	cid := cidtest.ID()
+
+	t.Run("return nil if not found", func(t *testing.T) {
+		require.ErrorIs(t, s.TreeDrop(cid, "123"), ErrTreeNotFound)
+	})
+
+	trees := []string{"tree1", "tree2"}
+	d := CIDDescriptor{cid, 0, 1}
+	for i := range trees {
+		_, err := s.TreeAddByPath(d, trees[i], AttributeFilename, []string{"path"},
+			[]KeyValue{{Key: "TreeName", Value: []byte(trees[i])}})
+		require.NoError(t, err)
+	}
+
+	err := s.TreeDrop(cid, trees[0])
+	require.NoError(t, err)
+
+	_, err = s.TreeGetByPath(cid, trees[0], AttributeFilename, []string{"path"}, true)
+	require.ErrorIs(t, err, ErrTreeNotFound)
+
+	_, err = s.TreeGetByPath(cid, trees[1], AttributeFilename, []string{"path"}, true)
+	require.NoError(t, err)
+}
+
 func TestForest_TreeAdd(t *testing.T) {
 	for i := range providers {
 		t.Run(providers[i].name, func(t *testing.T) {

--- a/pkg/local_object_storage/pilorama/forest_test.go
+++ b/pkg/local_object_storage/pilorama/forest_test.go
@@ -31,7 +31,9 @@ var providers = []struct {
 		tmpDir, err := os.MkdirTemp(os.TempDir(), "*")
 		require.NoError(t, err)
 
-		f := NewBoltForest(WithPath(filepath.Join(tmpDir, "test.db")))
+		f := NewBoltForest(
+			WithPath(filepath.Join(tmpDir, "test.db")),
+			WithMaxBatchSize(1))
 		require.NoError(t, f.Open(false))
 		require.NoError(t, f.Init())
 		t.Cleanup(func() {
@@ -486,9 +488,9 @@ func testForestTreeApplyRandom(t *testing.T, constructor func(t testing.TB) Fore
 	rand.Seed(42)
 
 	const (
-		nodeCount = 4
-		opCount   = 10
-		iterCount = 100
+		nodeCount = 5
+		opCount   = 20
+		iterCount = 200
 	)
 
 	cid := cidtest.ID()

--- a/pkg/local_object_storage/pilorama/interface.go
+++ b/pkg/local_object_storage/pilorama/interface.go
@@ -34,6 +34,9 @@ type Forest interface {
 	// TreeGetOpLog returns first log operation stored at or above the height.
 	// In case no such operation is found, empty Move and nil error should be returned.
 	TreeGetOpLog(cid cidSDK.ID, treeID string, height uint64) (Move, error)
+	// TreeDrop drops a tree from the database.
+	// If the tree is not found, ErrTreeNotFound should be returned.
+	TreeDrop(cid cidSDK.ID, treeID string) error
 }
 
 type ForestStorage interface {

--- a/pkg/local_object_storage/shard/tree.go
+++ b/pkg/local_object_storage/shard/tree.go
@@ -76,3 +76,11 @@ func (s *Shard) TreeGetOpLog(cid cidSDK.ID, treeID string, height uint64) (pilor
 	}
 	return s.pilorama.TreeGetOpLog(cid, treeID, height)
 }
+
+// TreeDrop implements the pilorama.Forest interface.
+func (s *Shard) TreeDrop(cid cidSDK.ID, treeID string) error {
+	if s.pilorama == nil {
+		return ErrPiloramaDisabled
+	}
+	return s.pilorama.TreeDrop(cid, treeID)
+}

--- a/pkg/services/tree/drop.go
+++ b/pkg/services/tree/drop.go
@@ -1,0 +1,14 @@
+package tree
+
+import (
+	"context"
+
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+)
+
+// DropTree drops a tree from the database. If treeID is empty, all the trees are dropped.
+func (s *Service) DropTree(_ context.Context, cid cid.ID, treeID string) error {
+	// The only current use-case is a container removal, where all trees should be removed.
+	// Thus there is no need to replicate the operation on other node.
+	return s.forest.TreeDrop(cid, treeID)
+}


### PR DESCRIPTION
Close #1630.

I think removing based on morph event covers our main use-case.
Do we need an RPC to remove trees without removing the container? @alexvanin @KirillovDenis 