### PR TITLE
morph/client: use 0 as OfflineState in update peer

### DIFF
--- a/pkg/morph/client/netmap/update_state.go
+++ b/pkg/morph/client/netmap/update_state.go
@@ -46,6 +46,10 @@ func (c *Client) UpdatePeerState(p UpdatePeerPrm) error {
 		method += "IR"
 	}
 
+	if p.state == 0 {
+		p.state = netmap.NodeStateOffline
+	}
+
 	prm := client.InvokePrm{}
 	prm.SetMethod(method)
 	prm.SetArgs(int64(p.state), p.key)


### PR DESCRIPTION
Close #1844 

As the documentation prescribes.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>