### PR TITLE
Fix/Unwrap incomplete object put errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Changelog for NeoFS Node
 - Notary requests on shutdown (#2075)
 - `neofs-cli container create ` check the sufficiency of the number of nodes in the selector for replicas (#2038)
 - Data duplication during request forwarding (#2047)
+- Incomplete object put errors message unwrapping (#2092)
 
 ### Removed
 - `-g` option from `neofs-cli control ...` and `neofs-cli container create` commands (#2089)

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -115,6 +115,10 @@ func (x errIncompletePut) Error() string {
 	return commonMsg
 }
 
+func (x errIncompletePut) Unwrap() error {
+	return x.singleErr
+}
+
 func (t *distributedTarget) WriteHeader(obj *objectSDK.Object) error {
 	t.obj = obj
 


### PR DESCRIPTION
Closes #2092.

Before:
```
Store lock object in NeoFS: client failure: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: (*putsvc.remoteTarget) could not put object to [/dns4/s02.neofs.devenv/tcp/8080]: write object via client: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: could not lock object from lock objects locally: status: code = 2051
...
rpc error: remove object via client: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: (*putsvc.remoteTarget) could not put object to [/dns4/s02.neofs.devenv/tcp/8080]: write object via client: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: could not delete objects from tombstone locally: lock object removal
...
rpc error: remove object via client: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: (*putsvc.remoteTarget) could not put object to [/dns4/s01.neofs.devenv/tcp/8080]: write object via client: status: code = 1024 message = incomplete object PUT by placement: could not close object stream: could not delete objects from tombstone locally: status: code = 2050
```

After:
```
Store lock object in NeoFS: client failure: status: code = 2051 message = locking non-regular object is forbidden
...
rpc error: remove object via client: status: code = 1024 message = lock object removal
...
rpc error: remove object via client: status: code = 2050 message = object is locked
```

Not sure if we want to lose error chain but that is how unwrapping (looking for API status errors) works in the current code base.