### PR TITLE
cli: Print used RPC timeout in verbose exec

### DIFF
--- a/cmd/neofs-cli/internal/client/sdk.go
+++ b/cmd/neofs-cli/internal/client/sdk.go
@@ -55,6 +55,8 @@ func GetSDKClient(key *ecdsa.PrivateKey, addr network.Address) (*client.Client, 
 		// for too long.
 		prmDial.SetTimeout(timeout)
 		prmDial.SetStreamTimeout(timeout)
+
+		common.PrintVerbose("Set request timeout to %s.", timeout)
 	}
 
 	c.Init(prmInit)


### PR DESCRIPTION
* relates to #1920

I've checked that command falls back to the timeout specified in the config file if `--timeout` flag is missing.

Can we close the related issue?

I don't think this change deserves changelog.