### PR TITLE
cli: Fix default buffer size for object PUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 ### Changed
 - Pilorama now can merge multiple batches into one (#2231)
 - Storage engine now can start even when some shard components are unavailable (#2238)
+- `neofs-cli` buffer for object put increased from 4 KiB to 3 MiB (#2243)
 
 ### Fixed
 - Big object removal with non-local parts (#1978)

--- a/cmd/neofs-cli/internal/client/client.go
+++ b/cmd/neofs-cli/internal/client/client.go
@@ -404,8 +404,7 @@ func PutObject(prm PutObjectPrm) (*PutObjectRes, error) {
 		}
 
 		if prm.rdr != nil {
-			// TODO: (neofs-node#1198) explore better values or configure it
-			const defaultBufferSizePut = 4096
+			const defaultBufferSizePut = 3 << 20 // Maximum chunk size is 3 MiB in the SDK.
 
 			if sz == 0 || sz > defaultBufferSizePut {
 				sz = defaultBufferSizePut


### PR DESCRIPTION
Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>

200MB object put time went down from 30s to 5s. Basically server spent _too_ much time verifying signatures.