### PR TITLE
go.mod: Retract `v1.*` versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,8 @@ require (
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+retract (
+	v1.22.1 // Contains retraction only.
+	v1.22.0 // Published accidentally.
+)


### PR DESCRIPTION
Close #2060 

Signed-off-by: Evgenii Stratonikov <evgeniy@morphbits.ru>