### PR TITLE
Fix/Big object `GET` with bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog for NeoFS Node
 - Fix concurrent map writes in `Object.Put` service (#2037)
 - Malformed request errors' reasons in the responses (#2028)
 - Session token's IAT and NBF checks in ACL service (#2028)
+- Losing meta information on request forwarding (#2040)
 
 ### Removed
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for NeoFS Node
 - Malformed request errors' reasons in the responses (#2028)
 - Session token's IAT and NBF checks in ACL service (#2028)
 - Losing meta information on request forwarding (#2040)
+- Assembly process triggered by a request with a bearer token (#2040)
 
 ### Removed
 ### Updated

--- a/pkg/services/object/get/assemble.go
+++ b/pkg/services/object/get/assemble.go
@@ -13,6 +13,19 @@ func (exec *execCtx) assemble() {
 		return
 	}
 
+	// Any access tokens are not expected to be used in the assembly process:
+	//  - there is no requirement to specify child objects in session/bearer
+	//    token for `GET`/`GETRANGE`/`RANGEHASH` requests in the API protocol,
+	//    and, therefore, their missing in the original request should not be
+	//    considered as error; on the other hand, without session for every child
+	//    object, it is impossible to attach bearer token in the new generated
+	//    requests correctly because the token has not been issued for that node's
+	//    key;
+	//  - the assembly process is expected to be handled on a container node
+	//    only since the requests forwarding mechanism presentation; such the
+	//    node should have enough rights for getting any child object by design.
+	exec.prm.common.ForgetTokens()
+
 	// Do not use forwarding during assembly stage.
 	// Request forwarding closure inherited in produced
 	// `execCtx` so it should be disabled there.

--- a/pkg/services/object/util/prm.go
+++ b/pkg/services/object/util/prm.go
@@ -102,6 +102,12 @@ func CommonPrmFromV2(req interface {
 	GetMetaHeader() *session.RequestMetaHeader
 }) (*CommonPrm, error) {
 	meta := req.GetMetaHeader()
+	ttl := meta.GetTTL()
+
+	// unwrap meta header to get original request meta information
+	for meta.GetOrigin() != nil {
+		meta = meta.GetOrigin()
+	}
 
 	var tokenSession *sessionsdk.Object
 	var err error
@@ -116,7 +122,6 @@ func CommonPrmFromV2(req interface {
 	}
 
 	xHdrs := meta.GetXHeaders()
-	ttl := meta.GetTTL()
 
 	prm := &CommonPrm{
 		local: ttl <= maxLocalTTL,

--- a/pkg/services/object/util/prm.go
+++ b/pkg/services/object/util/prm.go
@@ -98,6 +98,15 @@ func (p *CommonPrm) SetNetmapLookupDepth(v uint64) {
 	}
 }
 
+// ForgetTokens forgets all the tokens read from the request's
+// meta information before.
+func (p *CommonPrm) ForgetTokens() {
+	if p != nil {
+		p.token = nil
+		p.bearer = nil
+	}
+}
+
 func CommonPrmFromV2(req interface {
 	GetMetaHeader() *session.RequestMetaHeader
 }) (*CommonPrm, error) {


### PR DESCRIPTION
Closes #2040.

See #2046 about the first commit.