### PR TITLE
node/netmap: Write log messages about `NewEpoch` events

### DIFF
--- a/pkg/morph/subscriber/subscriber.go
+++ b/pkg/morph/subscriber/subscriber.go
@@ -133,6 +133,10 @@ func (s *subscriber) routeNotifications(ctx context.Context) {
 					continue
 				}
 
+				s.log.Debug("new notification event from sidechain",
+					zap.String("name", notifyEvent.Name),
+				)
+
 				s.notifyChan <- notifyEvent
 			case neorpc.BlockEventID:
 				b, ok := notification.Value.(*block.Block)


### PR DESCRIPTION
* inspired by explorations performed within https://github.com/nspcc-dev/neofs-node/issues/1721

Within the issue I made a hypothesis that node had missed some ticks of the epoch timer. However it was difficult to explicitly prove or disprove this assumption.

These changes make storage nodes to log new epochs. From now it'll be easy to track the node timeline.