### PR TITLE
object/acl: Fix correlation of object session to request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog for NeoFS Node
 - Fail startup if metabase has an old version (#1809)
 - Storage nodes could enter the network with any state (#1796)
 - Missing check of new state value in `ControlService.SetNetmapStatus` (#1797)
+- Correlation of object session to request (#1420)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)
@@ -45,6 +46,10 @@ If network allows maintenance state (*), it will be reflected in the network map
 Storage nodes under maintenance are not excluded from the network map, but don't
 serve object operations. (*) can be fetched from network configuration via
 `neofs-cli netmap netinfo` command.    
+
+When issuing an object session token for root (virtual, "big") objects,
+additionally include all members of the split-chain. If session context
+includes root object only, it is not spread to physical ("small") objects.
 
 ## [0.32.0] - 2022-09-14 - Pungdo (풍도, 楓島)
 

--- a/cmd/neofs-cli/modules/session/util.go
+++ b/cmd/neofs-cli/modules/session/util.go
@@ -63,7 +63,7 @@ func Prepare(cmd *cobra.Command, cnr cid.ID, obj *oid.ID, key *ecdsa.PrivateKey,
 
 		tok.BindContainer(cnr)
 		if obj != nil {
-			tok.LimitByObject(*obj)
+			tok.LimitByObjects(*obj)
 		}
 
 		err := tok.Sign(*key)

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.99.2
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b // indirect
-	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c
+	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d
 	github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220926102839-c6576c8112ee
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20221005093951-1325b4f27218
 	github.com/nspcc-dev/tzhash v1.6.1
 	github.com/panjf2000/ants/v2 v2.4.0
 	github.com/paulmach/orb v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b h1:J7
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b/go.mod h1:23bBw0v6pBYcrWs8CBEEDIEDJNbcFoIh8pGGcf2Vv8s=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c h1:YZwtBY9uypaShbe/NLhosDanIfxt8VhQlSLYUeFIWv8=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d h1:Oc15A8gDoP/TC5kdJi6TW9AnOp5dYiecZ0tJDRUV7vg=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
 github.com/nspcc-dev/neofs-contract v0.15.3/go.mod h1:BXVZUZUJxrmmDETglXHI8+5DSgn84B9y5DoSWqEjYCs=
 github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c h1:jG8gu/qLprxjh99J7qGqGiPMJPXPQ5eM0el8Cb6o0Tc=
 github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c/go.mod h1:gN5bo2TlMvLbySImmg76DVj3jVmYgti2VVlQ+h/tcr0=
@@ -465,8 +465,8 @@ github.com/nspcc-dev/neofs-crypto v0.4.0 h1:5LlrUAM5O0k1+sH/sktBtrgfWtq1pgpDs09f
 github.com/nspcc-dev/neofs-crypto v0.4.0/go.mod h1:6XJ8kbXgOfevbI2WMruOtI+qUJXNwSGM/E9eClXxPHs=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20211201182451-a5b61c4f6477/go.mod h1:dfMtQWmBHYpl9Dez23TGtIUKiFvCIxUZq/CkSIhEpz4=
 github.com/nspcc-dev/neofs-sdk-go v0.0.0-20220113123743-7f3162110659/go.mod h1:/jay1lr3w7NQd/VDBkEhkJmDmyPNsu4W+QV2obsUV40=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220926102839-c6576c8112ee h1:QR2YyUCGiI0nEIMeE3TKJSYroT7EkQ6WIN5I8mm/5CA=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220926102839-c6576c8112ee/go.mod h1:lJ1K24ZW5MsUrAi2741cs8/gZ/jj61ilHe2NyfMuYMs=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20221005093951-1325b4f27218 h1:XtCCJTVIRyW374PxwBdOv8lMAttMf6nJ2FiVPrtG9sQ=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20221005093951-1325b4f27218/go.mod h1:HIU7csNSqyYf71rgr4H5qitMZMxVpovBPl7m05y4V9g=
 github.com/nspcc-dev/rfc6979 v0.1.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=
 github.com/nspcc-dev/rfc6979 v0.2.0 h1:3e1WNxrN60/6N0DW7+UYisLeZJyfqZTNOjeV/toYvOE=
 github.com/nspcc-dev/rfc6979 v0.2.0/go.mod h1:exhIh1PdpDC5vQmyEsGvc4YDM/lyQp/452QxGq/UEso=

--- a/pkg/services/object/acl/v2/service.go
+++ b/pkg/services/object/acl/v2/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"github.com/nspcc-dev/neofs-sdk-go/container/acl"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	sessionSDK "github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"go.uber.org/zap"
@@ -113,9 +114,21 @@ func (b Service) Get(request *objectV2.GetRequest, stream object.GetObjectStream
 		return err
 	}
 
+	obj, err := getObjectIDFromRequestBody(request.GetBody())
+	if err != nil {
+		return err
+	}
+
 	sTok, err := originalSessionToken(request.GetMetaHeader())
 	if err != nil {
 		return err
+	}
+
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, cnr, obj)
+		if err != nil {
+			return err
+		}
 	}
 
 	bTok, err := originalBearerToken(request.GetMetaHeader())
@@ -135,12 +148,7 @@ func (b Service) Get(request *objectV2.GetRequest, stream object.GetObjectStream
 		return err
 	}
 
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
-	if err != nil {
-		return err
-	}
-
-	useObjectIDFromSession(&reqInfo, sTok)
+	reqInfo.obj = obj
 
 	if !b.checker.CheckBasicACL(reqInfo) {
 		return basicACLErr(reqInfo)
@@ -172,9 +180,21 @@ func (b Service) Head(
 		return nil, err
 	}
 
+	obj, err := getObjectIDFromRequestBody(request.GetBody())
+	if err != nil {
+		return nil, err
+	}
+
 	sTok, err := originalSessionToken(request.GetMetaHeader())
 	if err != nil {
 		return nil, err
+	}
+
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, cnr, obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bTok, err := originalBearerToken(request.GetMetaHeader())
@@ -194,12 +214,7 @@ func (b Service) Head(
 		return nil, err
 	}
 
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
-	if err != nil {
-		return nil, err
-	}
-
-	useObjectIDFromSession(&reqInfo, sTok)
+	reqInfo.obj = obj
 
 	if !b.checker.CheckBasicACL(reqInfo) {
 		return nil, basicACLErr(reqInfo)
@@ -228,6 +243,13 @@ func (b Service) Search(request *objectV2.SearchRequest, stream object.SearchStr
 		return err
 	}
 
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, id, nil)
+		if err != nil {
+			return err
+		}
+	}
+
 	bTok, err := originalBearerToken(request.GetMetaHeader())
 	if err != nil {
 		return err
@@ -241,11 +263,6 @@ func (b Service) Search(request *objectV2.SearchRequest, stream object.SearchStr
 	}
 
 	reqInfo, err := b.findRequestInfo(req, id, acl.OpObjectSearch)
-	if err != nil {
-		return err
-	}
-
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
 	if err != nil {
 		return err
 	}
@@ -271,9 +288,21 @@ func (b Service) Delete(
 		return nil, err
 	}
 
+	obj, err := getObjectIDFromRequestBody(request.GetBody())
+	if err != nil {
+		return nil, err
+	}
+
 	sTok, err := originalSessionToken(request.GetMetaHeader())
 	if err != nil {
 		return nil, err
+	}
+
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, cnr, obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bTok, err := originalBearerToken(request.GetMetaHeader())
@@ -293,12 +322,7 @@ func (b Service) Delete(
 		return nil, err
 	}
 
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
-	if err != nil {
-		return nil, err
-	}
-
-	useObjectIDFromSession(&reqInfo, sTok)
+	reqInfo.obj = obj
 
 	if !b.checker.CheckBasicACL(reqInfo) {
 		return nil, basicACLErr(reqInfo)
@@ -315,9 +339,21 @@ func (b Service) GetRange(request *objectV2.GetRangeRequest, stream object.GetOb
 		return err
 	}
 
+	obj, err := getObjectIDFromRequestBody(request.GetBody())
+	if err != nil {
+		return err
+	}
+
 	sTok, err := originalSessionToken(request.GetMetaHeader())
 	if err != nil {
 		return err
+	}
+
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, cnr, obj)
+		if err != nil {
+			return err
+		}
 	}
 
 	bTok, err := originalBearerToken(request.GetMetaHeader())
@@ -337,11 +373,7 @@ func (b Service) GetRange(request *objectV2.GetRangeRequest, stream object.GetOb
 		return err
 	}
 
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
-	if err != nil {
-		return err
-	}
-	useObjectIDFromSession(&reqInfo, sTok)
+	reqInfo.obj = obj
 
 	if !b.checker.CheckBasicACL(reqInfo) {
 		return basicACLErr(reqInfo)
@@ -364,9 +396,21 @@ func (b Service) GetRangeHash(
 		return nil, err
 	}
 
+	obj, err := getObjectIDFromRequestBody(request.GetBody())
+	if err != nil {
+		return nil, err
+	}
+
 	sTok, err := originalSessionToken(request.GetMetaHeader())
 	if err != nil {
 		return nil, err
+	}
+
+	if sTok != nil {
+		err = assertSessionRelation(*sTok, cnr, obj)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bTok, err := originalBearerToken(request.GetMetaHeader())
@@ -386,12 +430,7 @@ func (b Service) GetRangeHash(
 		return nil, err
 	}
 
-	reqInfo.obj, err = getObjectIDFromRequestBody(request.GetBody())
-	if err != nil {
-		return nil, err
-	}
-
-	useObjectIDFromSession(&reqInfo, sTok)
+	reqInfo.obj = obj
 
 	if !b.checker.CheckBasicACL(reqInfo) {
 		return nil, basicACLErr(reqInfo)
@@ -427,6 +466,18 @@ func (p putStreamBasicChecker) Send(request *objectV2.PutRequest) error {
 			return fmt.Errorf("invalid object owner: %w", err)
 		}
 
+		objV2 := part.GetObjectID()
+		var obj *oid.ID
+
+		if objV2 != nil {
+			obj = new(oid.ID)
+
+			err = obj.ReadFromV2(*objV2)
+			if err != nil {
+				return err
+			}
+		}
+
 		var sTok *sessionSDK.Object
 
 		if tokV2 := request.GetMetaHeader().GetSessionToken(); tokV2 != nil {
@@ -435,6 +486,11 @@ func (p putStreamBasicChecker) Send(request *objectV2.PutRequest) error {
 			err = sTok.ReadFromV2(*tokV2)
 			if err != nil {
 				return fmt.Errorf("invalid session token: %w", err)
+			}
+
+			err = assertSessionRelation(*sTok, cnr, obj)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -455,12 +511,7 @@ func (p putStreamBasicChecker) Send(request *objectV2.PutRequest) error {
 			return err
 		}
 
-		reqInfo.obj, err = getObjectIDFromRequestBody(part)
-		if err != nil {
-			return err
-		}
-
-		useObjectIDFromSession(&reqInfo, sTok)
+		reqInfo.obj = obj
 
 		if !p.source.checker.CheckBasicACL(reqInfo) || !p.source.checker.StickyBitCheck(reqInfo, idOwner) {
 			return basicACLErr(reqInfo)


### PR DESCRIPTION
In previous implementation of `neofs-node` app object session was not checked for substitution of the object related to it. Also, for access checks, the session object was substituted instead of the one from the request. This, on the one hand, made it possible to inherit the session from the parent object for authorization for certain actions. On the other hand, it covered the mentioned object substitution, which is a critical vulnerability.

Next changes are applied to processing of all Object service requests:
 - check if object session relates to the requested object
 - use requested object in access checks.

Disclosed problem of object context inheritance will be solved within #1420.

* relates #1420