### PR TITLE
[SUPPORT] Fix/Allow attaching static session to `object hash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Added
+- `session` flag support to `neofs-cli object hash` (#2029)
+
 ### Changed
 - `object lock` command reads CID and OID the same way other commands do (#1971)
 

--- a/cmd/neofs-cli/modules/object/hash.go
+++ b/cmd/neofs-cli/modules/object/hash.go
@@ -32,6 +32,7 @@ var objectHashCmd = &cobra.Command{
 
 func initObjectHashCmd() {
 	commonflags.Init(objectHashCmd)
+	initFlagSession(objectHeadCmd, "RANGEHASH")
 
 	flags := objectHashCmd.Flags()
 


### PR DESCRIPTION
All the other object commands already have it.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

Closes #2029.