### PR TITLE
[SUPPORT] Fix/Big objects removal with static sessions

### DIFF
--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -208,6 +208,12 @@ func ReadOrOpenSessionViaClient(cmd *cobra.Command, dst SessionPrm, cli *client.
 	var objs []oid.ID
 	if obj != nil {
 		objs = []oid.ID{*obj}
+
+		if _, ok := dst.(*internal.DeleteObjectPrm); ok {
+			common.PrintVerbose("Collecting relatives of the removal object...")
+
+			objs = append(objs, collectObjectRelatives(cmd, cli, cnr, *obj)...)
+		}
 	}
 
 	finalizeSession(cmd, dst, tok, key, cnr, objs...)


### PR DESCRIPTION
If an external session is provided and is not opened by CLI itself, add children objects to it too. It fixes "not found" errors when removing a big object with a predefined session (from a file).

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #1978.

