### PR TITLE
cli/util: Fix basic ACL rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog for NeoFS Node
 - Storage node's `replicator.put_timeout` config default to `1m` (#2227)
 
 ### Fixed
+- Pretty printer of basic ACL in the NeoFS CLI (#2259)
+
 ### Removed
 ### Updated
 - `neo-go` to `v0.100.1`

--- a/cmd/neofs-cli/modules/util/acl.go
+++ b/cmd/neofs-cli/modules/util/acl.go
@@ -24,7 +24,7 @@ func PrettyPrintTableBACL(cmd *cobra.Command, bacl *acl.Basic) {
 	fmt.Fprintln(w, "\tRangeHASH\tRange\tSearch\tDelete\tPut\tHead\tGet")
 	// Bits
 	bits := []string{
-		boolToString(bacl.Sticky()) + " " + boolToString(bacl.Extendable()),
+		boolToString(bacl.Sticky()) + " " + boolToString(!bacl.Extendable()),
 		getRoleBitsForOperation(bacl, acl.OpObjectHash), getRoleBitsForOperation(bacl, acl.OpObjectRange),
 		getRoleBitsForOperation(bacl, acl.OpObjectSearch), getRoleBitsForOperation(bacl, acl.OpObjectDelete),
 		getRoleBitsForOperation(bacl, acl.OpObjectPut), getRoleBitsForOperation(bacl, acl.OpObjectHead),
@@ -47,7 +47,7 @@ func getRoleBitsForOperation(bacl *acl.Basic, op acl.Op) string {
 	return boolToString(bacl.IsOpAllowed(op, acl.RoleOwner)) + " " +
 		boolToString(bacl.IsOpAllowed(op, acl.RoleContainer)) + " " +
 		boolToString(bacl.IsOpAllowed(op, acl.RoleOthers)) + " " +
-		boolToString(bacl.IsOpAllowed(op, acl.RoleInnerRing))
+		boolToString(bacl.AllowedBearerRules(op))
 }
 
 func boolToString(b bool) string {


### PR DESCRIPTION
Zero value before:
```
       RangeHASH    Range      Search     Delete     Put        Head       Get
0 1    0 1 0 1      0 0 0 0    0 1 0 1    0 0 0 0    0 1 0 0    0 1 0 1    0 1 0 1
X F    U S O B      U S O B    U S O B    U S O B    U S O B    U S O B    U S O B
  X-Sticky F-Final U-User S-System O-Others B-Bearer
```
Now:
```
       RangeHASH    Range      Search     Delete     Put        Head       Get
0 0    0 1 0 0      0 0 0 0    0 1 0 0    0 0 0 0    0 1 0 0    0 1 0 0    0 1 0 0
X F    U S O B      U S O B    U S O B    U S O B    U S O B    U S O B    U S O B
  X-Sticky F-Final U-User S-System O-Others B-Bearer
```