### PR TITLE
Fix node configuration parsing

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"path/filepath"
 	"sync"
@@ -470,6 +471,8 @@ func initShardOptions(c *cfg) {
 						return true
 					},
 				})
+			default:
+				panic(fmt.Errorf("invalid storage type: %s", storages[i].Type()))
 			}
 		}
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -443,7 +443,7 @@ func initShardOptions(c *cfg) {
 		var st []blobstor.SubStorage
 		for i := range storages {
 			switch storages[i].Type() {
-			case "blobovniczas":
+			case "blobovnicza":
 				sub := blobovniczaconfig.From((*config.Config)(storages[i]))
 				lim := sc.SmallSizeLimit()
 				st = append(st, blobstor.SubStorage{

--- a/pkg/local_object_storage/blobstor/blobovniczatree/blobovnicza.go
+++ b/pkg/local_object_storage/blobstor/blobovniczatree/blobovnicza.go
@@ -231,7 +231,7 @@ func u64FromHexString(str string) uint64 {
 
 // Type implements common.Storage.
 func (b *Blobovniczas) Type() string {
-	return "blobovniczas"
+	return "blobovnicza"
 }
 
 // SetCompressor implements common.Storage.


### PR DESCRIPTION
Because it is without `s` in the examples, I think we should leave it as it is.