### PR TITLE
Minor fixes for maintenance mode in `neofs-cli` and `neofs-adm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for NeoFS Node
 - Add new RPC `TreeService.Healthcheck`
 - Fallback to `GET` if `GET_RANGE` from one storage nodes to another is denied by basic ACL (#1884)
 - List of shards and logger level runtime reconfiguration (#1770)
+- `neofs-adm morph set-config` now supports well-known `MaintenanceModeAllowed` key (#1892)
 
 ### Changed
 - Allow to evacuate shard data with `EvacuateShard` control RPC (#1800)
@@ -63,6 +64,9 @@ If network allows maintenance state (*), it will be reflected in the network map
 Storage nodes under maintenance are not excluded from the network map, but don't
 serve object operations. (*) can be fetched from network configuration via
 `neofs-cli netmap netinfo` command.    
+
+To allow maintenance mode during neofs-adm deployments, set
+`network.maintenance_mode_allowed` parameter in config.
 
 When issuing an object session token for root (virtual, "big") objects,
 additionally include all members of the split-chain. If session context

--- a/cmd/neofs-adm/internal/modules/morph/config.go
+++ b/cmd/neofs-adm/internal/modules/morph/config.go
@@ -76,7 +76,7 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%d (int)\n", k, n)))
 		case netmapEigenTrustAlphaKey:
 			_, _ = tw.Write([]byte(fmt.Sprintf("%s:\t%s (str)\n", k, v)))
-		case netmapHomomorphicHashDisabledKey:
+		case netmapHomomorphicHashDisabledKey, netmapMaintenanceAllowedKey:
 			vBool, err := tuple[1].TryBool()
 			if err != nil {
 				return invalidConfigValueErr(k)
@@ -168,7 +168,7 @@ func parseConfigPair(kvStr string, force bool) (key string, val interface{}, err
 		}
 
 		val = valRaw
-	case netmapHomomorphicHashDisabledKey:
+	case netmapHomomorphicHashDisabledKey, netmapMaintenanceAllowedKey:
 		val, err = strconv.ParseBool(valRaw)
 		if err != nil {
 			err = fmt.Errorf("could not parse %s's value '%s' as bool: %w", key, valRaw, err)

--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -60,6 +60,7 @@ const (
 	netmapInnerRingCandidateFeeKey   = "InnerRingCandidateFee"
 	netmapWithdrawFeeKey             = "WithdrawFee"
 	netmapHomomorphicHashDisabledKey = "HomomorphicHashingDisabled"
+	netmapMaintenanceAllowedKey      = "MaintenanceModeAllowed"
 
 	defaultEigenTrustIterations = 4
 	defaultEigenTrustAlpha      = "0.1"
@@ -550,6 +551,7 @@ func (c *initializeContext) getContractDeployData(ctrName string, keysParam []in
 			netmapInnerRingCandidateFeeKey, viper.GetInt64(candidateFeeInitFlag),
 			netmapWithdrawFeeKey, viper.GetInt64(withdrawFeeInitFlag),
 			netmapHomomorphicHashDisabledKey, viper.GetBool(homomorphicHashDisabledInitFlag),
+			netmapMaintenanceAllowedKey, viper.GetBool(maintenanceModeAllowedInitFlag),
 		}
 		items = append(items,
 			c.Contracts[balanceContract].Hash,

--- a/cmd/neofs-adm/internal/modules/morph/root.go
+++ b/cmd/neofs-adm/internal/modules/morph/root.go
@@ -29,6 +29,7 @@ const (
 	candidateFeeInitFlag            = "network.fee.candidate"
 	candidateFeeCLIFlag             = "candidate-fee"
 	homomorphicHashDisabledInitFlag = "network.homomorphic_hash_disabled"
+	maintenanceModeAllowedInitFlag  = "network.maintenance_mode_allowed"
 	homomorphicHashDisabledCLIFlag  = "homomorphic-disabled"
 	withdrawFeeInitFlag             = "network.fee.withdraw"
 	withdrawFeeCLIFlag              = "withdraw-fee"

--- a/cmd/neofs-cli/modules/netmap/nodeinfo.go
+++ b/cmd/neofs-cli/modules/netmap/nodeinfo.go
@@ -54,6 +54,8 @@ func prettyPrintNodeInfo(cmd *cobra.Command, i netmap.NodeInfo) {
 		stateWord = "online"
 	case i.IsOffline():
 		stateWord = "offline"
+	case i.IsMaintenance():
+		stateWord = "maintenance"
 	}
 
 	cmd.Println("state:", stateWord)


### PR DESCRIPTION
1. Print proper status in `neofs-cli netmap nodeinfo`
2. Allow to set config in neofs-adm without --force flag.