### PR TITLE
Add support to store/restore/delete binary objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog for NeoFS Node
 
 ### Added
 - `morph list-containers` in `neofs-adm` (#1689)
+- `--binary` flag in `neofs-cli object put/get/delete` commands (#1338)
 
 ### Changed
 - `object lock` command reads CID and OID the same way other commands do (#1971)

--- a/cmd/neofs-cli/internal/commonflags/flags.go
+++ b/cmd/neofs-cli/internal/commonflags/flags.go
@@ -41,6 +41,12 @@ const (
 
 	ForceFlag          = "force"
 	ForceFlagShorthand = "f"
+
+	CIDFlag      = "cid"
+	CIDFlagUsage = "Container ID."
+
+	OIDFlag      = "oid"
+	OIDFlagUsage = "Object ID."
 )
 
 // Init adds common flags to the command:

--- a/cmd/neofs-cli/modules/acl/extended/create.go
+++ b/cmd/neofs-cli/modules/acl/extended/create.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/flynn-archive/go-shlex"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/spf13/cobra"
@@ -53,7 +54,7 @@ func init() {
 	createCmd.Flags().StringArrayP("rule", "r", nil, "Extended ACL table record to apply")
 	createCmd.Flags().StringP("file", "f", "", "Read list of extended ACL table records from from text file")
 	createCmd.Flags().StringP("out", "o", "", "Save JSON formatted extended ACL table in file")
-	createCmd.Flags().StringP("cid", "", "", "Container ID")
+	createCmd.Flags().StringP(commonflags.CIDFlag, "", "", commonflags.CIDFlagUsage)
 
 	_ = cobra.MarkFlagFilename(createCmd.Flags(), "file")
 	_ = cobra.MarkFlagFilename(createCmd.Flags(), "out")
@@ -63,7 +64,7 @@ func createEACL(cmd *cobra.Command, _ []string) {
 	rules, _ := cmd.Flags().GetStringArray("rule")
 	fileArg, _ := cmd.Flags().GetString("file")
 	outArg, _ := cmd.Flags().GetString("out")
-	cidArg, _ := cmd.Flags().GetString("cid")
+	cidArg, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 
 	var containerID cid.ID
 	if cidArg != "" {

--- a/cmd/neofs-cli/modules/container/delete.go
+++ b/cmd/neofs-cli/modules/container/delete.go
@@ -89,7 +89,7 @@ func initContainerDeleteCmd() {
 	flags.StringP(commonflags.Account, commonflags.AccountShorthand, commonflags.AccountDefault, commonflags.AccountUsage)
 	flags.StringP(commonflags.RPC, commonflags.RPCShorthand, commonflags.RPCDefault, commonflags.RPCUsage)
 
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.BoolVar(&containerAwait, "await", false, "Block execution until container is removed")
 	flags.BoolP(commonflags.ForceFlag, commonflags.ForceFlagShorthand, false, "Do not check whether container contains locks and remove immediately")
 }

--- a/cmd/neofs-cli/modules/container/get.go
+++ b/cmd/neofs-cli/modules/container/get.go
@@ -17,9 +17,6 @@ import (
 )
 
 const (
-	cidFlag      = "cid"
-	cidFlagUsage = "Container ID"
-
 	fromFlag      = "from"
 	fromFlagUsage = "Path to file with encoded container"
 )
@@ -64,7 +61,7 @@ func initContainerInfoCmd() {
 
 	flags := getContainerInfoCmd.Flags()
 
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.StringVar(&containerPathTo, "to", "", "Path to dump encoded container")
 	flags.StringVar(&containerPathFrom, fromFlag, "", fromFlagUsage)
 	flags.BoolVar(&containerJSON, commonflags.JSON, false, "Print or dump container in JSON format")

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -57,7 +57,7 @@ func initContainerGetEACLCmd() {
 
 	flags := getExtendedACLCmd.Flags()
 
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.StringVar(&containerPathTo, "to", "", "Path to dump encoded container (default: binary encoded)")
 	flags.BoolVar(&containerJSON, commonflags.JSON, false, "Encode EACL table in json format")
 }

--- a/cmd/neofs-cli/modules/container/list_objects.go
+++ b/cmd/neofs-cli/modules/container/list_objects.go
@@ -89,7 +89,7 @@ func initContainerListObjectsCmd() {
 
 	flags := listContainerObjectsCmd.Flags()
 
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.BoolVar(&flagVarListObjectsPrintAttr, flagListObjectPrintAttr, false,
 		"Request and print user attributes of each object",
 	)

--- a/cmd/neofs-cli/modules/container/nodes.go
+++ b/cmd/neofs-cli/modules/container/nodes.go
@@ -58,7 +58,7 @@ func initContainerNodesCmd() {
 	commonflags.Init(containerNodesCmd)
 
 	flags := containerNodesCmd.Flags()
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.StringVar(&containerPathFrom, fromFlag, "", fromFlagUsage)
 	flags.BoolVar(&short, "short", false, "Shortens output of node info")
 }

--- a/cmd/neofs-cli/modules/container/set_eacl.go
+++ b/cmd/neofs-cli/modules/container/set_eacl.go
@@ -96,7 +96,7 @@ func initContainerSetEACLCmd() {
 	commonflags.Init(setExtendedACLCmd)
 
 	flags := setExtendedACLCmd.Flags()
-	flags.StringVar(&containerID, cidFlag, "", cidFlagUsage)
+	flags.StringVar(&containerID, commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.StringVar(&flagVarsSetEACL.srcPath, "table", "", "path to file with JSON or binary encoded EACL table")
 	flags.BoolVar(&containerAwait, "await", false, "block execution until EACL is persisted")
 	flags.BoolVar(&flagVarsSetEACL.noPreCheck, "no-precheck", false, "do not pre-check the extensibility of the container ACL")

--- a/cmd/neofs-cli/modules/control/synchronize_tree.go
+++ b/cmd/neofs-cli/modules/control/synchronize_tree.go
@@ -6,6 +6,7 @@ import (
 
 	rawclient "github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/key"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	controlSvc "github.com/nspcc-dev/neofs-node/pkg/services/control/server"
@@ -29,7 +30,7 @@ func initControlSynchronizeTreeCmd() {
 	initControlFlags(synchronizeTreeCmd)
 
 	flags := synchronizeTreeCmd.Flags()
-	flags.String("cid", "", "Container ID")
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 	flags.String(synchronizeTreeIDFlag, "", "Tree ID")
 	flags.Uint64(synchronizeTreeHeightFlag, 0, "Starting height")
 }
@@ -38,7 +39,7 @@ func synchronizeTree(cmd *cobra.Command, _ []string) {
 	pk := key.Get(cmd)
 
 	var cnr cid.ID
-	cidStr, _ := cmd.Flags().GetString("cid")
+	cidStr, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 	common.ExitOnErr(cmd, "can't decode container ID: %w", cnr.DecodeString(cidStr))
 
 	treeID, _ := cmd.Flags().GetString("tree-id")

--- a/cmd/neofs-cli/modules/object/hash.go
+++ b/cmd/neofs-cli/modules/object/hash.go
@@ -35,11 +35,11 @@ func initObjectHashCmd() {
 
 	flags := objectHashCmd.Flags()
 
-	flags.String("cid", "", "Container ID")
-	_ = objectHashCmd.MarkFlagRequired("cid")
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = objectHashCmd.MarkFlagRequired(commonflags.CIDFlag)
 
-	flags.String("oid", "", "Object ID")
-	_ = objectHashCmd.MarkFlagRequired("oid")
+	flags.String(commonflags.OIDFlag, "", commonflags.OIDFlagUsage)
+	_ = objectHashCmd.MarkFlagRequired(commonflags.OIDFlag)
 
 	flags.String("range", "", "Range to take hash from in the form offset1:length1,...")
 	flags.String("type", hashSha256, "Hash type. Either 'sha256' or 'tz'")

--- a/cmd/neofs-cli/modules/object/head.go
+++ b/cmd/neofs-cli/modules/object/head.go
@@ -31,13 +31,13 @@ func initObjectHeadCmd() {
 
 	flags := objectHeadCmd.Flags()
 
-	flags.String("cid", "", "Container ID")
-	_ = objectHeadCmd.MarkFlagRequired("cid")
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = objectHeadCmd.MarkFlagRequired(commonflags.CIDFlag)
 
-	flags.String("oid", "", "Object ID")
-	_ = objectHeadCmd.MarkFlagRequired("oid")
+	flags.String(commonflags.OIDFlag, "", commonflags.OIDFlagUsage)
+	_ = objectHeadCmd.MarkFlagRequired(commonflags.OIDFlag)
 
-	flags.String("file", "", "File to write header to. Default: stdout.")
+	flags.String(fileFlag, "", "File to write header to. Default: stdout.")
 	flags.Bool("main-only", false, "Return only main fields")
 	flags.Bool(commonflags.JSON, false, "Marshal output in JSON")
 	flags.Bool("proto", false, "Marshal output in Protobuf")
@@ -73,7 +73,7 @@ func getObjectHeader(cmd *cobra.Command, _ []string) {
 		common.ExitOnErr(cmd, "rpc error: %w", err)
 	}
 
-	err = saveAndPrintHeader(cmd, res.Header(), cmd.Flag("file").Value.String())
+	err = saveAndPrintHeader(cmd, res.Header(), cmd.Flag(fileFlag).Value.String())
 	common.ExitOnErr(cmd, "", err)
 }
 

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -25,13 +25,13 @@ var objectLockCmd = &cobra.Command{
 	Short: "Lock object in container",
 	Long:  "Lock object in container",
 	Run: func(cmd *cobra.Command, _ []string) {
-		cidRaw, _ := cmd.Flags().GetString("cid")
+		cidRaw, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 
 		var cnr cid.ID
 		err := cnr.DecodeString(cidRaw)
 		common.ExitOnErr(cmd, "Incorrect container arg: %v", err)
 
-		oidsRaw, _ := cmd.Flags().GetStringSlice("oid")
+		oidsRaw, _ := cmd.Flags().GetStringSlice(commonflags.OIDFlag)
 
 		lockList := make([]oid.ID, len(oidsRaw))
 
@@ -96,11 +96,11 @@ func initCommandObjectLock() {
 
 	ff := objectLockCmd.Flags()
 
-	ff.String("cid", "", "Container ID")
-	_ = objectLockCmd.MarkFlagRequired("cid")
+	ff.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = objectLockCmd.MarkFlagRequired(commonflags.CIDFlag)
 
-	ff.StringSlice("oid", nil, "Object ID")
-	_ = objectLockCmd.MarkFlagRequired("oid")
+	ff.StringSlice(commonflags.OIDFlag, nil, commonflags.OIDFlagUsage)
+	_ = objectLockCmd.MarkFlagRequired(commonflags.OIDFlag)
 
 	ff.Uint64P(commonflags.ExpireAt, "e", 0, "Lock expiration epoch")
 

--- a/cmd/neofs-cli/modules/object/range.go
+++ b/cmd/neofs-cli/modules/object/range.go
@@ -32,14 +32,14 @@ func initObjectRangeCmd() {
 
 	flags := objectRangeCmd.Flags()
 
-	flags.String("cid", "", "Container ID")
-	_ = objectRangeCmd.MarkFlagRequired("cid")
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = objectRangeCmd.MarkFlagRequired(commonflags.CIDFlag)
 
-	flags.String("oid", "", "Object ID")
-	_ = objectRangeCmd.MarkFlagRequired("oid")
+	flags.String(commonflags.OIDFlag, "", commonflags.OIDFlagUsage)
+	_ = objectRangeCmd.MarkFlagRequired(commonflags.OIDFlag)
 
 	flags.String("range", "", "Range to take data from in the form offset:length")
-	flags.String("file", "", "File to write object payload to. Default: stdout.")
+	flags.String(fileFlag, "", "File to write object payload to. Default: stdout.")
 	flags.Bool(rawFlag, false, rawFlagDesc)
 }
 
@@ -58,7 +58,7 @@ func getObjectRange(cmd *cobra.Command, _ []string) {
 
 	var out io.Writer
 
-	filename := cmd.Flag("file").Value.String()
+	filename := cmd.Flag(fileFlag).Value.String()
 	if filename == "" {
 		out = os.Stdout
 	} else {

--- a/cmd/neofs-cli/modules/object/search.go
+++ b/cmd/neofs-cli/modules/object/search.go
@@ -15,8 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const searchOIDFlag = "oid"
-
 var (
 	searchFilters []string
 
@@ -34,15 +32,15 @@ func initObjectSearchCmd() {
 
 	flags := objectSearchCmd.Flags()
 
-	flags.String("cid", "", "Container ID")
-	_ = objectSearchCmd.MarkFlagRequired("cid")
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = objectSearchCmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	flags.StringSliceVarP(&searchFilters, "filters", "f", nil,
 		"Repeated filter expressions or files with protobuf JSON")
 
 	flags.Bool("root", false, "Search for user objects")
 	flags.Bool("phy", false, "Search physically stored objects")
-	flags.String(searchOIDFlag, "", "Search object by identifier")
+	flags.String(commonflags.OIDFlag, "", "Search object by identifier")
 }
 
 func searchObject(cmd *cobra.Command, _ []string) {
@@ -133,7 +131,7 @@ func parseSearchFilters(cmd *cobra.Command) (object.SearchFilters, error) {
 		fs.AddPhyFilter()
 	}
 
-	oid, _ := cmd.Flags().GetString(searchOIDFlag)
+	oid, _ := cmd.Flags().GetString(commonflags.OIDFlag)
 	if oid != "" {
 		var id oidSDK.ID
 		if err := id.DecodeString(oid); err != nil {

--- a/cmd/neofs-cli/modules/storagegroup/delete.go
+++ b/cmd/neofs-cli/modules/storagegroup/delete.go
@@ -23,8 +23,8 @@ func initSGDeleteCmd() {
 
 	flags := sgDelCmd.Flags()
 
-	flags.String(cidFlag, "", "Container ID")
-	_ = sgDelCmd.MarkFlagRequired(cidFlag)
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = sgDelCmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	flags.StringVarP(&sgID, sgIDFlag, "", "", "Storage group identifier")
 	_ = sgDelCmd.MarkFlagRequired(sgIDFlag)

--- a/cmd/neofs-cli/modules/storagegroup/get.go
+++ b/cmd/neofs-cli/modules/storagegroup/get.go
@@ -28,8 +28,8 @@ func initSGGetCmd() {
 
 	flags := sgGetCmd.Flags()
 
-	flags.String(cidFlag, "", "Container ID")
-	_ = sgGetCmd.MarkFlagRequired(cidFlag)
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = sgGetCmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	flags.StringVarP(&sgID, sgIDFlag, "", "", "Storage group identifier")
 	_ = sgGetCmd.MarkFlagRequired(sgIDFlag)

--- a/cmd/neofs-cli/modules/storagegroup/list.go
+++ b/cmd/neofs-cli/modules/storagegroup/list.go
@@ -21,8 +21,8 @@ var sgListCmd = &cobra.Command{
 func initSGListCmd() {
 	commonflags.Init(sgListCmd)
 
-	sgListCmd.Flags().String(cidFlag, "", "Container ID")
-	_ = sgListCmd.MarkFlagRequired(cidFlag)
+	sgListCmd.Flags().String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = sgListCmd.MarkFlagRequired(commonflags.CIDFlag)
 }
 
 func listSG(cmd *cobra.Command, _ []string) {

--- a/cmd/neofs-cli/modules/storagegroup/put.go
+++ b/cmd/neofs-cli/modules/storagegroup/put.go
@@ -36,8 +36,8 @@ func initSGPutCmd() {
 
 	flags := sgPutCmd.Flags()
 
-	flags.String(cidFlag, "", "Container ID")
-	_ = sgPutCmd.MarkFlagRequired(cidFlag)
+	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = sgPutCmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	flags.StringSliceVarP(&sgMembers, sgMembersFlag, "m", nil, "ID list of storage group members")
 	_ = sgPutCmd.MarkFlagRequired(sgMembersFlag)

--- a/cmd/neofs-cli/modules/storagegroup/root.go
+++ b/cmd/neofs-cli/modules/storagegroup/root.go
@@ -22,7 +22,6 @@ var Cmd = &cobra.Command{
 const (
 	sgIDFlag  = "id"
 	sgRawFlag = "raw"
-	cidFlag   = "cid"
 )
 
 func init() {

--- a/cmd/neofs-cli/modules/storagegroup/util.go
+++ b/cmd/neofs-cli/modules/storagegroup/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/spf13/cobra"
@@ -20,9 +21,9 @@ func readObjectAddress(cmd *cobra.Command, cnr *cid.ID, obj *oid.ID) oid.Address
 }
 
 func readCID(cmd *cobra.Command, id *cid.ID) {
-	f := cmd.Flag(cidFlag)
+	f := cmd.Flag(commonflags.CIDFlag)
 	if f == nil {
-		common.ExitOnErr(cmd, "", fmt.Errorf("missing container flag (%s)", cidFlag))
+		common.ExitOnErr(cmd, "", fmt.Errorf("missing container flag (%s)", commonflags.CIDFlag))
 		return
 	}
 

--- a/cmd/neofs-cli/modules/tree/add.go
+++ b/cmd/neofs-cli/modules/tree/add.go
@@ -37,7 +37,7 @@ func add(cmd *cobra.Command, _ []string) {
 	pk := key.GetOrGenerate(cmd)
 
 	var cnr cid.ID
-	err := cnr.DecodeString(cmd.Flag(containerIDFlagKey).Value.String())
+	err := cnr.DecodeString(cmd.Flag(commonflags.CIDFlag).Value.String())
 	common.ExitOnErr(cmd, "decode container ID string: %w", err)
 
 	tid, _ := cmd.Flags().GetString(treeIDFlagKey)

--- a/cmd/neofs-cli/modules/tree/add_by_path.go
+++ b/cmd/neofs-cli/modules/tree/add_by_path.go
@@ -42,7 +42,7 @@ func initAddByPathCmd() {
 func addByPath(cmd *cobra.Command, _ []string) {
 	pk := key.GetOrGenerate(cmd)
 
-	cidRaw, _ := cmd.Flags().GetString(containerIDFlagKey)
+	cidRaw, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 
 	var cnr cid.ID
 	err := cnr.DecodeString(cidRaw)

--- a/cmd/neofs-cli/modules/tree/get_by_path.go
+++ b/cmd/neofs-cli/modules/tree/get_by_path.go
@@ -42,7 +42,7 @@ func initGetByPathCmd() {
 func getByPath(cmd *cobra.Command, _ []string) {
 	pk := key.GetOrGenerate(cmd)
 
-	cidRaw, _ := cmd.Flags().GetString(containerIDFlagKey)
+	cidRaw, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 
 	var cnr cid.ID
 	err := cnr.DecodeString(cidRaw)

--- a/cmd/neofs-cli/modules/tree/list.go
+++ b/cmd/neofs-cli/modules/tree/list.go
@@ -24,15 +24,15 @@ func initListCmd() {
 	commonflags.Init(listCmd)
 
 	ff := listCmd.Flags()
-	ff.String(containerIDFlagKey, "", "Container ID")
-	_ = listCmd.MarkFlagRequired(containerIDFlagKey)
+	ff.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = listCmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	_ = cobra.MarkFlagRequired(ff, commonflags.RPC)
 }
 
 func list(cmd *cobra.Command, _ []string) {
 	pk := key.GetOrGenerate(cmd)
-	cidString, _ := cmd.Flags().GetString(containerIDFlagKey)
+	cidString, _ := cmd.Flags().GetString(commonflags.CIDFlag)
 
 	var cnr cid.ID
 	err := cnr.DecodeString(cidString)

--- a/cmd/neofs-cli/modules/tree/root.go
+++ b/cmd/neofs-cli/modules/tree/root.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
 	"github.com/spf13/cobra"
 )
 
@@ -22,9 +23,8 @@ func init() {
 }
 
 const (
-	containerIDFlagKey = "cid"
-	treeIDFlagKey      = "tid"
-	parentIDFlagKey    = "pid"
+	treeIDFlagKey   = "tid"
+	parentIDFlagKey = "pid"
 
 	metaFlagKey = "meta"
 
@@ -37,8 +37,8 @@ const (
 func initCTID(cmd *cobra.Command) {
 	ff := cmd.Flags()
 
-	ff.String(containerIDFlagKey, "", "Container ID")
-	_ = cmd.MarkFlagRequired(containerIDFlagKey)
+	ff.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	_ = cmd.MarkFlagRequired(commonflags.CIDFlag)
 
 	ff.String(treeIDFlagKey, "", "Tree ID")
 	_ = cmd.MarkFlagRequired(treeIDFlagKey)


### PR DESCRIPTION
Closes #1338

With flag `--binary` user can point to the file with serialized object structure - id + signature + header + payload
Added for development purposes.

Signed-off-by: Anton Nikiforov <an.nikiforov@yadro.com>