### PR TITLE
[#1906] writecache: Do not require `read-only` mode in `Flush`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for NeoFS Node
 - Increase error counter for write-cache flush errors (#1818)
 - Broadcasting helper objects (#1972)
 - `neofs-cli lock object`'s `lifetime` flag handling (#1972)
+- Do not move write-cache in read-only mode for flushing (#1906)
 
 ### Removed
 ### Updated

--- a/pkg/local_object_storage/shard/writecache.go
+++ b/pkg/local_object_storage/shard/writecache.go
@@ -2,8 +2,6 @@ package shard
 
 import (
 	"errors"
-
-	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 )
 
 // FlushWriteCachePrm represents parameters of a `FlushWriteCache` operation.
@@ -20,8 +18,7 @@ func (p *FlushWriteCachePrm) SetIgnoreErrors(ignore bool) {
 // but write-cache is disabled.
 var errWriteCacheDisabled = errors.New("write-cache is disabled")
 
-// FlushWriteCache moves writecache in read-only mode and flushes all data from it.
-// After the operation writecache will remain read-only mode.
+// FlushWriteCache flushes all data from the write-cache.
 func (s *Shard) FlushWriteCache(p FlushWriteCachePrm) error {
 	if !s.hasWriteCache() {
 		return errWriteCacheDisabled
@@ -36,10 +33,6 @@ func (s *Shard) FlushWriteCache(p FlushWriteCachePrm) error {
 	}
 	if s.info.Mode.NoMetabase() {
 		return ErrDegradedMode
-	}
-
-	if err := s.writeCache.SetMode(mode.ReadOnly); err != nil {
-		return err
 	}
 
 	return s.writeCache.Flush(p.ignoreErrors)

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -261,10 +261,6 @@ func (c *cache) Flush(ignoreErrors bool) error {
 	c.modeMtx.RLock()
 	defer c.modeMtx.RUnlock()
 
-	if !c.mode.ReadOnly() {
-		return errMustBeReadOnly
-	}
-
 	return c.flush(ignoreErrors)
 }
 

--- a/pkg/local_object_storage/writecache/flush_test.go
+++ b/pkg/local_object_storage/writecache/flush_test.go
@@ -113,7 +113,6 @@ func TestFlush(t *testing.T) {
 		wc, bs, mb := newCache(t)
 		objects := putObjects(t, wc)
 
-		require.NoError(t, wc.SetMode(mode.ReadOnly))
 		require.NoError(t, bs.SetMode(mode.ReadWrite))
 		require.NoError(t, mb.SetMode(mode.ReadWrite))
 


### PR DESCRIPTION
Close #1906.
It was needed before we started to flush during transition to `degraded` mode. Now it is confusing.

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>