### PR TITLE
Support new hash format in morph nns client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 - Shard can now change mode when encountering background disk errors (#2035)
 - Background workers and object service now use separate client caches (#2048)
 - `replicator.pool_size` config field to tune replicator pool size (#2049)
+- Fix NNS hash parsing in morph client (#2063)
 
 ### Changed
 - `object lock` command reads CID and OID the same way other commands do (#1971)

--- a/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_nns.go
@@ -261,6 +261,8 @@ func parseNNSResolveResult(res stackitem.Item) (util.Uint160, error) {
 			continue
 		}
 
+		// We support several formats for hash encoding, this logic should be maintained in sync
+		// with nnsResolve from pkg/morph/client/nns.go
 		h, err := util.Uint160DecodeStringLE(string(bs))
 		if err == nil {
 			return h, nil


### PR DESCRIPTION
In https://github.com/nspcc-dev/neofs-node/pull/1748 we've introduced a small inconsistency in NNS hash parsing:
* In function [parseNNSResolveResult](https://github.com/nspcc-dev/neofs-node/blob/support/v0.34/cmd/neofs-adm/internal/modules/morph/initialize_nns.go#L250) we support 2 hash formats (Uint160DecodeStringLE и StringToUint160).
* In function [nnsResolve](https://github.com/nspcc-dev/neofs-node/blob/support/v0.34/pkg/morph/client/nns.go#L140) we support only 1 format (Uint160DecodeStringLE).

This PR updates implementation of nnsResolve so that it is consistent with parseNNSResolveResult.

Per discussion with @fyrchik for now we just add missing logic to nnsResolve. In the future we will refactor implementation so that the logic is implemented in a single place.