### PR TITLE
Fix description of nodeinfo command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for NeoFS Node
 - Allow to evacuate shard data with `EvacuateShard` control RPC (#1800)
 
 ### Fixed
+- Description of command `netmap nodeinfo` (#1821)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -13,7 +13,7 @@ import (
 var getExtendedACLCmd = &cobra.Command{
 	Use:   "get-eacl",
 	Short: "Get extended ACL table of container",
-	Long:  `Get extended ACL talbe of container`,
+	Long:  `Get extended ACL table of container`,
 	Run: func(cmd *cobra.Command, args []string) {
 		id := parseContainerID(cmd)
 		pk := key.GetOrGenerate(cmd)

--- a/cmd/neofs-cli/modules/netmap/nodeinfo.go
+++ b/cmd/neofs-cli/modules/netmap/nodeinfo.go
@@ -15,8 +15,8 @@ const nodeInfoJSONFlag = commonflags.JSON
 
 var nodeInfoCmd = &cobra.Command{
 	Use:   "nodeinfo",
-	Short: "Get local node info",
-	Long:  `Get local node info`,
+	Short: "Get target node info",
+	Long:  `Get target node info`,
 	Run: func(cmd *cobra.Command, args []string) {
 		p := key.GetOrGenerate(cmd)
 		cli := internalclient.GetSDKClientByFlag(cmd, p, commonflags.RPC)


### PR DESCRIPTION
Description updated because the command returns information about the remote node that is listening to the `--rpc-endpoint`