### PR TITLE
engine: Add tests for initialization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - Pilorama now can merge multiple batches into one (#2231)
+- Storage engine now can start even when some shard components are unavailable (#2238)
 
 ### Fixed
 - Big object removal with non-local parts (#1978)

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -255,9 +255,11 @@ func (s *Shard) Close() error {
 
 	components = append(components, s.blobStor, s.metaBase)
 
+	var lastErr error
 	for _, component := range components {
 		if err := component.Close(); err != nil {
-			return fmt.Errorf("could not close %s: %w", component, err)
+			lastErr = err
+			s.log.Error("could not close shard component", zap.Error(err))
 		}
 	}
 
@@ -266,7 +268,7 @@ func (s *Shard) Close() error {
 		s.gc.stop()
 	}
 
-	return nil
+	return lastErr
 }
 
 // Reload reloads configuration portions that are necessary.


### PR DESCRIPTION
Fix bugs along the way.
Invalid mode on a directory is an approximation of missing media.
We expect any `Open`/`Init` errors to be logged and a shard to be disabled.