### PR TITLE
Fix/Do not return expired objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Do not search for the small objects in FSTree (#2206)
 - Correct status error for expired session token (#2207)
 - Restore subscriptions correctly on morph client switch (#2212)
+- Expired objects could be returned if not marked with GC yet (#2213)
 
 ### Removed
 ### Updated


### PR DESCRIPTION
"Object is expired" means that object is presented in `meta` but it is not `ObjectNotFound` error. Previous implementation made `shard` search for an object without `meta` which was an error.

Signed-off-by: Pavel Karpy <p.karpy@yadro.com>