### PR TITLE
[#2234] writecache: Fix possible panic in `initFlushMarks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog for NeoFS Node
 - Fix `*_req_count` and `*_req_count_success` metric values (#2241)
 - Storage ID update by write-cache (#2244)
 - `neo-go` client deadlock on subscription restoration (#2244)
+- Possible panic during write-cache initialization (#2234)
 
 ### Removed
 ### Updated

--- a/pkg/local_object_storage/writecache/init.go
+++ b/pkg/local_object_storage/writecache/init.go
@@ -46,6 +46,7 @@ func (c *cache) initFlushMarks() {
 	var batchSize = flushBatchSize
 	for {
 		m = m[:0]
+		indices = indices[:0]
 
 		// We put objects in batches of fixed size to not interfere with main put cycle a lot.
 		_ = c.db.View(func(tx *bbolt.Tx) error {


### PR DESCRIPTION
Fix #2234.

In case we have many small objects in the write-cache, `indices` should not be reused between iterations.

Signed-off-by: Evgenii Stratonikov <e.stratonikov@yadro.com>