### PR TITLE
neofs-cli: Check the sufficiency of the number of nodes in the selector for replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Changelog for NeoFS Node
 - Closing `neo-go` WS clients on shutdown and switch processes (#2080)
 - Making notary deposits with a zero GAS balance (#2080)
 - Notary requests on shutdown (#2075)
+- `neofs-cli container create ` check the sufficiency of the number of nodes in the selector for replicas (#2038)
 
 ### Removed
 - `-g` option from `neofs-cli control ...` and `neofs-cli container create` commands (#2089)

--- a/cmd/neofs-cli/modules/container/create.go
+++ b/cmd/neofs-cli/modules/container/create.go
@@ -50,9 +50,20 @@ It will be stored in sidechain when inner ring will accepts it.`,
 			common.ExitOnErr(cmd, "unable to get netmap snapshot to validate container placement, "+
 				"use --force option to skip this check: %w", err)
 
-			_, err = resmap.NetMap().ContainerNodes(*placementPolicy, nil)
+			nodesByRep, err := resmap.NetMap().ContainerNodes(*placementPolicy, nil)
 			common.ExitOnErr(cmd, "could not build container nodes based on given placement policy, "+
 				"use --force option to skip this check: %w", err)
+
+			for i, nodes := range nodesByRep {
+				if placementPolicy.ReplicaNumberByIndex(i) > uint32(len(nodes)) {
+					common.ExitOnErr(cmd, "", fmt.Errorf(
+						"the number of nodes '%d' in selector is not enough for the number of replicas '%d', "+
+							"use --force option to skip this check",
+						len(nodes),
+						placementPolicy.ReplicaNumberByIndex(i),
+					))
+				}
+			}
 		}
 
 		if containerSubnet != "" {


### PR DESCRIPTION
Perform this check on container creation.

Close #2038

Signed-off-by: Anton Nikiforov <an.nikiforov@yadro.com>