### PR TITLE
writecache: fix possible deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for NeoFS Node
 - Restore subscriptions correctly on morph client switch (#2212)
 - Expired objects could be returned if not marked with GC yet (#2213)
 - `neofs-adm morph dump-hashes` now properly iterates over custom domain (#2224)
+- Possible deadlock in write-cache (#2239)
 
 ### Removed
 ### Updated

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -23,6 +23,11 @@ type store struct {
 	maxFlushedMarksCount int
 	maxRemoveBatchSize   int
 
+	// flushed contains addresses of objects that were already flushed to the main storage.
+	// We use LRU cache instead of map here to facilitate removing of unused object in favour of
+	// frequently read ones.
+	// MUST NOT be used inside bolt db transaction because it's eviction handler
+	// removes untracked items from the database.
 	flushed simplelru.LRUCache
 	db      *bbolt.DB
 


### PR DESCRIPTION
Here is a scenario:
1. Read from `flushed` inside of a `View` transaction.
2. Eviction handler in other goroutine deletes items from the database which can lead to allocating new storage for mmap.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>