### PR TITLE
Feat/Reload config on SIGHUP

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -154,6 +154,11 @@ func (a *applicationConfiguration) readConfig(c *config.Config) error {
 	if a._read {
 		// clear if it is rereading
 		*a = applicationConfiguration{}
+
+		err := c.Reload()
+		if err != nil {
+			return err
+		}
 	} else {
 		// update the status
 		a._read = true

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -78,6 +78,10 @@ const notificationHandlerPoolSize = 10
 // structs).
 // It must not be used concurrently.
 type applicationConfiguration struct {
+	// _read indicated whether a config
+	// has already been read
+	_read bool
+
 	EngineCfg struct {
 		errorThreshold uint32
 		shardPoolSize  uint32
@@ -144,6 +148,14 @@ type subStorageCfg struct {
 // readConfig fills applicationConfiguration with raw configuration values
 // not modifying them.
 func (a *applicationConfiguration) readConfig(c *config.Config) error {
+	if a._read {
+		// clear if it is rereading
+		*a = applicationConfiguration{}
+	} else {
+		// update the status
+		a._read = true
+	}
+
 	a.EngineCfg.errorThreshold = engineconfig.ShardErrorThreshold(c)
 	a.EngineCfg.shardPoolSize = engineconfig.ShardPoolSize(c)
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -356,8 +356,6 @@ func initCfg(appCfg *config.Config) *cfg {
 	c.onShutdown(c.clientCache.CloseAll) // clean up connections
 	c.onShutdown(func() { _ = c.persistate.Close() })
 
-	initLocalStorage(c)
-
 	return c
 }
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -152,15 +152,22 @@ type subStorageCfg struct {
 // not modifying them.
 func (a *applicationConfiguration) readConfig(c *config.Config) error {
 	if a._read {
-		// clear if it is rereading
-		*a = applicationConfiguration{}
-
 		err := c.Reload()
 		if err != nil {
-			return err
+			return fmt.Errorf("could not reload configuration: %w", err)
 		}
+
+		err = validateConfig(c)
+		if err != nil {
+			return fmt.Errorf("configuration's validation: %w", err)
+		}
+
+		// clear if it is rereading
+		*a = applicationConfiguration{}
 	} else {
-		// update the status
+		// update the status.
+		// initial configuration validation is expected to be
+		// performed on the higher level
 		a._read = true
 	}
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path/filepath"
 	"sync"
 	atomicstd "sync/atomic"
 	"time"
@@ -494,7 +493,6 @@ func initShardOptions(c *cfg) {
 
 		metaPath := metabaseCfg.Path()
 		metaPerm := metabaseCfg.BoltDB().Perm()
-		fatalOnErr(util.MkdirAllX(filepath.Dir(metaPath), metaPerm))
 
 		gcEventChannel := make(chan shard.Event)
 		addNewEpochNotificationHandler(c, func(ev event.Event) {

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -379,6 +379,10 @@ func initLocalStorage(c *cfg) {
 
 	ls := engine.New(engineOpts...)
 
+	addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {
+		ls.HandleNewEpoch(ev.(netmap2.NewEpoch).EpochNumber())
+	})
+
 	// allocate memory for the service;
 	// service will be created later
 	c.cfgObject.getSvc = new(getsvc.Service)
@@ -494,11 +498,6 @@ func initShardOptions(c *cfg) {
 		metaPath := metabaseCfg.Path()
 		metaPerm := metabaseCfg.BoltDB().Perm()
 
-		gcEventChannel := make(chan shard.Event)
-		addNewEpochNotificationHandler(c, func(ev event.Event) {
-			gcEventChannel <- shard.EventNewEpoch(ev.(netmap2.NewEpoch).EpochNumber())
-		})
-
 		opts = append(opts, []shard.Option{
 			shard.WithLogger(c.log),
 			shard.WithRefillMetabase(sc.RefillMetabase()),
@@ -531,7 +530,6 @@ func initShardOptions(c *cfg) {
 
 				return pool
 			}),
-			shard.WithGCEventChannel(gcEventChannel),
 		})
 		return nil
 	})

--- a/cmd/neofs-node/config/config.go
+++ b/cmd/neofs-node/config/config.go
@@ -17,6 +17,8 @@ import (
 type Config struct {
 	v *viper.Viper
 
+	opts opts
+
 	defaultPath []string
 	path        []string
 }
@@ -53,6 +55,20 @@ func New(_ Prm, opts ...Option) *Config {
 	}
 
 	return &Config{
-		v: v,
+		v:    v,
+		opts: *o,
 	}
+}
+
+// Reload reads configuration path if any was provided
+// to the New. Returns any
+func (x *Config) Reload() error {
+	if x.opts.path != "" {
+		err := x.v.ReadInConfig()
+		if err != nil {
+			return fmt.Errorf("rereading configuration file: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/neofs-node/config/engine/shard/blobstor/fstree/config.go
+++ b/cmd/neofs-node/config/engine/shard/blobstor/fstree/config.go
@@ -26,14 +26,14 @@ func (x *Config) Type() string {
 //
 // Returns DepthDefault if the value is out of
 // [1:fstree.MaxDepth] range.
-func (x *Config) Depth() int {
-	d := config.IntSafe(
+func (x *Config) Depth() uint64 {
+	d := config.UintSafe(
 		(*config.Config)(x),
 		"depth",
 	)
 
 	if d >= 1 && d <= fstree.MaxDepth {
-		return int(d)
+		return d
 	}
 
 	return DepthDefault

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -81,7 +81,7 @@ func initAndLog(c *cfg, name string, initializer func(*cfg)) {
 func initApp(c *cfg) {
 	initLocalStorage(c)
 
-	c.ctx, c.ctxCancel = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	c.ctx, c.ctxCancel = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	initAndLog(c, "storage engine", func(c *cfg) {
 		fatalOnErr(c.cfgObject.cfgLocalStorage.localStorage.Open())
@@ -102,6 +102,8 @@ func initApp(c *cfg) {
 	initAndLog(c, "control", initControlService)
 
 	initAndLog(c, "morph notifications", listenMorphNotifications)
+
+	c.workers = append(c.workers, newWorkerFromFunc(c.configWatcher))
 }
 
 func runAndLog(c *cfg, name string, logSuccess bool, starter func(*cfg)) {

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -79,6 +79,8 @@ func initAndLog(c *cfg, name string, initializer func(*cfg)) {
 }
 
 func initApp(c *cfg) {
+	initLocalStorage(c)
+
 	c.ctx, c.ctxCancel = signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	initAndLog(c, "storage engine", func(c *cfg) {

--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -23,7 +23,7 @@ type FSTree struct {
 	Info
 
 	*compression.Config
-	Depth      int
+	Depth      uint64
 	DirNameLen int
 
 	readOnly bool
@@ -96,7 +96,7 @@ func (t *FSTree) Iterate(prm common.IteratePrm) (common.IterateRes, error) {
 	return common.IterateRes{}, t.iterate(0, []string{t.RootPath}, prm)
 }
 
-func (t *FSTree) iterate(depth int, curPath []string, prm common.IteratePrm) error {
+func (t *FSTree) iterate(depth uint64, curPath []string, prm common.IteratePrm) error {
 	curName := strings.Join(curPath[1:], "")
 	des, err := os.ReadDir(filepath.Join(curPath...))
 	if err != nil {
@@ -172,7 +172,7 @@ func (t *FSTree) treePath(addr oid.Address) string {
 	dirs := make([]string, 0, t.Depth+1+1) // 1 for root, 1 for file
 	dirs = append(dirs, t.RootPath)
 
-	for i := 0; i < t.Depth; i++ {
+	for i := 0; uint64(i) < t.Depth; i++ {
 		dirs = append(dirs, sAddr[:t.DirNameLen])
 		sAddr = sAddr[t.DirNameLen:]
 	}

--- a/pkg/local_object_storage/blobstor/fstree/option.go
+++ b/pkg/local_object_storage/blobstor/fstree/option.go
@@ -6,7 +6,7 @@ import (
 
 type Option func(*FSTree)
 
-func WithDepth(d int) Option {
+func WithDepth(d uint64) Option {
 	return func(f *FSTree) {
 		f.Depth = d
 	}

--- a/pkg/local_object_storage/engine/control.go
+++ b/pkg/local_object_storage/engine/control.go
@@ -263,10 +263,7 @@ func (e *StorageEngine) Reload(rcfg ReConfiguration) error {
 
 	e.mtx.RUnlock()
 
-	err := e.removeShards(shardsToRemove...)
-	if err != nil {
-		return fmt.Errorf("could not remove shards: %w", err)
-	}
+	e.removeShards(shardsToRemove...)
 
 	for _, newPath := range shardsToAdd {
 		sh, err := e.createShard(rcfg.shards[newPath])

--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -139,7 +139,7 @@ func testNewShard(t testing.TB, id int) *shard.Shard {
 	return s
 }
 
-func testEngineFromShardOpts(t *testing.T, num int, extraOpts func(int) []shard.Option) *StorageEngine {
+func testEngineFromShardOpts(t *testing.T, num int, extraOpts []shard.Option) *StorageEngine {
 	engine := New()
 	for i := 0; i < num; i++ {
 		_, err := engine.AddShard(append([]shard.Option{
@@ -155,7 +155,7 @@ func testEngineFromShardOpts(t *testing.T, num int, extraOpts func(int) []shard.
 			),
 			shard.WithPiloramaOptions(
 				pilorama.WithPath(filepath.Join(t.Name(), fmt.Sprintf("pilorama%d", i)))),
-		}, extraOpts(i)...)...)
+		}, extraOpts...)...)
 		require.NoError(t, err)
 	}
 

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -176,6 +176,18 @@ func (e *StorageEngine) SetShardMode(id *shard.ID, m mode.Mode, resetErrorCounte
 	return errShardNotFound
 }
 
+// HandleNewEpoch notifies every shard about NewEpoch event.
+func (e *StorageEngine) HandleNewEpoch(epoch uint64) {
+	ev := shard.EventNewEpoch(epoch)
+
+	e.mtx.RLock()
+	defer e.mtx.RUnlock()
+
+	for _, sh := range e.shards {
+		sh.NotificationChannel() <- ev
+	}
+}
+
 func (s hashedShard) Hash() uint64 {
 	return hrw.Hash(
 		[]byte(s.Shard.ID().String()),

--- a/pkg/local_object_storage/engine/shards_test.go
+++ b/pkg/local_object_storage/engine/shards_test.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveShard(t *testing.T) {
+	const numOfShards = 6
+
+	e := testNewEngineWithShardNum(t, numOfShards)
+	t.Cleanup(func() {
+		e.Close()
+		os.RemoveAll(t.Name())
+	})
+
+	require.Equal(t, numOfShards, len(e.shardPools))
+	require.Equal(t, numOfShards, len(e.shards))
+
+	removedNum := numOfShards / 2
+
+	mSh := make(map[string]bool, numOfShards)
+	for i, sh := range e.DumpInfo().Shards {
+		if i == removedNum {
+			break
+		}
+
+		mSh[sh.ID.String()] = true
+	}
+
+	for id, remove := range mSh {
+		if remove {
+			require.NoError(t, e.removeShards(id))
+		}
+	}
+
+	require.Equal(t, numOfShards-removedNum, len(e.shardPools))
+	require.Equal(t, numOfShards-removedNum, len(e.shards))
+
+	for id, removed := range mSh {
+		_, ok := e.shards[id]
+		require.True(t, ok != removed)
+	}
+}

--- a/pkg/local_object_storage/engine/shards_test.go
+++ b/pkg/local_object_storage/engine/shards_test.go
@@ -32,7 +32,7 @@ func TestRemoveShard(t *testing.T) {
 
 	for id, remove := range mSh {
 		if remove {
-			require.NoError(t, e.removeShards(id))
+			e.removeShards(id)
 		}
 	}
 

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -134,6 +134,7 @@ func (s *Shard) Init() error {
 		gcCfg:       s.gcCfg,
 		remover:     s.removeGarbage,
 		stopChannel: make(chan struct{}),
+		eventChan:   make(chan Event),
 		mEventHandler: map[eventType]*eventHandlers{
 			eventNewEpoch: {
 				cancelFunc: func() {},

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -215,13 +215,6 @@ func WithGCWorkerPoolInitializer(wpInit func(int) util.WorkerPool) Option {
 	}
 }
 
-// WithGCEventChannel returns option to set a GC event channel.
-func WithGCEventChannel(eventChan <-chan Event) Option {
-	return func(c *cfg) {
-		c.gcCfg.eventChan = eventChan
-	}
-}
-
 // WithGCRemoverSleepInterval returns option to specify sleep
 // interval between object remover executions.
 func WithGCRemoverSleepInterval(dur time.Duration) Option {


### PR DESCRIPTION
Related to #1770.

1. Storage interface could be unified: `Open` and `Reload` could have the same args list but that will require additional refactoring, not sure if we need that.
2. It now seems like we have duplication of configuration structs: one placed in the `main` pkg and another in the `cmd/neofs-node/config` dir. They could be merged somehow if we need them to be together.
