### PR TITLE
[SUPPORT] Fix/Write-cache flush duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changelog for NeoFS Node
 - Removing all trees by container ID if tree ID is empty in `pilorama.Forest.TreeDrop` (#1940)
 - Concurrent mode changes in the metabase and blobstor (#2057)
 - Panic in IR when performing HEAD requests (#2069)
+- Write-cache flush duplication (#2074)
 
 ### Removed
 ### Updated

--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -27,10 +27,6 @@ const (
 	defaultFlushInterval = time.Second
 )
 
-// errMustBeReadOnly is returned when write-cache must be
-// in read-only mode to perform an operation.
-var errMustBeReadOnly = errors.New("write-cache must be in read-only mode")
-
 // runFlushLoop starts background workers which periodically flush objects to the blobstor.
 func (c *cache) runFlushLoop() {
 	for i := 0; i < c.workersCount; i++ {
@@ -71,7 +67,6 @@ func (c *cache) flushDB() {
 		}
 
 		m = m[:0]
-		sz := 0
 
 		c.modeMtx.RLock()
 		if c.readOnly() {
@@ -89,7 +84,6 @@ func (c *cache) flushDB() {
 					continue
 				}
 
-				sz += len(k) + len(v)
 				m = append(m, objectInfo{
 					addr: string(k),
 					data: slice.Copy(v),


### PR DESCRIPTION
Fixes

```
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.933Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.934Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.934Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.934Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.934Z        debug        writecache/flush.go:121        tried to flush items from write-cache        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "count": 1, "start": ""}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.946Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.947Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.947Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.947Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.947Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
Nov 03 08:10:25 vedi neofs-node[606]: 2022-11-03T08:10:25.947Z        info        log/log.go:13        local object storage operation        {"shard_id": "Q4JVDpjCDxx5as5HYzRdyZ", "address": "7QwoRQ8cW63GRyT5DZJbXcpkBhyaCHsPsUBvV6PGQAHt/HRCKtbDHaVXcb51F3vde89fFw99E9VfZXoWd8zdTeGCu", "op": "PUT", "type": "blobovnicza", "storage_id": "3/0"}
```