### PR TITLE
Fix/Multi client error reporting

### DIFF
--- a/pkg/core/client/client.go
+++ b/pkg/core/client/client.go
@@ -33,6 +33,8 @@ type MultiAddressClient interface {
 	// RawForAddress must return rawclient.Client
 	// for the passed network.Address.
 	RawForAddress(network.Address, func(cli *rawclient.Client) error) error
+
+	ReportError(error)
 }
 
 // NodeInfo groups information about a NeoFS storage node needed for Client construction.


### PR DESCRIPTION
Missing `ReportError` method did not allow casing multi-client interface to `errorReporter` interface and dropping broken connections. Multi-client scheme is extremely hard to maintain, it makes unpredictable casts and does not allow tracking code flow, so it will be refactored in the future anyway.

Signed-off-by: Pavel Karpy <p.karpy@yadro.com>