### PR TITLE
Fix/Keep local node info in sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog for NeoFS Node
 - Correlation of object session to request (#1420)
 - Do not increase error counter in `engine.Inhume` if shard is read-only (#1839)
 - `control drop-objects` can remove split objects (#1830)
+- Node's status in `neofs-cli netmap nodeinfo` command (#1833)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -65,6 +65,17 @@ func (s *networkState) setNodeInfo(ni *netmapSDK.NodeInfo) {
 		}
 	} else {
 		ctrlNetSt = control.NetmapStatus_OFFLINE
+
+		niRaw := s.nodeInfo.Load()
+		if niRaw != nil {
+			niOld := niRaw.(netmapSDK.NodeInfo)
+
+			// nil ni means that the node is not included
+			// in the netmap
+			niOld.SetOffline()
+
+			s.nodeInfo.Store(niOld)
+		}
 	}
 
 	s.controlNetStatus.Store(ctrlNetSt)


### PR DESCRIPTION
If the contract returns a netmap that does not contain the node, update local `NodeInfo`. It fixes `neofs-cli netmap nodeinfo` command that printed "state: online" previously.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1833.