### PR TITLE
Improve FSTree behaviour for partially written objects

### DIFF
--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -239,16 +239,17 @@ func (t *FSTree) Put(prm common.PutPrm) (common.PutRes, error) {
 		prm.RawData = t.Compress(prm.RawData)
 	}
 
-	err := t.writeFile(p, prm.RawData)
+	tmpPath := p + "#"
+	err := t.writeFile(tmpPath, prm.RawData)
 	if err != nil {
 		var pe *fs.PathError
 		if errors.As(err, &pe) && pe.Err == syscall.ENOSPC {
 			err = common.ErrNoSpace
-			_ = os.RemoveAll(p)
+			_ = os.RemoveAll(tmpPath)
 		}
 	}
 
-	return common.PutRes{StorageID: []byte{}}, err
+	return common.PutRes{StorageID: []byte{}}, os.Rename(tmpPath, p)
 }
 
 func (t *FSTree) writeFlags() int {

--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -244,6 +244,7 @@ func (t *FSTree) Put(prm common.PutPrm) (common.PutRes, error) {
 		var pe *fs.PathError
 		if errors.As(err, &pe) && pe.Err == syscall.ENOSPC {
 			err = common.ErrNoSpace
+			_ = os.RemoveAll(p)
 		}
 	}
 

--- a/pkg/local_object_storage/engine/evacuate.go
+++ b/pkg/local_object_storage/engine/evacuate.go
@@ -82,6 +82,8 @@ func (e *StorageEngine) Evacuate(prm EvacuateShardPrm) (EvacuateShardRes, error)
 		return EvacuateShardRes{}, errMustHaveTwoShards
 	}
 
+	e.log.Info("started shards evacuation", zap.Strings("shard_ids", sidList))
+
 	// We must have all shards, to have correct information about their
 	// indexes in a sorted slice and set appropriate marks in the metabase.
 	// Evacuated shard is skipped during put.
@@ -185,5 +187,7 @@ mainLoop:
 		}
 	}
 
+	e.log.Info("finished shards evacuation",
+		zap.Strings("shard_ids", sidList))
 	return res, nil
 }

--- a/pkg/local_object_storage/shard/mode.go
+++ b/pkg/local_object_storage/shard/mode.go
@@ -3,6 +3,7 @@ package shard
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
+	"go.uber.org/zap"
 )
 
 // ErrReadOnlyMode is returned when it is impossible to apply operation
@@ -24,6 +25,10 @@ func (s *Shard) SetMode(m mode.Mode) error {
 }
 
 func (s *Shard) setMode(m mode.Mode) error {
+	s.log.Info("setting shard mode",
+		zap.Stringer("old_mode", s.info.Mode),
+		zap.Stringer("new_mode", m))
+
 	components := []interface{ SetMode(mode.Mode) error }{
 		s.metaBase, s.blobStor,
 	}
@@ -61,6 +66,8 @@ func (s *Shard) setMode(m mode.Mode) error {
 		s.metricsWriter.SetReadonly(s.info.Mode != mode.ReadWrite)
 	}
 
+	s.log.Info("shard mode set successfully",
+		zap.Stringer("mode", s.info.Mode))
 	return nil
 }
 


### PR DESCRIPTION
1. Partially written object is deleted.
2. First write to a temporary file to avoid partially written files during hard-reset

Also, log time-consuming operations to help administrator observe system behaviour until we have a proper async operations support in `control` service.