### PR TITLE
Fix/Refine container placement description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 ### Changed
 ### Fixed
 - Open FSTree in sync mode by default (#1992)
+- `neofs-cli container nodes`'s output (#1991)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-cli/modules/container/nodes.go
+++ b/cmd/neofs-cli/modules/container/nodes.go
@@ -39,12 +39,14 @@ var containerNodesCmd = &cobra.Command{
 		binCnr := make([]byte, sha256.Size)
 		id.Encode(binCnr)
 
+		policy := cnr.PlacementPolicy()
+
 		var cnrNodes [][]netmap.NodeInfo
-		cnrNodes, err = resmap.NetMap().ContainerNodes(cnr.PlacementPolicy(), binCnr)
+		cnrNodes, err = resmap.NetMap().ContainerNodes(policy, binCnr)
 		common.ExitOnErr(cmd, "could not build container nodes for given container: %w", err)
 
 		for i := range cnrNodes {
-			cmd.Printf("Rep %d\n", i+1)
+			cmd.Printf("Descriptor #%d, REP %d:\n", i+1, policy.ReplicaNumberByIndex(i))
 			for j := range cnrNodes[i] {
 				common.PrettyPrintNodeInfo(cmd, cnrNodes[i][j], j, "\t", short)
 			}


### PR DESCRIPTION
Not to confuse a user by mixing replication vector number with its copy number.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1991, was not a bug btw.