### PR TITLE
adm: use native neo-go sessions in `dump-hashes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - Correct status error for expired session token (#2207)
 - Restore subscriptions correctly on morph client switch (#2212)
 - Expired objects could be returned if not marked with GC yet (#2213)
+- `neofs-adm morph dump-hashes` now properly iterates over custom domain (#2224)
 
 ### Removed
 ### Updated


### PR DESCRIPTION
If we had lots of domains in one zone, `dump-hashes` for all others can miss some domains, because we need to restrict ourselves with _some_ number.
In this commit we use neo-go sessions by default, with a proper failback to in-script iterator unwrapping.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>