### PR TITLE
[SUPPORT] Fix/Object removal with a bearer token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for NeoFS Node
 - Broadcasting helper objects (#1972)
 - `neofs-cli lock object`'s `lifetime` flag handling (#1972)
 - Do not move write-cache in read-only mode for flushing (#1906)
+- Child object collection on CLI side with a bearer token (#2000)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -328,6 +328,8 @@ func collectObjectRelatives(cmd *cobra.Command, cli *client.Client, cnr cid.ID, 
 	prmHead.SetAddress(addrObj)
 	prmHead.SetRawFlag(true)
 
+	Prepare(cmd, &prmHead)
+
 	_, err := internal.HeadObject(prmHead)
 
 	var errSplit *object.SplitInfoError


### PR DESCRIPTION
Closes #2000 _exactly_, neither more nor less.