### PR TITLE
services/object: Unify apistatus errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Open FSTree in sync mode by default (#1992)
 - `neofs-cli container nodes`'s output (#1991)
-- Do not panic with bad inputs for `GET_RANGE` (#2007)
+- Do not panic and return correct errors for bad inputs in `GET_RANGE` (#2007, #2024)
 - Correctly select the shard for applying tree service operations (#1996)
 - Physical child object removal by GC (#1699)
 - Increase error counter for write-cache flush errors (#1818)

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -96,7 +96,7 @@ func (exec *execCtx) initFromChild(obj oid.ID) (prev *oid.ID, children []oid.ID)
 		if seekTo < seekOff || parSize < seekOff || parSize < seekTo {
 			var errOutOfRange apistatus.ObjectOutOfRange
 
-			exec.err = errOutOfRange
+			exec.err = &errOutOfRange
 			exec.status = statusOutOfRange
 
 			return

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -88,11 +88,12 @@ func (exec *execCtx) initFromChild(obj oid.ID) (prev *oid.ID, children []oid.ID)
 	var payload []byte
 
 	if rng := exec.ctxRange(); rng != nil {
-		seekLen := rng.GetLength()
 		seekOff := rng.GetOffset()
+		seekLen := rng.GetLength()
+		seekTo := seekOff + seekLen
 		parSize := par.PayloadSize()
 
-		if seekOff+seekLen > parSize {
+		if seekTo < seekOff || parSize < seekOff || parSize < seekTo {
 			var errOutOfRange apistatus.ObjectOutOfRange
 
 			exec.err = errOutOfRange

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -156,7 +156,7 @@ func (c *clientWrapper) getObject(exec *execCtx, info coreclient.NodeInfo) (*obj
 				to := from + rng.GetLength()
 
 				if pLen := uint64(len(payload)); to < from || pLen < from || pLen < to {
-					return nil, apistatus.ObjectOutOfRange{}
+					return nil, new(apistatus.ObjectOutOfRange)
 				}
 
 				return payloadOnlyObject(payload[from:to]), nil

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -330,7 +330,8 @@ const maxInitialBufferSize = 1024 * 1024 // 1 MiB
 // Returns:
 //
 //	error of type *object.SplitInfoError if object raw flag is set and requested object is virtual;
-//	error of type *apistatus.ObjectAlreadyRemoved if the requested object is marked to be removed.
+//	error of type *apistatus.ObjectAlreadyRemoved if the requested object is marked to be removed;
+//	error of type *apistatus.ObjectOutOfRange if the requested range is too big.
 //
 // PayloadRange ignores the provided session if it is not related to the requested object.
 func PayloadRange(prm PayloadRangePrm) (*PayloadRangeRes, error) {
@@ -359,7 +360,7 @@ func PayloadRange(prm PayloadRangePrm) (*PayloadRangeRes, error) {
 		// `CopyN` expects `int64`, this check ensures that the result is positive.
 		// On practice this means that we can return incorrect results for objects
 		// with size > 8_388 Petabytes, this will be fixed later with support for streaming.
-		return nil, apistatus.ObjectOutOfRange{}
+		return nil, new(apistatus.ObjectOutOfRange)
 	}
 
 	ln := prm.ln


### PR DESCRIPTION
Fixes some autotests with bad ranges and expected `out of range` error.