### PR TITLE
Fix/`GETRANGEHASH` with session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changelog for NeoFS Node
 - Use `sync.Pool` in Object.PUT service (#2139)
 - Shard uses metabase for `HEAD` requests by default, not write-cache (#2167)
 - Clarify help for `--expire-at` parameter for commands `object lock/put` and `bearer create` (#2097)
+- Node spawns `GETRANGE` requests signed with the node's key if session key was not found for `RANGEHASH` (#2144) 
 
 ### Fixed
 - Open FSTree in sync mode by default (#1992)

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -109,6 +109,12 @@ func (exec execCtx) isChild(obj *objectSDK.Object) bool {
 }
 
 func (exec execCtx) key() (*ecdsa.PrivateKey, error) {
+	if exec.prm.signerKey != nil {
+		// the key has already been requested and
+		// cached in the previous operations
+		return exec.prm.signerKey, nil
+	}
+
 	var sessionInfo *util.SessionInfo
 
 	if tok := exec.prm.common.SessionToken(); tok != nil {

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -1,6 +1,7 @@
 package getsvc
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"hash"
 
@@ -74,6 +75,11 @@ type commonPrm struct {
 	raw bool
 
 	forwarder RequestForwarder
+
+	// signerKey is a cached key that should be used for spawned
+	// requests (if any), could be nil if incoming request handling
+	// routine does not include any key fetching operations
+	signerKey *ecdsa.PrivateKey
 }
 
 // ChunkWriter is an interface of target component
@@ -143,6 +149,11 @@ func (p *commonPrm) WithAddress(addr oid.Address) {
 // WithRawFlag sets flag of raw reading.
 func (p *commonPrm) WithRawFlag(raw bool) {
 	p.raw = raw
+}
+
+// WithCachedSignerKey sets optional key for all further requests.
+func (p *commonPrm) WithCachedSignerKey(signerKey *ecdsa.PrivateKey) {
+	p.signerKey = signerKey
 }
 
 // SetHeaderWriter sets target component to write the object header.

--- a/pkg/services/object/util/key.go
+++ b/pkg/services/object/util/key.go
@@ -51,10 +51,13 @@ type SessionInfo struct {
 	Owner user.ID
 }
 
-// GetKey returns private key of the node.
+// GetKey fetches private key depending on the SessionInfo.
 //
-// If token is not nil, session private key is returned.
-// Otherwise, node private key is returned.
+// If info is not `nil`, searches for dynamic session token through the
+// underlying token storage. Returns apistatus.SessionTokenNotFound if
+// token storage does not contain information about provided dynamic session.
+//
+// If info is `nil`, returns node's private key.
 func (s *KeyStorage) GetKey(info *SessionInfo) (*ecdsa.PrivateKey, error) {
 	if info != nil {
 		binID, err := info.ID.MarshalBinary()


### PR DESCRIPTION
Closes #2144.

Could not come up with a better than [comment](https://github.com/nspcc-dev/neofs-node/issues/2144#issuecomment-1357759999) solution. If fact, i was surprised that `GETRANGEHASH` spawns `GETRANGE` requests.

I think we can localize all the places when a node signs a new request to minimize such unexpected bugs.