### PR TITLE
Use endless notary deposit for side chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for NeoFS Node
 - `object lock` command reads CID and OID the same way other commands do (#1971)
 - `LOCK` object are stored on every container node (#1502)
 - `neofs-cli container get-eacl` print ACL table in json format only with arg `--json' (#2012)
+- Side chain notary deposits use max uint32 as till parameter (#1486)
 
 ### Fixed
 - Open FSTree in sync mode by default (#1992)

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -141,15 +141,7 @@ func makeNotaryDeposit(c *cfg) (util.Uint256, error) {
 		return util.Uint256{}, fmt.Errorf("could not calculate notary deposit: %w", err)
 	}
 
-	epochDur, err := c.cfgNetmap.wrapper.EpochDuration()
-	if err != nil {
-		return util.Uint256{}, fmt.Errorf("could not get current epoch duration: %w", err)
-	}
-
-	return c.cfgMorph.client.DepositNotary(
-		depositAmount,
-		uint32(epochDur)+notaryDepositExtraBlocks,
-	)
+	return c.cfgMorph.client.DepositEndlessNotary(depositAmount)
 }
 
 var (

--- a/pkg/innerring/notary.go
+++ b/pkg/innerring/notary.go
@@ -46,10 +46,7 @@ func (s *Server) depositSideNotary() (tx util.Uint256, err error) {
 		return util.Uint256{}, fmt.Errorf("could not calculate side notary deposit amount: %w", err)
 	}
 
-	return s.morphClient.DepositNotary(
-		depositAmount,
-		uint32(s.epochDuration.Load())+notaryExtraBlocks,
-	)
+	return s.morphClient.DepositEndlessNotary(depositAmount)
 }
 
 func (s *Server) notaryHandler(_ event.Event) {


### PR DESCRIPTION
It's time to solve `fallback transaction is valid after deposit is unlocked` once and for all.
Closes #1486 

Questions from original issue.

> I do not remember if it is allowed to make the same notary deposits (the same till, the same amount).

It is allowed.

> Doing a deposit with max int64 forces us to use the same till in all the further deposits (it is impossible to make deposits with newTill < currentTill).

Yes. Once we go for it, we won't be able to go back in the side chain. Don't see a problem with that.

> We have the same deposit logic in the side and main chains. While it is kinda ok to block some GAS forever in the sidechain, doing that in the main chain may have some misunderstanding (if we ever have notary turned on in the main chain).

Main chain is not affected by new `DepositEndlessNotary` method.

> New logs on notary deposits (with the amount, till, and epoch) could be useful for debugging.

Deposits and their logs are still there, we just use constant `until` value.