### PR TITLE
Support `MAINTENANCE` state of storage nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 - Serving `NetmapService.NetmapSnapshot` RPC (#1793)
 - `netmap snapshot` command of NeoFS CLI (#1793)
 - `apiclient.allow_external` config flag to fallback to node external addresses (#1817)
+- Support `MAINTENANCE` state of the storage nodes (#1680, #1681)
 - Changelog updates CI step (#1808)
 - Validate storage node configuration before node startup (#1805)
 - `neofs-node -check` command to check the configuration file (#1805)
@@ -14,7 +15,6 @@ Changelog for NeoFS Node
 - `wallet-address` flag in `neofs-adm morph refill-gas` command (#1820)
 
 ### Changed
-
 - Allow to evacuate shard data with `EvacuateShard` control RPC (#1800)
 - Flush write-cache when moving shard to DEGRADED mode (#1825)
 
@@ -22,6 +22,8 @@ Changelog for NeoFS Node
 - Description of command `netmap nodeinfo` (#1821)
 - Proper status for object.Delete if session token is missing (#1697)
 - Fail startup if metabase has an old version (#1809)
+- Storage nodes could enter the network with any state (#1796)
+- Missing check of new state value in `ControlService.SetNetmapStatus` (#1797)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)
@@ -35,6 +37,12 @@ Changelog for NeoFS Node
 Replace using the `control netmap-snapshot` command with `netmap snapshot` one in NeoFS CLI.
 Node can now specify additional addresses in `ExternalAddr` attribute. To allow a node to dial
 other nodes external address, use `apiclient.allow_external` config setting.
+
+Pass `maintenance` state to `neofs-cli control set-status` to enter maintenance mode.
+If network allows maintenance state (*), it will be reflected in the network map.
+Storage nodes under maintenance are not excluded from the network map, but don't
+serve object operations. (*) can be fetched from network configuration via
+`neofs-cli netmap netinfo` command.    
 
 ## [0.32.0] - 2022-09-14 - Pungdo (풍도, 楓島)
 

--- a/cmd/neofs-adm/internal/modules/morph/remove_node.go
+++ b/cmd/neofs-adm/internal/modules/morph/remove_node.go
@@ -45,7 +45,7 @@ func removeNodesCmd(cmd *cobra.Command, args []string) error {
 	bw := io.NewBufBinWriter()
 	for i := range nodeKeys {
 		emit.AppCall(bw.BinWriter, nmHash, "updateStateIR", callflag.All,
-			int64(netmapcontract.OfflineState), nodeKeys[i].Bytes())
+			int64(netmapcontract.NodeStateOffline), nodeKeys[i].Bytes())
 	}
 
 	if err := emitNewEpochCall(bw, wCtx, nmHash); err != nil {

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -47,6 +47,7 @@ var netInfoCmd = &cobra.Command{
 		cmd.Printf(format, "Inner Ring candidate fee", netInfo.IRCandidateFee())
 		cmd.Printf(format, "Maximum object size", netInfo.MaxObjectSize())
 		cmd.Printf(format, "Withdrawal fee", netInfo.WithdrawalFee())
+		cmd.Printf(format, "Homomorphic hashing disabled", netInfo.HomomorphicHashingDisabled())
 
 		cmd.Println("NeoFS network configuration (other)")
 		netInfo.IterateRawNetworkParameters(func(name string, value []byte) {

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -48,6 +48,7 @@ var netInfoCmd = &cobra.Command{
 		cmd.Printf(format, "Maximum object size", netInfo.MaxObjectSize())
 		cmd.Printf(format, "Withdrawal fee", netInfo.WithdrawalFee())
 		cmd.Printf(format, "Homomorphic hashing disabled", netInfo.HomomorphicHashingDisabled())
+		cmd.Printf(format, "Maintenance mode allowed", netInfo.MaintenanceModeAllowed())
 
 		cmd.Println("NeoFS network configuration (other)")
 		netInfo.IterateRawNetworkParameters(func(name string, value []byte) {

--- a/cmd/neofs-cli/modules/netmap/snapshot.go
+++ b/cmd/neofs-cli/modules/netmap/snapshot.go
@@ -42,10 +42,14 @@ func prettyPrintNetMap(cmd *cobra.Command, nm netmap.NetMap) {
 		var strState string
 
 		switch {
+		default:
+			strState = "STATE_UNSUPPORTED"
 		case nodes[i].IsOnline():
 			strState = "ONLINE"
 		case nodes[i].IsOffline():
 			strState = "OFFLINE"
+		case nodes[i].IsMaintenance():
+			strState = "MAINTENANCE"
 		}
 
 		cmd.Printf("Node %d: %s %s ", i+1, hex.EncodeToString(nodes[i].PublicKey()), strState)

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -335,6 +335,28 @@ type cfg struct {
 
 	// current network map
 	netMap atomicstd.Value // type netmap.NetMap
+
+	// is node under maintenance
+	isMaintenance atomic.Bool
+}
+
+// starts node's maintenance.
+func (c *cfg) startMaintenance() {
+	c.isMaintenance.Store(true)
+	c.log.Info("started local node's maintenance")
+}
+
+// stops node's maintenance.
+func (c *cfg) stopMaintenance() {
+	c.isMaintenance.Store(false)
+	c.log.Info("stopped local node's maintenance")
+}
+
+// IsMaintenance checks if storage node is under maintenance.
+//
+// Provides util.NodeState to Object service.
+func (c *cfg) IsMaintenance() bool {
+	return c.isMaintenance.Load()
 }
 
 // ReadCurrentNetMap reads network map which has been cached at the

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -321,8 +321,12 @@ var errRelayBootstrap = errors.New("setting netmap status is forbidden in relay 
 var errNodeMaintenance = errors.New("node is in maintenance mode")
 
 func (c *cfg) SetNetmapStatus(st control.NetmapStatus) error {
-	if st == control.NetmapStatus_MAINTENANCE {
+	switch st {
+	default:
+		return fmt.Errorf("unsupported status %v", st)
+	case control.NetmapStatus_MAINTENANCE:
 		return c.cfgObject.cfgLocalStorage.localStorage.BlockExecution(errNodeMaintenance)
+	case control.NetmapStatus_ONLINE, control.NetmapStatus_OFFLINE:
 	}
 
 	err := c.cfgObject.cfgLocalStorage.localStorage.ResumeExecution()

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -400,6 +400,10 @@ func (n *netInfo) Dump(ver version.Version) (*netmapSDK.NetworkInfo, error) {
 		ni.SetIRCandidateFee(netInfoMorph.IRCandidateFee)
 		ni.SetWithdrawalFee(netInfoMorph.WithdrawalFee)
 
+		if netInfoMorph.HomomorphicHashingDisabled {
+			ni.DisableHomomorphicHashing()
+		}
+
 		for i := range netInfoMorph.Raw {
 			ni.SetRawNetworkParameter(netInfoMorph.Raw[i].Name, netInfoMorph.Raw[i].Value)
 		}

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -16,6 +16,7 @@ import (
 	netmapTransportGRPC "github.com/nspcc-dev/neofs-node/pkg/network/transport/netmap/grpc"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	netmapService "github.com/nspcc-dev/neofs-node/pkg/services/netmap"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	netmapSDK "github.com/nspcc-dev/neofs-sdk-go/netmap"
 	subnetid "github.com/nspcc-dev/neofs-sdk-go/subnet/id"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
@@ -318,7 +319,7 @@ func addNewEpochAsyncNotificationHandler(c *cfg, h event.Handler) {
 
 var errRelayBootstrap = errors.New("setting netmap status is forbidden in relay mode")
 
-var errNodeMaintenance = errors.New("node is in maintenance mode")
+var errNodeMaintenance apistatus.NodeUnderMaintenance
 
 func (c *cfg) SetNetmapStatus(st control.NetmapStatus) error {
 	switch st {

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -404,6 +404,10 @@ func (n *netInfo) Dump(ver version.Version) (*netmapSDK.NetworkInfo, error) {
 			ni.DisableHomomorphicHashing()
 		}
 
+		if netInfoMorph.MaintenanceModeAllowed {
+			ni.AllowMaintenanceMode()
+		}
+
 		for i := range netInfoMorph.Raw {
 			ni.SetRawNetworkParameter(netInfoMorph.Raw[i].Name, netInfoMorph.Raw[i].Value)
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.99.2
 	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b // indirect
 	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c
-	github.com/nspcc-dev/neofs-contract v0.15.5
+	github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.6.0.20220926102839-c6576c8112ee
 	github.com/nspcc-dev/tzhash v1.6.1
 	github.com/panjf2000/ants/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyE
 github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c h1:YZwtBY9uypaShbe/NLhosDanIfxt8VhQlSLYUeFIWv8=
 github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
 github.com/nspcc-dev/neofs-contract v0.15.3/go.mod h1:BXVZUZUJxrmmDETglXHI8+5DSgn84B9y5DoSWqEjYCs=
-github.com/nspcc-dev/neofs-contract v0.15.5 h1:6Fsr1VRaG1klCWipWWPHvVkKaVS85tcxxsNDbvVB2zk=
-github.com/nspcc-dev/neofs-contract v0.15.5/go.mod h1:gN5bo2TlMvLbySImmg76DVj3jVmYgti2VVlQ+h/tcr0=
+github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c h1:jG8gu/qLprxjh99J7qGqGiPMJPXPQ5eM0el8Cb6o0Tc=
+github.com/nspcc-dev/neofs-contract v0.15.5-0.20220930133158-d95bc535894c/go.mod h1:gN5bo2TlMvLbySImmg76DVj3jVmYgti2VVlQ+h/tcr0=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -690,8 +690,10 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper, errChan chan<- 
 		}
 	}
 
+	netSettings := (*networkSettings)(server.netmapClient)
+
 	var netMapCandidateStateValidator statevalidation.NetMapCandidateValidator
-	netMapCandidateStateValidator.SetNetworkSettings((*networkSettings)(server.netmapClient))
+	netMapCandidateStateValidator.SetNetworkSettings(netSettings)
 
 	// create netmap processor
 	server.netmapProcessor, err = netmap.New(&netmap.Params{
@@ -722,6 +724,8 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper, errChan chan<- 
 		),
 		NotaryDisabled: server.sideNotaryConfig.disabled,
 		SubnetContract: &server.contracts.subnet,
+
+		NodeStateSettings: netSettings,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -691,6 +691,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper, errChan chan<- 
 	}
 
 	var netMapCandidateStateValidator statevalidation.NetMapCandidateValidator
+	netMapCandidateStateValidator.SetNetworkSettings((*networkSettings)(server.netmapClient))
 
 	// create netmap processor
 	server.netmapProcessor, err = netmap.New(&netmap.Params{

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap"
 	nodevalidator "github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation"
 	addrvalidator "github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/maddress"
+	statevalidation "github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/state"
 	subnetvalidator "github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/subnet"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/reputation"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement"
@@ -689,6 +690,8 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper, errChan chan<- 
 		}
 	}
 
+	var netMapCandidateStateValidator statevalidation.NetMapCandidateValidator
+
 	// create netmap processor
 	server.netmapProcessor, err = netmap.New(&netmap.Params{
 		Log:              log,
@@ -711,6 +714,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *viper.Viper, errChan chan<- 
 		),
 		AlphabetSyncHandler: alphaSync,
 		NodeValidator: nodevalidator.New(
+			&netMapCandidateStateValidator,
 			addrvalidator.New(),
 			locodeValidator,
 			subnetValidator,

--- a/pkg/innerring/netmap.go
+++ b/pkg/innerring/netmap.go
@@ -1,6 +1,8 @@
 package innerring
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/state"
 	netmapclient "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 )
@@ -16,5 +18,12 @@ type networkSettings netmapclient.Client
 // and check allowance of storage node's maintenance mode according to it.
 // Always returns state.ErrMaintenanceModeDisallowed.
 func (s *networkSettings) MaintenanceModeAllowed() error {
+	allowed, err := (*netmapclient.Client)(s).MaintenanceModeAllowed()
+	if err != nil {
+		return fmt.Errorf("read maintenance mode's allowance from the Sidechain: %w", err)
+	} else if allowed {
+		return nil
+	}
+
 	return state.ErrMaintenanceModeDisallowed
 }

--- a/pkg/innerring/netmap.go
+++ b/pkg/innerring/netmap.go
@@ -1,0 +1,20 @@
+package innerring
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/state"
+	netmapclient "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
+)
+
+/*
+File contains dependencies for processor of the Netmap contract's notifications.
+*/
+
+// wraps Netmap contract's client and provides state.NetworkSettings.
+type networkSettings netmapclient.Client
+
+// MaintenanceModeAllowed requests network configuration from the Sidechain
+// and check allowance of storage node's maintenance mode according to it.
+// Always returns state.ErrMaintenanceModeDisallowed.
+func (s *networkSettings) MaintenanceModeAllowed() error {
+	return state.ErrMaintenanceModeDisallowed
+}

--- a/pkg/innerring/processors/alphabet/process_emit.go
+++ b/pkg/innerring/processors/alphabet/process_emit.go
@@ -40,7 +40,7 @@ func (ap *Processor) processEmit() {
 		return
 	}
 
-	networkMap, err := ap.netmapClient.Snapshot()
+	networkMap, err := ap.netmapClient.NetMap()
 	if err != nil {
 		ap.log.Warn("can't get netmap snapshot to emit gas to storage nodes",
 			zap.String("error", err.Error()))

--- a/pkg/innerring/processors/netmap/nodevalidation/state/validator.go
+++ b/pkg/innerring/processors/netmap/nodevalidation/state/validator.go
@@ -1,0 +1,41 @@
+/*
+Package state collects functionality for verifying states of network map members.
+
+NetMapCandidateValidator type provides an interface for checking the network
+map candidates.
+*/
+package state
+
+import (
+	"errors"
+
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+)
+
+// NetMapCandidateValidator represents tool which checks state of nodes which
+// are going to register in the NeoFS network (enter the network map).
+//
+// NetMapCandidateValidator can be instantiated using built-in var declaration
+// and currently doesn't require any additional initialization.
+//
+// NetMapCandidateValidator implements
+// github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap.NodeValidator.
+type NetMapCandidateValidator struct {
+}
+
+// VerifyAndUpdate checks state of the network map candidate described by
+// netmap.NodeInfo parameter. Returns no error if status is correct, otherwise
+// returns an error describing a violation of the rules:
+//
+//	status MUST be ONLINE
+//
+// VerifyAndUpdate does not mutate the parameter in a binary format.
+//
+// See also netmap.NodeInfo.IsOnline/SetOnline.
+func (x *NetMapCandidateValidator) VerifyAndUpdate(node *netmap.NodeInfo) error {
+	if node.IsOnline() {
+		return nil
+	}
+
+	return errors.New("invalid status: MUST be ONLINE")
+}

--- a/pkg/innerring/processors/netmap/nodevalidation/state/validator.go
+++ b/pkg/innerring/processors/netmap/nodevalidation/state/validator.go
@@ -12,6 +12,20 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 )
 
+// ErrMaintenanceModeDisallowed is returned when maintenance mode is disallowed.
+var ErrMaintenanceModeDisallowed = errors.New("maintenance mode is disallowed")
+
+// NetworkSettings encapsulates current settings of the NeoFS network and
+// provides interface used for processing the network map candidates.
+type NetworkSettings interface {
+	// MaintenanceModeAllowed checks if maintenance state of the storage nodes
+	// is allowed to be set, and returns:
+	//  no error if allowed;
+	//  ErrMaintenanceModeDisallowed if disallowed;
+	//  other error if there are any problems with the check.
+	MaintenanceModeAllowed() error
+}
+
 // NetMapCandidateValidator represents tool which checks state of nodes which
 // are going to register in the NeoFS network (enter the network map).
 //
@@ -21,21 +35,34 @@ import (
 // NetMapCandidateValidator implements
 // github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap.NodeValidator.
 type NetMapCandidateValidator struct {
+	netSettings NetworkSettings
+}
+
+// SetNetworkSettings specifies provider of the NetworkSettings interface.
+// MUST be called before any VerifyAndUpdate call. Parameter MUST NOT be nil.
+func (x *NetMapCandidateValidator) SetNetworkSettings(netSettings NetworkSettings) {
+	x.netSettings = netSettings
 }
 
 // VerifyAndUpdate checks state of the network map candidate described by
 // netmap.NodeInfo parameter. Returns no error if status is correct, otherwise
 // returns an error describing a violation of the rules:
 //
-//	status MUST be ONLINE
+//	status MUST be either ONLINE or MAINTENANCE;
+//	if status is MAINTENANCE, then it SHOULD be allowed by the network.
 //
 // VerifyAndUpdate does not mutate the parameter in a binary format.
+// MUST NOT be called before SetNetworkSettings.
 //
-// See also netmap.NodeInfo.IsOnline/SetOnline.
+// See also netmap.NodeInfo.IsOnline/SetOnline and other similar methods.
 func (x *NetMapCandidateValidator) VerifyAndUpdate(node *netmap.NodeInfo) error {
 	if node.IsOnline() {
 		return nil
 	}
 
-	return errors.New("invalid status: MUST be ONLINE")
+	if node.IsMaintenance() {
+		return x.netSettings.MaintenanceModeAllowed()
+	}
+
+	return errors.New("invalid status: MUST be either ONLINE or MAINTENANCE")
 }

--- a/pkg/innerring/processors/netmap/nodevalidation/state/validator_test.go
+++ b/pkg/innerring/processors/netmap/nodevalidation/state/validator_test.go
@@ -1,0 +1,54 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/state"
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidator_VerifyAndUpdate(t *testing.T) {
+	var v state.NetMapCandidateValidator
+
+	for _, testCase := range []struct {
+		name     string
+		preparer func(*netmap.NodeInfo) // modifies zero instance
+		valid    bool                   // is node valid after preparation
+	}{
+		{
+			name:     "UNDEFINED",
+			preparer: func(info *netmap.NodeInfo) {},
+			valid:    false,
+		},
+		{
+			name:     "ONLINE",
+			preparer: (*netmap.NodeInfo).SetOnline,
+			valid:    true,
+		},
+		{
+			name:     "OFFLINE",
+			preparer: (*netmap.NodeInfo).SetOffline,
+			valid:    false,
+		},
+	} {
+		var node netmap.NodeInfo
+
+		// prepare node
+		testCase.preparer(&node)
+
+		// save binary representation for mutation check
+		binNode := node.Marshal()
+
+		err := v.VerifyAndUpdate(&node)
+
+		if testCase.valid {
+			require.NoError(t, err, testCase.name)
+		} else {
+			require.Error(t, err, testCase.name)
+		}
+
+		// check mutation
+		require.Equal(t, binNode, node.Marshal(), testCase.name)
+	}
+}

--- a/pkg/innerring/processors/netmap/process_epoch.go
+++ b/pkg/innerring/processors/netmap/process_epoch.go
@@ -37,7 +37,7 @@ func (np *Processor) processNewEpoch(ev netmapEvent.NewEpoch) {
 	}
 
 	// get new netmap snapshot
-	networkMap, err := np.netmapClient.Snapshot()
+	networkMap, err := np.netmapClient.NetMap()
 	if err != nil {
 		np.log.Warn("can't get netmap snapshot to perform cleanup",
 			zap.String("error", err.Error()))

--- a/pkg/innerring/processors/netmap/process_peers.go
+++ b/pkg/innerring/processors/netmap/process_peers.go
@@ -169,14 +169,12 @@ func (np *Processor) processRemoveSubnetNode(ev subnetEvent.RemoveNode) {
 		return
 	}
 
-	candidateNodes := candidates.Nodes()
-
-	for i := range candidateNodes {
-		if !bytes.Equal(candidateNodes[i].PublicKey(), ev.Node()) {
+	for i := range candidates {
+		if !bytes.Equal(candidates[i].PublicKey(), ev.Node()) {
 			continue
 		}
 
-		err = candidateNodes[i].IterateSubnets(func(subNetID subnetid.ID) error {
+		err = candidates[i].IterateSubnets(func(subNetID subnetid.ID) error {
 			if subNetID.Equals(subnetToRemoveFrom) {
 				return netmap.ErrRemoveSubnet
 			}
@@ -198,7 +196,7 @@ func (np *Processor) processRemoveSubnetNode(ev subnetEvent.RemoveNode) {
 			}
 		} else {
 			prm := netmapclient.AddPeerPrm{}
-			prm.SetNodeInfo(candidateNodes[i])
+			prm.SetNodeInfo(candidates[i])
 			prm.SetHash(ev.TxHash())
 
 			err = np.netmapClient.AddPeer(prm)

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/mempoolevent"
 	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/netmap/nodevalidation/state"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
 	nmClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
@@ -74,6 +75,8 @@ type (
 		nodeValidator NodeValidator
 
 		notaryDisabled bool
+
+		nodeStateSettings state.NetworkSettings
 	}
 
 	// Params of the processor constructor.
@@ -97,6 +100,8 @@ type (
 		NodeValidator NodeValidator
 
 		NotaryDisabled bool
+
+		NodeStateSettings state.NetworkSettings
 	}
 )
 
@@ -132,6 +137,8 @@ func New(p *Params) (*Processor, error) {
 		return nil, errors.New("ir/netmap: node validator is not set")
 	case p.SubnetContract == nil:
 		return nil, errors.New("ir/netmap: subnet contract script hash is not set")
+	case p.NodeStateSettings == nil:
+		return nil, errors.New("ir/netmap: node state settings is not set")
 	}
 
 	p.Log.Debug("netmap worker pool", zap.Int("size", p.PoolSize))
@@ -162,6 +169,8 @@ func New(p *Params) (*Processor, error) {
 		nodeValidator: p.NodeValidator,
 
 		notaryDisabled: p.NotaryDisabled,
+
+		nodeStateSettings: p.NodeStateSettings,
 	}, nil
 }
 

--- a/pkg/innerring/subnet.go
+++ b/pkg/innerring/subnet.go
@@ -301,10 +301,8 @@ func (s *Server) handleSubnetRemoval(e event.Event) {
 		return
 	}
 
-	candidateNodes := candidates.Nodes()
-
-	for i := range candidateNodes {
-		s.processCandidate(delEv.TxHash(), removedID, candidateNodes[i])
+	for i := range candidates {
+		s.processCandidate(delEv.TxHash(), removedID, candidates[i])
 	}
 }
 

--- a/pkg/morph/client/netmap/config.go
+++ b/pkg/morph/client/netmap/config.go
@@ -244,6 +244,8 @@ type NetworkConfiguration struct {
 
 	WithdrawalFee uint64
 
+	HomomorphicHashingDisabled bool
+
 	Raw []RawNetworkParameter
 }
 
@@ -308,6 +310,8 @@ func (c *Client) ReadNetworkConfiguration() (NetworkConfiguration, error) {
 			res.IRCandidateFee = bytesToUint64(value)
 		case withdrawFeeConfig:
 			res.WithdrawalFee = bytesToUint64(value)
+		case homomorphicHashingDisabledKey:
+			res.HomomorphicHashingDisabled = bytesToBool(value)
 		}
 
 		return nil
@@ -321,6 +325,16 @@ func bytesToUint64(val []byte) uint64 {
 		return 0
 	}
 	return bigint.FromBytes(val).Uint64()
+}
+
+func bytesToBool(val []byte) bool {
+	for i := range val {
+		if val[i] != 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ErrConfigNotFound is returned when the requested key was not found

--- a/pkg/morph/client/netmap/config.go
+++ b/pkg/morph/client/netmap/config.go
@@ -22,6 +22,7 @@ const (
 	irCandidateFeeConfig          = "InnerRingCandidateFee"
 	withdrawFeeConfig             = "WithdrawFee"
 	homomorphicHashingDisabledKey = "HomomorphicHashingDisabled"
+	maintenanceModeAllowedConfig  = "MaintenanceModeAllowed"
 )
 
 // MaxObjectSize receives max object size configuration
@@ -141,6 +142,15 @@ func (c *Client) WithdrawFee() (uint64, error) {
 	return fee, nil
 }
 
+// MaintenanceModeAllowed reads admission of "maintenance" state from the
+// NeoFS network configuration stored in the Sidechain. The admission means
+// that storage nodes are allowed to switch their state to "maintenance".
+//
+// By default, maintenance state is disallowed.
+func (c *Client) MaintenanceModeAllowed() (bool, error) {
+	return c.readBoolConfig(maintenanceModeAllowedConfig)
+}
+
 func (c *Client) readUInt64Config(key string) (uint64, error) {
 	v, err := c.config([]byte(key), IntegerAssert)
 	if err != nil {
@@ -246,6 +256,8 @@ type NetworkConfiguration struct {
 
 	HomomorphicHashingDisabled bool
 
+	MaintenanceModeAllowed bool
+
 	Raw []RawNetworkParameter
 }
 
@@ -312,6 +324,8 @@ func (c *Client) ReadNetworkConfiguration() (NetworkConfiguration, error) {
 			res.WithdrawalFee = bytesToUint64(value)
 		case homomorphicHashingDisabledKey:
 			res.HomomorphicHashingDisabled = bytesToBool(value)
+		case maintenanceModeAllowedConfig:
+			res.MaintenanceModeAllowed = bytesToBool(value)
 		}
 
 		return nil

--- a/pkg/morph/client/netmap/netmap_test.go
+++ b/pkg/morph/client/netmap/netmap_test.go
@@ -19,10 +19,12 @@ func Test_stackItemsToNodeInfos(t *testing.T) {
 		rand.Read(pub)
 
 		switch i % 3 {
-		case int(netmapcontract.OfflineState):
+		default:
 			expected[i].SetOffline()
-		case int(netmapcontract.OnlineState):
+		case int(netmapcontract.NodeStateOnline):
 			expected[i].SetOnline()
+		case int(netmapcontract.NodeStateMaintenance):
+			expected[i].SetMaintenance()
 		}
 
 		expected[i].SetPublicKey(pub)
@@ -38,20 +40,20 @@ func Test_stackItemsToNodeInfos(t *testing.T) {
 
 		switch {
 		case expected[i].IsOnline():
-			state = int64(netmapcontract.OnlineState)
+			state = int64(netmapcontract.NodeStateOnline)
 		case expected[i].IsOffline():
-			state = int64(netmapcontract.OfflineState)
+			state = int64(netmapcontract.NodeStateOffline)
+		case expected[i].IsMaintenance():
+			state = int64(netmapcontract.NodeStateMaintenance)
 		}
 
 		items[i] = stackitem.NewStruct([]stackitem.Item{
-			stackitem.NewStruct([]stackitem.Item{
-				stackitem.NewByteArray(data),
-			}),
+			stackitem.NewByteArray(data),
 			stackitem.NewBigInteger(big.NewInt(state)),
 		})
 	}
 
-	actual, err := nodeInfosFromStackItems([]stackitem.Item{stackitem.NewArray(items)}, "")
+	actual, err := decodeNodeList(stackitem.NewArray(items))
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }

--- a/pkg/morph/client/netmap/snapshot.go
+++ b/pkg/morph/client/netmap/snapshot.go
@@ -1,28 +1,12 @@
 package netmap
 
 import (
-	"fmt"
-
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 )
 
-// GetNetMap receives information list about storage nodes
-// through the Netmap contract call, composes network map
-// from them and returns it. With diff == 0 returns current
-// network map, else return snapshot of previous network map.
+// GetNetMap calls "snapshot" method and decodes netmap.NetMap from the response.
 func (c *Client) GetNetMap(diff uint64) (*netmap.NetMap, error) {
-	return c.getNetMap(diff)
-}
-
-// Snapshot returns current netmap node infos.
-// Consider using pkg/morph/client/netmap for this.
-func (c *Client) Snapshot() (*netmap.NetMap, error) {
-	return c.getNetMap(0)
-}
-
-func (c *Client) getNetMap(diff uint64) (*netmap.NetMap, error) {
 	prm := client.TestInvokePrm{}
 	prm.SetMethod(snapshotMethod)
 	prm.SetArgs(diff)
@@ -32,24 +16,5 @@ func (c *Client) getNetMap(diff uint64) (*netmap.NetMap, error) {
 		return nil, err
 	}
 
-	return unmarshalNetmap(res, snapshotMethod)
-}
-
-func unmarshalNetmap(items []stackitem.Item, method string) (*netmap.NetMap, error) {
-	rawPeers, err := peersFromStackItems(items, method)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]netmap.NodeInfo, len(rawPeers))
-	for i := range rawPeers {
-		if err := result[i].Unmarshal(rawPeers[i]); err != nil {
-			return nil, fmt.Errorf("can't unmarshal node info (%s): %w", method, err)
-		}
-	}
-
-	var nm netmap.NetMap
-	nm.SetNodes(result)
-
-	return &nm, nil
+	return decodeNetMap(res)
 }

--- a/pkg/morph/client/netmap/update_state.go
+++ b/pkg/morph/client/netmap/update_state.go
@@ -11,6 +11,7 @@ import (
 const (
 	stateOffline int8 = iota
 	stateOnline
+	stateMaintenance
 )
 
 // UpdatePeerPrm groups parameters of UpdatePeerState operation.
@@ -34,6 +35,13 @@ func (u *UpdatePeerPrm) SetOnline() {
 	u.state = stateOnline
 }
 
+// SetMaintenance marks node to be switched into "maintenance" state.
+//
+// Zero UpdatePeerPrm marks node as "offline".
+func (u *UpdatePeerPrm) SetMaintenance() {
+	u.state = stateMaintenance
+}
+
 // UpdatePeerState changes peer status through Netmap contract call.
 func (c *Client) UpdatePeerState(p UpdatePeerPrm) error {
 	method := updateStateMethod
@@ -54,6 +62,8 @@ func (c *Client) UpdatePeerState(p UpdatePeerPrm) error {
 		// already set above
 	case stateOnline:
 		state = netmap.OnlineState
+	case stateMaintenance:
+		state = netmap.OfflineState + 1 // FIXME: use named constant after neofs-contract#269
 	}
 
 	prm := client.InvokePrm{}

--- a/pkg/morph/event/netmap/update_peer.go
+++ b/pkg/morph/event/netmap/update_peer.go
@@ -16,6 +16,7 @@ import (
 const (
 	_ int8 = iota
 	stateOnline
+	stateMaintenance
 )
 
 type UpdatePeer struct {
@@ -31,8 +32,16 @@ type UpdatePeer struct {
 // MorphEvent implements Neo:Morph Event interface.
 func (UpdatePeer) MorphEvent() {}
 
+// Online returns true if node's state is requested to be switched
+// to "online".
 func (s UpdatePeer) Online() bool {
 	return s.state == stateOnline
+}
+
+// Maintenance returns true if node's state is requested to be switched
+// to "maintenance".
+func (s UpdatePeer) Maintenance() bool {
+	return s.state == stateMaintenance
 }
 
 func (s UpdatePeer) PublicKey() *keys.PublicKey {
@@ -85,6 +94,8 @@ func ParseUpdatePeer(e *state.ContainedNotificationEvent) (event.Event, error) {
 	case int64(netmap.OfflineState):
 	case int64(netmap.OnlineState):
 		ev.state = stateOnline
+	case int64(netmap.OfflineState) + 1: // FIXME: use named constant after neofs-contract#269
+		ev.state = stateMaintenance
 	}
 
 	return ev, nil

--- a/pkg/morph/event/netmap/update_peer.go
+++ b/pkg/morph/event/netmap/update_peer.go
@@ -12,10 +12,16 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
+// TODO: enum can become redundant after neofs-contract#270
+const (
+	_ int8 = iota
+	stateOnline
+)
+
 type UpdatePeer struct {
 	publicKey *keys.PublicKey
 
-	online bool
+	state int8 // state enum value
 
 	// For notary notifications only.
 	// Contains raw transactions of notary request.
@@ -26,7 +32,7 @@ type UpdatePeer struct {
 func (UpdatePeer) MorphEvent() {}
 
 func (s UpdatePeer) Online() bool {
-	return s.online
+	return s.state == stateOnline
 }
 
 func (s UpdatePeer) PublicKey() *keys.PublicKey {
@@ -78,7 +84,7 @@ func ParseUpdatePeer(e *state.ContainedNotificationEvent) (event.Event, error) {
 		return nil, fmt.Errorf("unsupported node state %d", st)
 	case int64(netmap.OfflineState):
 	case int64(netmap.OnlineState):
-		ev.online = true
+		ev.state = stateOnline
 	}
 
 	return ev, nil

--- a/pkg/morph/event/netmap/update_peer_notary.go
+++ b/pkg/morph/event/netmap/update_peer_notary.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
-	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-contract/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
@@ -61,12 +61,14 @@ func ParseUpdatePeerNotary(ne event.NotaryEvent) (event.Event, error) {
 				return nil, err
 			}
 
-			switch v2netmap.NodeState(state) {
+			switch state {
 			default:
 				return nil, fmt.Errorf("unsupported node state %d", err)
-			case v2netmap.Offline:
-			case v2netmap.Online:
+			case int64(netmap.OfflineState):
+			case int64(netmap.OnlineState):
 				ev.state = stateOnline
+			case int64(netmap.OfflineState) + 1: // FIXME: use named constant after neofs-contract#269
+				ev.state = stateMaintenance
 			}
 
 			fieldNum++

--- a/pkg/morph/event/netmap/update_peer_notary.go
+++ b/pkg/morph/event/netmap/update_peer_notary.go
@@ -66,7 +66,7 @@ func ParseUpdatePeerNotary(ne event.NotaryEvent) (event.Event, error) {
 				return nil, fmt.Errorf("unsupported node state %d", err)
 			case v2netmap.Offline:
 			case v2netmap.Online:
-				ev.online = true
+				ev.state = stateOnline
 			}
 
 			fieldNum++

--- a/pkg/morph/event/netmap/update_peer_notary.go
+++ b/pkg/morph/event/netmap/update_peer_notary.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/vm/opcode"
-	"github.com/nspcc-dev/neofs-contract/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 )
 
@@ -61,14 +60,9 @@ func ParseUpdatePeerNotary(ne event.NotaryEvent) (event.Event, error) {
 				return nil, err
 			}
 
-			switch state {
-			default:
-				return nil, fmt.Errorf("unsupported node state %d", err)
-			case int64(netmap.OfflineState):
-			case int64(netmap.OnlineState):
-				ev.state = stateOnline
-			case int64(netmap.OfflineState) + 1: // FIXME: use named constant after neofs-contract#269
-				ev.state = stateMaintenance
+			err = ev.decodeState(state)
+			if err != nil {
+				return nil, err
 			}
 
 			fieldNum++

--- a/pkg/morph/event/netmap/update_peer_test.go
+++ b/pkg/morph/event/netmap/update_peer_test.go
@@ -51,7 +51,7 @@ func TestParseUpdatePeer(t *testing.T) {
 
 		require.Equal(t, UpdatePeer{
 			publicKey: publicKey,
-			online:    true,
+			state:     stateOnline,
 		}, ev)
 	})
 }

--- a/pkg/morph/event/netmap/update_peer_test.go
+++ b/pkg/morph/event/netmap/update_peer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neofs-contract/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	"github.com/stretchr/testify/require"
 )
@@ -43,15 +44,16 @@ func TestParseUpdatePeer(t *testing.T) {
 	})
 
 	t.Run("correct behavior", func(t *testing.T) {
+		const state = netmap.NodeStateMaintenance
 		ev, err := ParseUpdatePeer(createNotifyEventFromItems([]stackitem.Item{
-			stackitem.NewBigInteger(new(big.Int).SetInt64(1)),
+			stackitem.NewBigInteger(big.NewInt(int64(state))),
 			stackitem.NewByteArray(publicKey.Bytes()),
 		}))
 		require.NoError(t, err)
 
 		require.Equal(t, UpdatePeer{
 			publicKey: publicKey,
-			state:     stateOnline,
+			state:     state,
 		}, ev)
 	})
 }

--- a/pkg/services/object/get/service.go
+++ b/pkg/services/object/get/service.go
@@ -130,3 +130,10 @@ func WithKeyStorage(store *util.KeyStorage) Option {
 		c.keyStore = store
 	}
 }
+
+// WithNodeState provides util.NodeState to Service.
+func WithNodeState(v util.NodeState) Option {
+	return func(c *cfg) {
+		c.localStorage.(*storageEngineWrapper).state = v
+	}
+}

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -8,6 +8,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	internal "github.com/nspcc-dev/neofs-node/pkg/services/object/internal/client"
 	internalclient "github.com/nspcc-dev/neofs-node/pkg/services/object/internal/client"
+	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 )
 
@@ -26,6 +28,8 @@ type clientWrapper struct {
 }
 
 type storageEngineWrapper struct {
+	state util.NodeState
+
 	engine *engine.StorageEngine
 }
 
@@ -170,6 +174,11 @@ func (c *clientWrapper) getObject(exec *execCtx, info coreclient.NodeInfo) (*obj
 }
 
 func (e *storageEngineWrapper) get(exec *execCtx) (*object.Object, error) {
+	if e.state != nil && e.state.IsMaintenance() {
+		var st apistatus.NodeUnderMaintenance
+		return nil, st
+	}
+
 	if exec.headOnly() {
 		var headPrm engine.HeadPrm
 		headPrm.WithAddress(exec.address())

--- a/pkg/services/object/search/service.go
+++ b/pkg/services/object/search/service.go
@@ -81,9 +81,12 @@ func WithLogger(l *logger.Logger) Option {
 
 // WithLocalStorageEngine returns option to set local storage
 // instance.
-func WithLocalStorageEngine(e *engine.StorageEngine) Option {
+func WithLocalStorageEngine(e *engine.StorageEngine, state util.NodeState) Option {
 	return func(c *cfg) {
-		c.localStorage = (*storageEngineWrapper)(e)
+		c.localStorage = &storageEngineWrapper{
+			state:   state,
+			storage: e,
+		}
 	}
 }
 

--- a/pkg/services/object/util/node_state.go
+++ b/pkg/services/object/util/node_state.go
@@ -1,0 +1,9 @@
+package util
+
+// NodeState is storage node state processed by Object service.
+type NodeState interface {
+	// IsMaintenance checks if node is under maintenance. Node MUST NOT serve
+	// local object operations. Node MUST respond with apistatus.NodeUnderMaintenance
+	// error if IsMaintenance returns true.
+	IsMaintenance() bool
+}


### PR DESCRIPTION
* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/339
* blocked by https://github.com/nspcc-dev/neofs-contract/issues/269
* based on and blocked by https://github.com/nspcc-dev/neofs-contract/pull/273
* closes #1796
* closes #1797
* closes #1681
* relates #1680

I'm NOT going to cover `Replication` chapter of #1680 since it's better to be done in a separate PR.

I also decided to postpone the final solution of blocking local Object service in maintenance to #1834.