### PR TITLE
neofs-node: use `writecache.max_object_size` from the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog for NeoFS Node
 
 ### Changed
 ### Fixed
+- `writecache.max_object_size` is now correctly handled (#1925)
+
 ### Removed
 ### Updated
 ### Updating from v0.33.0

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -128,7 +128,6 @@ type shardCfg struct {
 		smallObjectSize  uint64
 		maxObjSize       uint64
 		flushWorkerCount int
-		maxCacheSize     uint64
 		sizeLimit        uint64
 	}
 
@@ -215,7 +214,7 @@ func (a *applicationConfiguration) readConfig(c *config.Config) error {
 			wc.path = writeCacheCfg.Path()
 			wc.maxBatchSize = writeCacheCfg.BoltDB().MaxBatchSize()
 			wc.maxBatchDelay = writeCacheCfg.BoltDB().MaxBatchDelay()
-			wc.maxCacheSize = writeCacheCfg.MaxObjectSize()
+			wc.maxObjSize = writeCacheCfg.MaxObjectSize()
 			wc.smallObjectSize = writeCacheCfg.SmallObjectSize()
 			wc.flushWorkerCount = writeCacheCfg.WorkersNumber()
 			wc.sizeLimit = writeCacheCfg.SizeLimit()


### PR DESCRIPTION
Close #1926

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>