### PR TITLE
policer: Reduce default cache size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Changelog for NeoFS Node
 - `neofs-cli container get-eacl` print ACL table in json format only with arg `--json' (#2012)
 - Side chain notary deposits use max uint32 as till parameter (#1486)
 - Allow object removal without linking object (#2100)
-- `neofs-cli container delete` command pre-checks container ownership (#2106) 
+- `neofs-cli container delete` command pre-checks container ownership (#2106)
+- Policer cache size is now 1024 (#2158)
 
 ### Fixed
 - Open FSTree in sync mode by default (#1992)

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -99,7 +99,7 @@ func defaultCfg() *cfg {
 	return &cfg{
 		log:           &logger.Logger{Logger: zap.L()},
 		batchSize:     10,
-		cacheSize:     200_000, // should not allocate more than 200 MiB
+		cacheSize:     1024, // 1024 * address size = 1024 * 64 = 64 MiB
 		rebalanceFreq: 1 * time.Second,
 		evictDuration: 30 * time.Second,
 	}


### PR DESCRIPTION
We use cache to avoid policing the same object multiple times in a short time span (< 30 seconds). If we have 200_000 objects in a blobstor, it is a bit useless -- if it takes 1 second to process an object and we have `replicator.pool_size: 20` in config, the next iteration will happen in 10_000 second which is much larger than 30 second. However we still consume a lot of memory, so it makes sense to use saner default.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>