### PR TITLE
core/netmap: change node addresses iteration order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Changelog for NeoFS Node
 - Panic in `GETRANGE` with zero length (#2095)
 - Spawning useless `GETRANGE` with zero length for a big object (#2101)
 - Incomplete object put errors do contain the deepest error's message (#2092)
+- Prioritize internal addresses for clients (#2156)
 
 ### Removed
 - `-g` option from `neofs-cli control ...` and `neofs-cli container create` commands (#2089)

--- a/pkg/core/netmap/nodes.go
+++ b/pkg/core/netmap/nodes.go
@@ -17,12 +17,12 @@ func (x Node) PublicKey() []byte {
 // IterateAddresses iterates over all announced network addresses
 // and passes them into f. Handler MUST NOT be nil.
 func (x Node) IterateAddresses(f func(string) bool) {
+	(netmap.NodeInfo)(x).IterateNetworkEndpoints(f)
 	for _, addr := range (netmap.NodeInfo)(x).ExternalAddresses() {
 		if f(addr) {
 			return
 		}
 	}
-	(netmap.NodeInfo)(x).IterateNetworkEndpoints(f)
 }
 
 // NumberOfAddresses returns number of announced network addresses.


### PR DESCRIPTION
Previously we have given external addresses a priority in some circumstances.
Now we prioritize internal addresses.

Should fix a problem where data interface is used even though internal is available.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>