### PR TITLE
services/tree: close connection after the syncronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Changelog for NeoFS Node
 - Prioritize internal addresses for clients (#2156)
 - Force object removal via control service (#2145)
 - Synchronizing a tree now longer reports an error for a single-node container (#2154)
+- Prevent leaking goroutines in the tree service (#2162)
 
 ### Removed
 - `-g` option from `neofs-cli control ...` and `neofs-cli container create` commands (#2089)

--- a/pkg/services/tree/sync.go
+++ b/pkg/services/tree/sync.go
@@ -137,6 +137,7 @@ func (s *Service) synchronizeTree(ctx context.Context, d pilorama.CIDDescriptor,
 				// Failed to connect, try the next address.
 				return false
 			}
+			defer cc.Close()
 
 			treeClient := NewTreeServiceClient(cc)
 			for {


### PR DESCRIPTION
There was a goroutine leak here.

No need to test.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>