### PR TITLE
[SUPPORT] Fix/Helper object broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog for NeoFS Node
 - Correctly select the shard for applying tree service operations (#1996)
 - Physical child object removal by GC (#1699)
 - Increase error counter for write-cache flush errors (#1818)
+- Broadcasting helper objects (#1972)
+- `neofs-cli lock object`'s `lifetime` flag handling (#1972)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -63,8 +63,10 @@ var objectLockCmd = &cobra.Command{
 			currEpoch, err := internalclient.GetCurrentEpoch(ctx, endpoint)
 			common.ExitOnErr(cmd, "Request current epoch: %w", err)
 
-			exp += currEpoch
+			exp = currEpoch + lifetime
 		}
+
+		common.PrintVerbose("Lock object will expire at %d epoch", exp)
 
 		var expirationAttr objectSDK.Attribute
 		expirationAttr.SetKey(objectV2.SysAttributeExpEpoch)

--- a/pkg/core/object/fmt_test.go
+++ b/pkg/core/object/fmt_test.go
@@ -2,8 +2,6 @@ package object
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/sha256"
 	"strconv"
 	"testing"
 
@@ -18,15 +16,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/stretchr/testify/require"
 )
-
-func testSHA(t *testing.T) [sha256.Size]byte {
-	cs := [sha256.Size]byte{}
-
-	_, err := rand.Read(cs[:])
-	require.NoError(t, err)
-
-	return cs
-}
 
 func blankValidObject(key *ecdsa.PrivateKey) *object.Object {
 	var idOwner user.ID
@@ -89,7 +78,8 @@ func TestFormatValidator_Validate(t *testing.T) {
 		user.IDFromKey(&idOwner, ownerKey.PrivateKey.PublicKey)
 
 		tok := sessiontest.Object()
-		tok.Sign(ownerKey.PrivateKey)
+		err := tok.Sign(ownerKey.PrivateKey)
+		require.NoError(t, err)
 
 		obj := object.New()
 		obj.SetContainerID(cidtest.ID())

--- a/pkg/services/object/put/local.go
+++ b/pkg/services/object/put/local.go
@@ -3,31 +3,55 @@ package putsvc
 import (
 	"fmt"
 
+	objectCore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/transformer"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // ObjectStorage is an object storage interface.
 type ObjectStorage interface {
 	// Put must save passed object
 	// and return any appeared error.
-	Put(o *objectSDK.Object) error
+	Put(*object.Object) error
+	// Delete must delete passed objects
+	// and return any appeared error.
+	Delete(tombstone oid.Address, toDelete []oid.ID) error
+	// Lock must lock passed objects
+	// and return any appeared error.
+	Lock(locker oid.Address, toLock []oid.ID) error
 }
 
 type localTarget struct {
 	storage ObjectStorage
 
-	obj *object.Object
+	obj  *object.Object
+	meta objectCore.ContentMeta
 }
 
-func (t *localTarget) WriteHeader(obj *object.Object) error {
+func (t *localTarget) WriteObject(obj *object.Object, meta objectCore.ContentMeta) error {
 	t.obj = obj
+	t.meta = meta
 
 	return nil
 }
 
 func (t *localTarget) Close() (*transformer.AccessIdentifiers, error) {
+	switch t.meta.Type() {
+	case object.TypeTombstone:
+		err := t.storage.Delete(objectCore.AddressOf(t.obj), t.meta.Objects())
+		if err != nil {
+			return nil, fmt.Errorf("could not delete objects from tombstone locally: %w", err)
+		}
+	case object.TypeLock:
+		err := t.storage.Lock(objectCore.AddressOf(t.obj), t.meta.Objects())
+		if err != nil {
+			return nil, fmt.Errorf("could not lock object from lock objects locally: %w", err)
+		}
+	default:
+		// objects that do not change meta storage
+	}
+
 	if err := t.storage.Put(t.obj); err != nil {
 		return nil, fmt.Errorf("(%T) could not put object to local storage: %w", t, err)
 	}

--- a/pkg/services/object/put/remote.go
+++ b/pkg/services/object/put/remote.go
@@ -6,6 +6,7 @@ import (
 
 	clientcore "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	netmapCore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
+	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	internalclient "github.com/nspcc-dev/neofs-node/pkg/services/object/internal/client"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object_manager/transformer"
@@ -42,7 +43,7 @@ type RemotePutPrm struct {
 	obj *object.Object
 }
 
-func (t *remoteTarget) WriteHeader(obj *object.Object) error {
+func (t *remoteTarget) WriteObject(obj *object.Object, _ objectcore.ContentMeta) error {
 	t.obj = obj
 
 	return nil
@@ -126,7 +127,7 @@ func (s *RemoteSender) PutObject(ctx context.Context, p *RemotePutPrm) error {
 		return fmt.Errorf("parse client node info: %w", err)
 	}
 
-	if err := t.WriteHeader(p.obj); err != nil {
+	if err := t.WriteObject(p.obj, objectcore.ContentMeta{}); err != nil {
 		return fmt.Errorf("(%T) could not send object header: %w", s, err)
 	} else if _, err := t.Close(); err != nil {
 		return fmt.Errorf("(%T) could not send object: %w", s, err)

--- a/pkg/services/object/put/service.go
+++ b/pkg/services/object/put/service.go
@@ -128,12 +128,6 @@ func WithNetmapKeys(v netmap.AnnouncedKeys) Option {
 	}
 }
 
-func WithFormatValidatorOpts(v ...object.FormatValidatorOption) Option {
-	return func(c *cfg) {
-		c.fmtValidatorOpts = v
-	}
-}
-
 func WithNetworkState(v netmap.State) Option {
 	return func(c *cfg) {
 		c.networkState = v

--- a/pkg/services/object/put/validation.go
+++ b/pkg/services/object/put/validation.go
@@ -34,9 +34,9 @@ type validatingTarget struct {
 }
 
 var (
-	// ErrExceedingMaxSize is returned when chunk payload size is greater than the length declared in header.
+	// ErrExceedingMaxSize is returned when payload size is greater than the limit.
 	ErrExceedingMaxSize = errors.New("payload size is greater than the limit")
-	// ErrWrongPayloadSize is returned when payload size is greater than the limit.
+	// ErrWrongPayloadSize is returned when chunk payload size is greater than the length declared in header.
 	ErrWrongPayloadSize = errors.New("wrong payload size")
 )
 


### PR DESCRIPTION
Closes #1972.

Includes:
1. CLI `object lock`'s `lifetime` flag fix;
2. Changing broadcasting logic: a node does not save object relations if it is not in the object's container. I did not find any usage of that, but it disallows correct object handling: putting a TS record to a storage of a node that does not belong to the container skips any lock object checks (it just does not have any helper objects of the container) and does not have any reasons. @fyrchik, @cthulhu-rider, please, double-check that.