### PR TITLE
[SUPPORT] Fix/Non-logical shard mode switch

### DIFF
--- a/pkg/local_object_storage/engine/engine.go
+++ b/pkg/local_object_storage/engine/engine.go
@@ -120,6 +120,13 @@ func (e *StorageEngine) reportShardErrorBackground(id string, msg string, err er
 		return
 	}
 
+	if isLogical(err) {
+		e.log.Warn(msg,
+			zap.Stringer("shard_id", sh.ID()),
+			zap.String("error", err.Error()))
+		return
+	}
+
 	errCount := sh.errorCount.Inc()
 	e.reportShardErrorWithFlags(sh.Shard, errCount, false, msg, err)
 }


### PR DESCRIPTION
Related to #2053.

```
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        debug        writecache/flush.go:122        tried to flush items from write-cache        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "count": 1, "start": ""}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 2, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 3, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 4, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 5, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 6, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 7, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 8, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 9, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 10, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 11, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 12, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 13, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 14, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 15, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 16, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 17, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 18, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 19, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 20, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 21, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 22, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 23, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.148Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 24, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 25, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 26, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 27, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 28, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 29, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        warn        engine/engine.go:153        can't update object storage ID        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3", "error count": 30, "error": "status: code = 2049"}
Nov 14 02:42:42 az neofs-node[14468]: 2022-11-14T02:42:42.149Z        debug        blobstor/control.go:49        closing...        {"shard_id": "UdNgukPGsHGaTvDp7tGtz3"}
```