### PR TITLE
node: Increase default replication timeout to 1 minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - `common.PrintVerbose` prints via `cobra.Command.Printf` (#1962)
+- Storage node's `replicator.put_timeout` config default to `1m` (#2227)
 
 ### Fixed
 ### Removed

--- a/cmd/neofs-node/config/replicator/config.go
+++ b/cmd/neofs-node/config/replicator/config.go
@@ -10,7 +10,7 @@ const (
 	subsection = "replicator"
 
 	// PutTimeoutDefault is a default timeout of object put request in replicator.
-	PutTimeoutDefault = 5 * time.Second
+	PutTimeoutDefault = time.Minute
 )
 
 // PutTimeout returns the value of "put_timeout" config parameter

--- a/config/example/node.yaml
+++ b/config/example/node.yaml
@@ -103,7 +103,7 @@ policer:
   head_timeout: 15s  # timeout for the Policer HEAD remote operation
 
 replicator:
-  put_timeout: 15s  # timeout for the Replicator PUT remote operation
+  put_timeout: 15s  # timeout for the Replicator PUT remote operation (defaults to 1m)
   pool_size: 10     # maximum amount of concurrent replications
 
 object:

--- a/docs/storage-node-configuration.md
+++ b/docs/storage-node-configuration.md
@@ -411,7 +411,7 @@ replicator:
 
 | Parameter     | Type       | Default value                          | Description                                 |
 |---------------|------------|----------------------------------------|---------------------------------------------|
-| `put_timeout` | `duration` | `5s`                                   | Timeout for performing the `PUT` operation. |
+| `put_timeout` | `duration` | `1m`                                   | Timeout for performing the `PUT` operation. |
 | `pool_size`   | `int`      | Equal to `object.put.pool_size_remote` | Maximum amount of concurrent replications.  |
 
 # `object` section


### PR DESCRIPTION
Inspired by MainNet. "Fast" networks are considered more rare and requiring detailed configuration.