### PR TITLE
Fix/Container size estimations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changelog for NeoFS Node
 - Write-cache flush duplication (#2074)
 - Ignore error if a transaction already exists in a morph client (#2075)
 - ObjectID signature output in the CLI (#2104)
+- Container size estimation value (#2113)
 
 ### Removed
 ### Updated


### PR DESCRIPTION
The lead node should take into account container replication factor, the size of the container vector and the vectors number: the average estimation report by the container nodes does not describe container size, it only could say how much space an average container node uses and such an estimation works correctly for the `REP 1 CBF 1` containers only.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>