### PR TITLE
Fix/Shard id in the object counter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changelog for NeoFS Node
 - `control drop-objects` can remove split objects (#1830)
 - Node's status in `neofs-cli netmap nodeinfo` command (#1833)
 - Child check in object assembly process of `ObjectService.Get` handler (#1878)
+- Shard ID in the object counter metrics (#1863)
 
 ### Removed
 - Remove WIF and NEP2 support in `neofs-cli`'s --wallet flag (#1128)

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -23,19 +23,25 @@ type metricsWithID struct {
 	mw MetricRegister
 }
 
-func (m metricsWithID) SetObjectCounter(objectType string, v uint64) {
+func (m *metricsWithID) SetShardID(id string) {
+	// concurrent settings are not expected =>
+	// no mutex protection
+	m.id = id
+}
+
+func (m *metricsWithID) SetObjectCounter(objectType string, v uint64) {
 	m.mw.SetObjectCounter(m.id, objectType, v)
 }
 
-func (m metricsWithID) AddToObjectCounter(objectType string, delta int) {
+func (m *metricsWithID) AddToObjectCounter(objectType string, delta int) {
 	m.mw.AddToObjectCounter(m.id, objectType, delta)
 }
 
-func (m metricsWithID) IncObjectCounter(objectType string) {
+func (m *metricsWithID) IncObjectCounter(objectType string) {
 	m.mw.AddToObjectCounter(m.id, objectType, +1)
 }
 
-func (m metricsWithID) DecObjectCounter(objectType string) {
+func (m *metricsWithID) DecObjectCounter(objectType string) {
 	m.mw.AddToObjectCounter(m.id, objectType, -1)
 }
 
@@ -67,7 +73,7 @@ func (e *StorageEngine) createShard(opts []shard.Option) (*shard.Shard, error) {
 
 	if e.metrics != nil {
 		opts = append(opts, shard.WithMetricsWriter(
-			metricsWithID{
+			&metricsWithID{
 				id: id.String(),
 				mw: e.metrics,
 			},

--- a/pkg/local_object_storage/shard/id.go
+++ b/pkg/local_object_storage/shard/id.go
@@ -43,6 +43,10 @@ func (s *Shard) UpdateID() (err error) {
 	}
 	if len(id) != 0 {
 		s.info.ID = NewIDFromBytes(id)
+
+		if s.cfg.metricsWriter != nil {
+			s.cfg.metricsWriter.SetShardID(s.info.ID.String())
+		}
 	}
 
 	s.log = &logger.Logger{Logger: s.log.With(zap.String("shard_id", s.info.ID.String()))}

--- a/pkg/local_object_storage/shard/metrics_test.go
+++ b/pkg/local_object_storage/shard/metrics_test.go
@@ -19,6 +19,8 @@ type metricsStore struct {
 	s map[string]uint64
 }
 
+func (m metricsStore) SetShardID(_ string) {}
+
 func (m metricsStore) SetObjectCounter(objectType string, v uint64) {
 	m.s[objectType] = v
 }

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -59,6 +59,9 @@ type MetricsWriter interface {
 	// DecObjectCounter must decrement shard's object counter taking into account
 	// object type.
 	DecObjectCounter(objectType string)
+	// SetShardID must set (update) the shard identifier that will be used in
+	// metrics.
+	SetShardID(id string)
 }
 
 type cfg struct {


### PR DESCRIPTION
If shard ID is stored in metabase (it is not the first time boot), read it, set it, use it (not a generated one) in the metrics writer.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Close #1863.