### PR TITLE
[#1931] control: Allow to clear errors in `SetShardMode` RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 - `writecache.max_object_size` is now correctly handled (#1925)
 - Correctly handle setting ONLINE netmap status after maintenance (#1922)
+- Correctly reset shard errors in `ControlService.SetShardMode` RPC (#1931)
 
 ### Removed
 ### Updated

--- a/pkg/services/control/server/set_shard_mode.go
+++ b/pkg/services/control/server/set_shard_mode.go
@@ -37,7 +37,7 @@ func (s *Server) SetShardMode(_ context.Context, req *control.SetShardModeReques
 	}
 
 	for _, shardID := range s.getShardIDList(req.Body.GetShard_ID()) {
-		err = s.s.SetShardMode(shardID, m, false)
+		err = s.s.SetShardMode(shardID, m, req.Body.GetResetErrorCounter())
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}


### PR DESCRIPTION
Close #1931.
It hasn't been working since the initial implementation 7fb15fa1d0df0.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>