### PR TITLE
Add command `container nodes` to output list of nodes for container, grouped by replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - `wallet-address` flag in `neofs-adm morph refill-gas` command (#1820)
 - Validate policy before container creation (#1704)
 - `--timeout` flag in `neofs-cli` subcommands (#1837)
+- `container nodes` command to output list of nodes for container, grouped by replica (#1704)
 
 ### Changed
 - Allow to evacuate shard data with `EvacuateShard` control RPC (#1800)

--- a/cmd/neofs-cli/internal/common/netmap.go
+++ b/cmd/neofs-cli/internal/common/netmap.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"encoding/hex"
+
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+	"github.com/spf13/cobra"
+)
+
+// PrettyPrintNodeInfo print information about network node with given indent and index.
+// To avoid printing attribute list use short parameter.
+func PrettyPrintNodeInfo(cmd *cobra.Command, node netmap.NodeInfo,
+	index int, indent string, short bool) {
+	var strState string
+
+	switch {
+	default:
+		strState = "STATE_UNSUPPORTED"
+	case node.IsOnline():
+		strState = "ONLINE"
+	case node.IsOffline():
+		strState = "OFFLINE"
+	case node.IsMaintenance():
+		strState = "MAINTENANCE"
+	}
+
+	cmd.Printf("%sNode %d: %s %s ", indent, index+1, hex.EncodeToString(node.PublicKey()), strState)
+
+	netmap.IterateNetworkEndpoints(node, func(endpoint string) {
+		cmd.Printf("%s ", endpoint)
+	})
+	cmd.Println()
+
+	if !short {
+		node.IterateAttributes(func(key, value string) {
+			cmd.Printf("%s\t%s: %s\n", indent, key, value)
+		})
+	}
+}
+
+// PrettyPrintNetMap print information about network map
+func PrettyPrintNetMap(cmd *cobra.Command, nm netmap.NetMap) {
+	cmd.Println("Epoch:", nm.Epoch())
+
+	nodes := nm.Nodes()
+	for i := range nodes {
+		PrettyPrintNodeInfo(cmd, nodes[i], i, "", false)
+	}
+}

--- a/cmd/neofs-cli/modules/container/delete.go
+++ b/cmd/neofs-cli/modules/container/delete.go
@@ -96,7 +96,7 @@ func initContainerDeleteCmd() {
 	flags.StringP(commonflags.Account, commonflags.AccountShorthand, commonflags.AccountDefault, commonflags.AccountUsage)
 	flags.StringP(commonflags.RPC, commonflags.RPCShorthand, commonflags.RPCDefault, commonflags.RPCUsage)
 
-	flags.StringVar(&containerID, "cid", "", "container ID")
+	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
 	flags.BoolVar(&containerAwait, "await", false, "block execution until container is removed")
 	flags.BoolP(commonflags.ForceFlag, commonflags.ForceFlagShorthand, false, "do not check whether container contains locks and remove immediately")
 }

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -57,7 +57,7 @@ func initContainerGetEACLCmd() {
 
 	flags := getExtendedACLCmd.Flags()
 
-	flags.StringVar(&containerID, "cid", "", "container ID")
+	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
 	flags.StringVar(&containerPathTo, "to", "", "path to dump encoded container (default: binary encoded)")
 	flags.BoolVar(&containerJSON, commonflags.JSON, false, "encode EACL table in json format")
 }

--- a/cmd/neofs-cli/modules/container/list_objects.go
+++ b/cmd/neofs-cli/modules/container/list_objects.go
@@ -89,7 +89,7 @@ func initContainerListObjectsCmd() {
 
 	flags := listContainerObjectsCmd.Flags()
 
-	flags.StringVar(&containerID, "cid", "", "container ID")
+	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
 	flags.BoolVar(&flagVarListObjectsPrintAttr, flagListObjectPrintAttr, false,
 		"request and print user attributes of each object",
 	)

--- a/cmd/neofs-cli/modules/container/nodes.go
+++ b/cmd/neofs-cli/modules/container/nodes.go
@@ -1,0 +1,62 @@
+package container
+
+import (
+	"crypto/sha256"
+
+	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/key"
+	containerAPI "github.com/nspcc-dev/neofs-sdk-go/container"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+	"github.com/spf13/cobra"
+)
+
+var short bool
+
+var containerNodesCmd = &cobra.Command{
+	Use:   "nodes",
+	Short: "Show nodes for container",
+	Long:  "Show nodes taking part in a container at the current epoch.",
+	Run: func(cmd *cobra.Command, args []string) {
+		var cnr, pkey = getContainer(cmd)
+
+		if pkey == nil {
+			pkey = key.GetOrGenerate(cmd)
+		}
+
+		cli := internalclient.GetSDKClientByFlag(cmd, pkey, commonflags.RPC)
+
+		var prm internalclient.NetMapSnapshotPrm
+		prm.SetClient(cli)
+
+		resmap, err := internalclient.NetMapSnapshot(prm)
+		common.ExitOnErr(cmd, "unable to get netmap snapshot", err)
+
+		var id cid.ID
+		containerAPI.CalculateID(&id, cnr)
+		binCnr := make([]byte, sha256.Size)
+		id.Encode(binCnr)
+
+		var cnrNodes [][]netmap.NodeInfo
+		cnrNodes, err = resmap.NetMap().ContainerNodes(cnr.PlacementPolicy(), binCnr)
+		common.ExitOnErr(cmd, "could not build container nodes for given container: %w", err)
+
+		for i := range cnrNodes {
+			cmd.Printf("Rep %d\n", i+1)
+			for j := range cnrNodes[i] {
+				common.PrettyPrintNodeInfo(cmd, cnrNodes[i][j], j, "\t", short)
+			}
+		}
+	},
+}
+
+func initContainerNodesCmd() {
+	commonflags.Init(containerNodesCmd)
+
+	flags := containerNodesCmd.Flags()
+	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerPathFrom, fromFlag, "", fromFlagUsage)
+	flags.BoolVar(&short, "short", false, "Shortens output of node info")
+}

--- a/cmd/neofs-cli/modules/container/root.go
+++ b/cmd/neofs-cli/modules/container/root.go
@@ -27,6 +27,7 @@ func init() {
 		getContainerInfoCmd,
 		getExtendedACLCmd,
 		setExtendedACLCmd,
+		containerNodesCmd,
 	}
 
 	Cmd.AddCommand(containerChildCommand...)
@@ -38,6 +39,7 @@ func init() {
 	initContainerInfoCmd()
 	initContainerGetEACLCmd()
 	initContainerSetEACLCmd()
+	initContainerNodesCmd()
 
 	for _, containerCommand := range containerChildCommand {
 		commonflags.InitAPI(containerCommand)

--- a/cmd/neofs-cli/modules/container/set_eacl.go
+++ b/cmd/neofs-cli/modules/container/set_eacl.go
@@ -103,7 +103,7 @@ func initContainerSetEACLCmd() {
 	commonflags.Init(setExtendedACLCmd)
 
 	flags := setExtendedACLCmd.Flags()
-	flags.StringVar(&containerID, "cid", "", "container ID")
+	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
 	flags.StringVar(&flagVarsSetEACL.srcPath, "table", "", "path to file with JSON or binary encoded EACL table")
 	flags.BoolVar(&containerAwait, "await", false, "block execution until EACL is persisted")
 	flags.BoolVar(&flagVarsSetEACL.noPreCheck, "no-precheck", false, "do not pre-check the extensibility of the container ACL")

--- a/cmd/neofs-cli/modules/netmap/snapshot.go
+++ b/cmd/neofs-cli/modules/netmap/snapshot.go
@@ -1,13 +1,10 @@
 package netmap
 
 import (
-	"encoding/hex"
-
 	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/key"
-	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/spf13/cobra"
 )
 
@@ -25,43 +22,11 @@ var snapshotCmd = &cobra.Command{
 		res, err := internalclient.NetMapSnapshot(prm)
 		common.ExitOnErr(cmd, "rpc error: %w", err)
 
-		prettyPrintNetMap(cmd, res.NetMap())
+		common.PrettyPrintNetMap(cmd, res.NetMap())
 	},
 }
 
 func initSnapshotCmd() {
 	commonflags.Init(snapshotCmd)
 	commonflags.InitAPI(snapshotCmd)
-}
-
-func prettyPrintNetMap(cmd *cobra.Command, nm netmap.NetMap) {
-	cmd.Println("Epoch:", nm.Epoch())
-
-	nodes := nm.Nodes()
-	for i := range nodes {
-		var strState string
-
-		switch {
-		default:
-			strState = "STATE_UNSUPPORTED"
-		case nodes[i].IsOnline():
-			strState = "ONLINE"
-		case nodes[i].IsOffline():
-			strState = "OFFLINE"
-		case nodes[i].IsMaintenance():
-			strState = "MAINTENANCE"
-		}
-
-		cmd.Printf("Node %d: %s %s ", i+1, hex.EncodeToString(nodes[i].PublicKey()), strState)
-
-		netmap.IterateNetworkEndpoints(nodes[i], func(endpoint string) {
-			cmd.Printf("%s ", endpoint)
-		})
-
-		cmd.Println()
-
-		nodes[i].IterateAttributes(func(key, value string) {
-			cmd.Printf("\t%s: %s\n", key, value)
-		})
-	}
 }


### PR DESCRIPTION

Closes #1704
Example of `short` output:
```
@:~/workspace/neofs-node$ neofs-cli container nodes --from ~/cnt --wallet ~/workspace/neofs-dev-env/wallets/wallet.json --rpc-endpoint 192.168.130.71:8080 --short
Enter password > 
Rep 1
	Node 1: 022bb4041c50d607ff871dec7e4cd7778388e0ea6849d84ccbd9aa8f32e16a8131 ONLINE /dns4/s01.neofs.devenv/tcp/8080 
	Node 2: 038c862959e56b43e20f79187c4fe9e0bc7c8c66c1603e6cf0ec7f87ab6b08dc35 ONLINE /dns4/s04.neofs.devenv/tcp/8082/tls /dns4/s04.neofs.devenv/tcp/8080 
Rep 2
	Node 1: 022bb4041c50d607ff871dec7e4cd7778388e0ea6849d84ccbd9aa8f32e16a8131 ONLINE /dns4/s01.neofs.devenv/tcp/8080 
	Node 2: 038c862959e56b43e20f79187c4fe9e0bc7c8c66c1603e6cf0ec7f87ab6b08dc35 ONLINE /dns4/s04.neofs.devenv/tcp/8082/tls /dns4/s04.neofs.devenv/tcp/8080 
```
Example of normal output:
```
@:~/workspace/neofs-node$ neofs-cli container nodes --from ~/cnt --wallet ~/workspace/neofs-dev-env/wallets/wallet.json --rpc-endpoint 192.168.130.71:8080
Enter password > 
Rep 1
	Node 1: 022bb4041c50d607ff871dec7e4cd7778388e0ea6849d84ccbd9aa8f32e16a8131 ONLINE /dns4/s01.neofs.devenv/tcp/8080 
		Continent: Europe
		Country: Russia
		CountryCode: RU
		Location: Moskva
		Price: 22
		SubDiv: Moskva
		SubDivCode: MOW
		UN-LOCODE: RU MOW
		User-Agent: NeoFS\/0.26
	Node 2: 038c862959e56b43e20f79187c4fe9e0bc7c8c66c1603e6cf0ec7f87ab6b08dc35 ONLINE /dns4/s04.neofs.devenv/tcp/8082/tls /dns4/s04.neofs.devenv/tcp/8080 
		Continent: Europe
		...
Rep 2
	Node 1: 022bb4041c50d607ff871dec7e4cd7778388e0ea6849d84ccbd9aa8f32e16a8131 ONLINE /dns4/s01.neofs.devenv/tcp/8080 
		Continent: Europe
		...

``` 