### PR TITLE
Clarify help for `--expire-at` parameter for commands `object lock/put` and `bearer create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog for NeoFS Node
 - Pilorama no longer tries to apply already applied operations (#2161)
 - Use `sync.Pool` in Object.PUT service (#2139)
 - Shard uses metabase for `HEAD` requests by default, not write-cache (#2167)
+- Clarify help for `--expire-at` parameter for commands `object lock/put` and `bearer create` (#2097)
 
 ### Fixed
 - Open FSTree in sync mode by default (#1992)

--- a/cmd/neofs-cli/modules/bearer/create.go
+++ b/cmd/neofs-cli/modules/bearer/create.go
@@ -41,7 +41,7 @@ func init() {
 	createCmd.Flags().StringP(eaclFlag, "e", "", "Path to the extended ACL table")
 	createCmd.Flags().StringP(issuedAtFlag, "i", "", "Epoch to issue token at")
 	createCmd.Flags().StringP(notValidBeforeFlag, "n", "", "Not valid before epoch")
-	createCmd.Flags().StringP(commonflags.ExpireAt, "x", "", "Expiration epoch")
+	createCmd.Flags().StringP(commonflags.ExpireAt, "x", "", "The last active epoch for the token")
 	createCmd.Flags().StringP(ownerFlag, "o", "", "Token owner")
 	createCmd.Flags().String(outFlag, "", "File to write token to")
 	createCmd.Flags().Bool(jsonFlag, false, "Output token in JSON")

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -66,7 +66,7 @@ var objectLockCmd = &cobra.Command{
 			exp = currEpoch + lifetime
 		}
 
-		common.PrintVerbose("Lock object will expire at %d epoch", exp)
+		common.PrintVerbose("Lock object will expire after %d epoch", exp)
 
 		var expirationAttr objectSDK.Attribute
 		expirationAttr.SetKey(objectV2.SysAttributeExpEpoch)
@@ -104,7 +104,7 @@ func initCommandObjectLock() {
 	ff.StringSlice(commonflags.OIDFlag, nil, commonflags.OIDFlagUsage)
 	_ = objectLockCmd.MarkFlagRequired(commonflags.OIDFlag)
 
-	ff.Uint64P(commonflags.ExpireAt, "e", 0, "Lock expiration epoch")
+	ff.Uint64P(commonflags.ExpireAt, "e", 0, "The last active epoch for the lock")
 
 	ff.Uint64(commonflags.Lifetime, 0, "Lock lifetime")
 	objectLockCmd.MarkFlagsMutuallyExclusive(commonflags.ExpireAt, commonflags.Lifetime)

--- a/cmd/neofs-cli/modules/object/put.go
+++ b/cmd/neofs-cli/modules/object/put.go
@@ -51,7 +51,7 @@ func initObjectPutCmd() {
 	flags.String("attributes", "", "User attributes in form of Key1=Value1,Key2=Value2")
 	flags.Bool("disable-filename", false, "Do not set well-known filename attribute")
 	flags.Bool("disable-timestamp", false, "Do not set well-known timestamp attribute")
-	flags.Uint64VarP(&putExpiredOn, commonflags.ExpireAt, "e", 0, "Last epoch in the life of the object")
+	flags.Uint64VarP(&putExpiredOn, commonflags.ExpireAt, "e", 0, "The last active epoch in the life of the object")
 	flags.Bool(noProgressFlag, false, "Do not show progress bar")
 
 	flags.String(notificationFlag, "", "Object notification in the form of *epoch*:*topic*; '-' topic means using default")

--- a/cmd/neofs-cli/modules/storagegroup/get.go
+++ b/cmd/neofs-cli/modules/storagegroup/get.go
@@ -67,7 +67,7 @@ func getSG(cmd *cobra.Command, _ []string) {
 	err = storagegroupSDK.ReadFromObject(&sg, *rawObj)
 	common.ExitOnErr(cmd, "could not read storage group from the obj: %w", err)
 
-	cmd.Printf("Expiration epoch: %d\n", sg.ExpirationEpoch())
+	cmd.Printf("The last active epoch: %d\n", sg.ExpirationEpoch())
 	cmd.Printf("Group size: %d\n", sg.ValidationDataSize())
 	common.PrintChecksum(cmd, "Group hash", sg.ValidationDataHash)
 


### PR DESCRIPTION
Closes #2097 and #2099

Signed-off-by: Anton Nikiforov <an.nikiforov@yadro.com>