### PR TITLE
Tree service fixes

### DIFF
--- a/pkg/local_object_storage/pilorama/batch.go
+++ b/pkg/local_object_storage/pilorama/batch.go
@@ -34,8 +34,9 @@ func (b *batch) run() {
 	sort.Slice(b.operations, func(i, j int) bool {
 		return b.operations[i].Time < b.operations[j].Time
 	})
+	fullID := bucketName(b.cid, b.treeID)
 	err := b.forest.db.Update(func(tx *bbolt.Tx) error {
-		bLog, bTree, err := b.forest.getTreeBuckets(tx, b.cid, b.treeID)
+		bLog, bTree, err := b.forest.getTreeBuckets(tx, fullID)
 		if err != nil {
 			return err
 		}

--- a/pkg/local_object_storage/pilorama/forest.go
+++ b/pkg/local_object_storage/pilorama/forest.go
@@ -44,7 +44,7 @@ func (f *memoryForest) TreeMove(d CIDDescriptor, treeID string, op *Move) (*LogM
 
 	lm := s.do(op)
 	s.operations = append(s.operations, lm)
-	return &lm, nil
+	return &lm.Move, nil
 }
 
 // TreeAddByPath implements the Forest interface.
@@ -66,20 +66,21 @@ func (f *memoryForest) TreeAddByPath(d CIDDescriptor, treeID string, attr string
 	i, node := s.getPathPrefix(attr, path)
 	lm := make([]LogMove, len(path)-i+1)
 	for j := i; j < len(path); j++ {
-		lm[j-i] = s.do(&Move{
+		op := s.do(&Move{
 			Parent: node,
 			Meta: Meta{
 				Time:  s.timestamp(d.Position, d.Size),
 				Items: []KeyValue{{Key: attr, Value: []byte(path[j])}}},
 			Child: s.findSpareID(),
 		})
-		node = lm[j-i].Child
-		s.operations = append(s.operations, lm[j-i])
+		lm[j-i] = op.Move
+		node = op.Child
+		s.operations = append(s.operations, op)
 	}
 
 	mCopy := make([]KeyValue, len(m))
 	copy(mCopy, m)
-	lm[len(lm)-1] = s.do(&Move{
+	op := s.do(&Move{
 		Parent: node,
 		Meta: Meta{
 			Time:  s.timestamp(d.Position, d.Size),
@@ -87,6 +88,7 @@ func (f *memoryForest) TreeAddByPath(d CIDDescriptor, treeID string, attr string
 		},
 		Child: s.findSpareID(),
 	})
+	lm[len(lm)-1] = op.Move
 	return lm, nil
 }
 

--- a/pkg/local_object_storage/pilorama/inmemory.go
+++ b/pkg/local_object_storage/pilorama/inmemory.go
@@ -6,9 +6,15 @@ type nodeInfo struct {
 	Meta   Meta
 }
 
+type move struct {
+	Move
+	HasOld bool
+	Old    nodeInfo
+}
+
 // state represents state being replicated.
 type state struct {
-	operations []LogMove
+	operations []move
 	tree
 }
 
@@ -20,7 +26,7 @@ func newState() *state {
 }
 
 // undo un-does op and changes s in-place.
-func (s *state) undo(op *LogMove) {
+func (s *state) undo(op *move) {
 	children := s.tree.childMap[op.Parent]
 	for i := range children {
 		if children[i] == op.Child {
@@ -76,8 +82,8 @@ func (s *state) Apply(op *Move) error {
 }
 
 // do performs a single move operation on a tree.
-func (s *state) do(op *Move) LogMove {
-	lm := LogMove{
+func (s *state) do(op *Move) move {
+	lm := move{
 		Move: Move{
 			Parent: op.Parent,
 			Meta:   op.Meta,

--- a/pkg/local_object_storage/pilorama/types.go
+++ b/pkg/local_object_storage/pilorama/types.go
@@ -36,11 +36,7 @@ type Move struct {
 }
 
 // LogMove represents log record for a single move operation.
-type LogMove struct {
-	Move
-	HasOld bool
-	Old    nodeInfo
-}
+type LogMove = Move
 
 const (
 	// RootID represents the ID of a root node.

--- a/pkg/services/tree/replicator.go
+++ b/pkg/services/tree/replicator.go
@@ -148,7 +148,7 @@ func (s *Service) pushToQueue(cid cidSDK.ID, treeID string, op *pilorama.LogMove
 		treeID: treeID,
 		op:     op,
 	}:
-	case <-s.closeCh:
+	default:
 	}
 }
 

--- a/pkg/services/tree/service.go
+++ b/pkg/services/tree/service.go
@@ -485,7 +485,8 @@ func (s *Service) Apply(_ context.Context, req *ApplyRequest) (*ApplyResponse, e
 		return nil, fmt.Errorf("can't parse meta-information: %w", err)
 	}
 
-	s.replicateLocalCh <- applyOp{
+	select {
+	case s.replicateLocalCh <- applyOp{
 		treeID:        req.GetBody().GetTreeId(),
 		CIDDescriptor: pilorama.CIDDescriptor{CID: cid, Position: pos, Size: size},
 		Move: pilorama.Move{
@@ -493,6 +494,8 @@ func (s *Service) Apply(_ context.Context, req *ApplyRequest) (*ApplyResponse, e
 			Child:  op.GetChildId(),
 			Meta:   meta,
 		},
+	}:
+	default:
 	}
 	return &ApplyResponse{Body: &ApplyResponse_Body{}, Signature: &Signature{}}, nil
 }


### PR DESCRIPTION
Currently under consistent high load for >30m the performance degrade. The number of goroutines also increases (up to ~60k).
In think PR we do 2 things:
1. Simplify DB layout (this speeds up all transactions and reduces degradation)
2. Use non-blocking send (fix goroutine unbounded increase)