### PR TITLE
Add metric `readonly` to get shards mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - Fix NNS hash parsing in morph client (#2063)
 - `neofs-cli neofs-cli acl basic/extended print` commands (#2012)
 - `neofs_node_object_*_req_count_success` prometheus metrics for tracking successfully executed requests (#1984)
+- Metric 'readonly' to get shards mode (#2022)
 
 ### Changed
 - `object lock` command reads CID and OID the same way other commands do (#1971)

--- a/pkg/local_object_storage/engine/metrics.go
+++ b/pkg/local_object_storage/engine/metrics.go
@@ -19,6 +19,8 @@ type MetricRegister interface {
 
 	SetObjectCounter(shardID, objectType string, v uint64)
 	AddToObjectCounter(shardID, objectType string, delta int)
+
+	SetReadonly(shardID string, readonly bool)
 }
 
 func elapsed(addFunc func(d time.Duration)) func() {

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -45,6 +45,10 @@ func (m *metricsWithID) DecObjectCounter(objectType string) {
 	m.mw.AddToObjectCounter(m.id, objectType, -1)
 }
 
+func (m *metricsWithID) SetReadonly(readonly bool) {
+	m.mw.SetReadonly(m.id, readonly)
+}
+
 // AddShard adds a new shard to the storage engine.
 //
 // Returns any error encountered that did not allow adding a shard.
@@ -58,6 +62,10 @@ func (e *StorageEngine) AddShard(opts ...shard.Option) (*shard.ID, error) {
 	err = e.addShard(sh)
 	if err != nil {
 		return nil, fmt.Errorf("could not add %s shard: %w", sh.ID().String(), err)
+	}
+
+	if e.cfg.metrics != nil {
+		e.cfg.metrics.SetReadonly(sh.ID().String(), sh.GetMode() != mode.ReadWrite)
 	}
 
 	return sh.ID(), nil

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -57,6 +57,9 @@ func (s *Shard) setMode(m mode.Mode) error {
 	}
 
 	s.info.Mode = m
+	if s.metricsWriter != nil {
+		s.metricsWriter.SetReadonly(s.info.Mode != mode.ReadWrite)
+	}
 
 	return nil
 }

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -62,6 +62,8 @@ type MetricsWriter interface {
 	// SetShardID must set (update) the shard identifier that will be used in
 	// metrics.
 	SetShardID(id string)
+	// SetReadonly must set shard readonly state.
+	SetReadonly(readonly bool)
 }
 
 type cfg struct {


### PR DESCRIPTION
How it looks in prometheus:
```
# HELP neofs_node_object_readonly Shards state
# TYPE neofs_node_object_readonly gauge
neofs_node_object_readonly{shard="4SVWUS1TajZ9ZwPRbUaNMY"} 1
neofs_node_object_readonly{shard="NoxKcaHtMd4rQp8DjqJiP5"} 0
```
Close #2022

Signed-off-by: Anton Nikiforov <an.nikiforov@yadro.com>