### PR TITLE
adm: Pack parameters for `setPrice` invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changelog for NeoFS Node
 - Panic in IR when performing HEAD requests (#2069)
 - Write-cache flush duplication (#2074)
 - Ignore error if a transaction already exists in a morph client (#2075)
+- Pack arguments of `setPrice` invocation during contract update (#2078)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize_deploy.go
@@ -287,6 +287,8 @@ func (c *initializeContext) updateContracts() error {
 	c.Command.Printf("NNS: Set %s -> %s\n", morphClient.NNSGroupKeyName, hex.EncodeToString(groupKey.Bytes()))
 
 	emit.Opcodes(w.BinWriter, opcode.LDSFLD0)
+	emit.Int(w.BinWriter, 1)
+	emit.Opcodes(w.BinWriter, opcode.PACK)
 	emit.AppCallNoArgs(w.BinWriter, nnsHash, "setPrice", callflag.All)
 
 	if err := c.sendCommitteeTx(w.Bytes(), false); err != nil {


### PR DESCRIPTION
```
Error: could not perform test invocation: script failed (FAULT state) due to an error: at instruction 117 (SYSCALL): element is not an array 
```

Contract arguments have to be packed.
