### PR TITLE
Fix/OID signature in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changelog for NeoFS Node
 - Panic in IR when performing HEAD requests (#2069)
 - Write-cache flush duplication (#2074)
 - Ignore error if a transaction already exists in a morph client (#2075)
+- ObjectID signature output in the CLI (#2104)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-cli/modules/object/head.go
+++ b/cmd/neofs-cli/modules/object/head.go
@@ -160,6 +160,17 @@ func printHeader(cmd *cobra.Command, obj *object.Object) error {
 		cmd.Printf("  %s=%s\n", attr.Key(), attr.Value())
 	}
 
+	if signature := obj.Signature(); signature != nil {
+		cmd.Print("ID signature:\n")
+
+		// TODO(@carpawell): #1387 implement and use another approach to avoid conversion
+		var sigV2 refs.Signature
+		signature.WriteToV2(&sigV2)
+
+		cmd.Printf("  public key: %s\n", hex.EncodeToString(sigV2.GetKey()))
+		cmd.Printf("  signature: %s\n", hex.EncodeToString(sigV2.GetSign()))
+	}
+
 	return printSplitHeader(cmd, obj)
 }
 
@@ -178,17 +189,6 @@ func printSplitHeader(cmd *cobra.Command, obj *object.Object) error {
 
 	for _, child := range obj.Children() {
 		cmd.Printf("Split ChildID: %s\n", child.String())
-	}
-
-	if signature := obj.Signature(); signature != nil {
-		cmd.Print("Split Header Signature:\n")
-
-		// TODO(@cthulhu-rider): #1387 implement and use another approach to avoid conversion
-		var sigV2 refs.Signature
-		signature.WriteToV2(&sigV2)
-
-		cmd.Printf("  public key: %s\n", hex.EncodeToString(sigV2.GetKey()))
-		cmd.Printf("  signature: %s\n", hex.EncodeToString(sigV2.GetSign()))
 	}
 
 	parent := obj.Parent()


### PR DESCRIPTION
OID signature should always be present in an object; it does not relate to the object split.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>

It is about [the field](https://github.com/nspcc-dev/neofs-api/blob/813c04bea4a23b99fb90666b1b325c95e0a364cf/object/types.proto#L202).