### PR TITLE
engine: handle Inhume errors properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog for NeoFS Node
 - Storage nodes could enter the network with any state (#1796)
 - Missing check of new state value in `ControlService.SetNetmapStatus` (#1797)
 - Correlation of object session to request (#1420)
+- Do not increase error counter in `engine.Inhume` if shard is read-only (#1839)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)


### PR DESCRIPTION
If shard is in read-only or degraded mode, there is no need to increase error counter.

Found by @EliChin .
```
2022-10-04T14:55:12.765Z        warn    engine/engine.go:44     could not inhume object in shard        {"shard_id": "FsrPomaDsLXubwDYC1epFA", "error count": 22, "error": "shard is in read-only mode"}
2022-10-04T14:55:12.765Z        warn    engine/engine.go:44     could not inhume object in shard        {"shard_id": "FsrPomaDsLXubwDYC1epFA", "error count": 23, "error": "shard is in read-only mode"}
```

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>