### PR TITLE
[#1846] neofs-node: Make morph.cache_ttl equal to block time by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for NeoFS Node
 ### Changed
 - Allow to evacuate shard data with `EvacuateShard` control RPC (#1800)
 - Flush write-cache when moving shard to DEGRADED mode (#1825)
+- Make `morph.cache_ttl` default value equal to morph block time (#1846)
 
 ### Fixed
 - Description of command `netmap nodeinfo` (#1821)

--- a/cmd/neofs-node/config/morph/config.go
+++ b/cmd/neofs-node/config/morph/config.go
@@ -28,7 +28,9 @@ const (
 	// PriorityDefault is a default endpoint priority for the morph client.
 	PriorityDefault = 1
 
-	CacheTTLDefault = 30 * time.Second
+	// CacheTTLDefault is a default value for cached values TTL.
+	// It is 0, because actual default depends on block time.
+	CacheTTLDefault = time.Duration(0)
 )
 
 // RPCEndpoint returns list of the values of "rpc_endpoint" config parameter

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
@@ -89,7 +90,14 @@ func initMorphComponents(c *cfg) {
 
 	c.cfgMorph.cacheTTL = morphconfig.CacheTTL(c.appCfg)
 
-	if c.cfgMorph.cacheTTL <= 0 {
+	if c.cfgMorph.cacheTTL == 0 {
+		msPerBlock, err := c.cfgMorph.client.MsPerBlock()
+		fatalOnErr(err)
+		c.cfgMorph.cacheTTL = time.Duration(msPerBlock) * time.Millisecond
+		c.log.Debug("morph.cache_ttl fetched from network", zap.Duration("value", c.cfgMorph.cacheTTL))
+	}
+
+	if c.cfgMorph.cacheTTL < 0 {
 		netmapSource = wrap
 	} else {
 		// use RPC node as source of netmap (with caching)

--- a/config/example/node.yaml
+++ b/config/example/node.yaml
@@ -82,6 +82,7 @@ contracts:  # side chain NEOFS contract script hashes; optional, override values
 morph:
   dial_timeout: 30s  # timeout for side chain NEO RPC client connection
   cache_ttl: 15s  # Sidechain cache TTL value (min interval between similar calls). Negative value disables caching.
+               # Default value: block time. It is recommended to have this value less or equal to block time.
                # Cached entities: containers, container lists, eACL tables.
   rpc_endpoint:  # side chain NEO RPC endpoints; are shuffled and used one by one until the first success
     - address: wss://rpc1.morph.fs.neo.org:40341/ws

--- a/docs/storage-node-configuration.md
+++ b/docs/storage-node-configuration.md
@@ -139,11 +139,11 @@ morph:
       priority: 2
  ```
 
-| Parameter      | Type                                                      | Default value | Description                                                                                                                                                         |
-|----------------|-----------------------------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `dial_timeout` | `duration`                                                | `5s`          | Timeout for dialing connections to N3 RPCs.                                                                                                                         |
-| `cache_ttl`    | `duration`                                                | `30s`         | Sidechain cache TTL value (min interval between similar calls).<br/>Negative value disables caching.<br/>Cached entities: containers, container lists, eACL tables. |
-| `rpc_endpoint` | list of [endpoint descriptions](#rpc_endpoint-subsection) |               | Array of endpoint descriptions.                                                                                                                                     |
+| Parameter      | Type                                                      | Default value    | Description                                                                                                                                                         |
+|----------------|-----------------------------------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `dial_timeout` | `duration`                                                | `5s`             | Timeout for dialing connections to N3 RPCs.                                                                                                                         |
+| `cache_ttl`    | `duration`                                                | Morph block time | Sidechain cache TTL value (min interval between similar calls).<br/>Negative value disables caching.<br/>Cached entities: containers, container lists, eACL tables. |
+| `rpc_endpoint` | list of [endpoint descriptions](#rpc_endpoint-subsection) |                  | Array of endpoint descriptions.                                                                                                                                     |
 
 ## `rpc_endpoint` subsection
 | Parameter  | Type     | Default value | Description                                                                                                                                                                                                              |


### PR DESCRIPTION
Close #1846 

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>