### PR TITLE
Fix/Big object removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - `neofs-cli container nodes`'s output (#1991)
 - Do not panic with bad inputs for `GET_RANGE` (#2007)
 - Correctly select the shard for applying tree service operations (#1996)
+- Physical child object removal by GC (#1699)
 
 ### Removed
 ### Updated

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -157,7 +157,10 @@ func (db *DB) delete(tx *bbolt.Tx, addr oid.Address, refCounter referenceCounter
 	// unmarshal object, work only with physically stored (raw == true) objects
 	obj, err := db.get(tx, addr, key, false, true, currEpoch)
 	if err != nil {
-		if errors.As(err, new(apistatus.ObjectNotFound)) {
+		var siErr *objectSDK.SplitInfoError
+		var notFoundErr apistatus.ObjectNotFound
+
+		if errors.As(err, &notFoundErr) || errors.As(err, &siErr) {
 			return false, false, nil
 		}
 

--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -39,9 +39,9 @@ func TestDB_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, l, 1)
 
-	// try to remove parent unsuccessfully
+	// try to remove parent, should be no-op, error-free
 	err = metaDelete(db, object.AddressOf(parent))
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	// inhume parent and child so they will be on graveyard
 	ts := generateObjectWithCID(t, cnr)


### PR DESCRIPTION
It is not an error: removing virtual object is expected and should be just skipped. Getting a virtual object with `raw` flag is considered as an impossible action, all the virtual objects removals will be handled via their children's removals implicitly.

Closes #1699.