### PR TITLE
Fixes for a failover scenario.

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -342,9 +342,10 @@ type shared struct {
 	privateTokenStore sessionStorage
 	persistate        *state.PersistentStorage
 
-	clientCache   *cache.ClientCache
-	bgClientCache *cache.ClientCache
-	localAddr     network.AddressGroup
+	clientCache    *cache.ClientCache
+	bgClientCache  *cache.ClientCache
+	putClientCache *cache.ClientCache
+	localAddr      network.AddressGroup
 
 	key            *keys.PrivateKey
 	binPublicKey   []byte
@@ -570,13 +571,14 @@ func initCfg(appCfg *config.Config) *cfg {
 		ReconnectTimeout: apiclientconfig.ReconnectTimeout(appCfg),
 	}
 	c.shared = shared{
-		key:           key,
-		binPublicKey:  key.PublicKey().Bytes(),
-		localAddr:     netAddr,
-		respSvc:       response.NewService(response.WithNetworkState(netState)),
-		clientCache:   cache.NewSDKClientCache(cacheOpts),
-		bgClientCache: cache.NewSDKClientCache(cacheOpts),
-		persistate:    persistate,
+		key:            key,
+		binPublicKey:   key.PublicKey().Bytes(),
+		localAddr:      netAddr,
+		respSvc:        response.NewService(response.WithNetworkState(netState)),
+		clientCache:    cache.NewSDKClientCache(cacheOpts),
+		bgClientCache:  cache.NewSDKClientCache(cacheOpts),
+		putClientCache: cache.NewSDKClientCache(cacheOpts),
+		persistate:     persistate,
 	}
 	c.cfgAccounting = cfgAccounting{
 		scriptHash: contractsconfig.Balance(appCfg),
@@ -615,8 +617,9 @@ func initCfg(appCfg *config.Config) *cfg {
 		netState.metrics = c.metricsCollector
 	}
 
-	c.onShutdown(c.clientCache.CloseAll)   // clean up connections
-	c.onShutdown(c.bgClientCache.CloseAll) // clean up connections
+	c.onShutdown(c.clientCache.CloseAll)    // clean up connections
+	c.onShutdown(c.bgClientCache.CloseAll)  // clean up connections
+	c.onShutdown(c.putClientCache.CloseAll) // clean up connections
 	c.onShutdown(func() { _ = c.persistate.Close() })
 
 	return c

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -182,6 +182,14 @@ func initObjectService(c *cfg) {
 		basicConstructor: c.clientCache,
 	}
 
+	putConstructor := &coreClientConstructor{
+		log:              c.log,
+		nmSrc:            c.netMapSource,
+		netState:         c.cfgNetmap.state,
+		trustStorage:     c.cfgReputation.localTrustStorage,
+		basicConstructor: c.putClientCache,
+	}
+
 	var irFetcher v2.InnerRingFetcher
 
 	if c.cfgMorph.client.ProbeNotary() {
@@ -255,7 +263,7 @@ func initObjectService(c *cfg) {
 
 	sPut := putsvc.NewService(
 		putsvc.WithKeyStorage(keyStorage),
-		putsvc.WithClientConstructor(coreConstructor),
+		putsvc.WithClientConstructor(putConstructor),
 		putsvc.WithMaxSizeSource(newCachedMaxObjectSizeSource(c)),
 		putsvc.WithObjectStorage(os),
 		putsvc.WithContainerSource(c.cfgObject.cnrSource),

--- a/pkg/network/cache/multi.go
+++ b/pkg/network/cache/multi.go
@@ -202,7 +202,6 @@ func (s *singleClient) invalidate() {
 		_ = s.client.Close()
 	}
 	s.client = nil
-	s.lastAttempt = time.Now()
 	s.Unlock()
 }
 

--- a/pkg/network/cache/multi.go
+++ b/pkg/network/cache/multi.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/network"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type singleClient struct {
@@ -169,6 +171,10 @@ func (x *multiClient) iterateClients(ctx context.Context, f func(clientcore.Clie
 
 func (x *multiClient) ReportError(err error) {
 	if errors.Is(err, errRecentlyFailed) {
+		return
+	}
+
+	if status.Code(err) == codes.Canceled || errors.Is(err, context.Canceled) {
 		return
 	}
 

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -128,7 +128,7 @@ func (exec execCtx) key() (*ecdsa.PrivateKey, error) {
 }
 
 func (exec *execCtx) canAssemble() bool {
-	return exec.svc.assembly && !exec.isRaw() && !exec.headOnly()
+	return exec.svc.assembly && !exec.isRaw() && !exec.headOnly() && !exec.isLocal()
 }
 
 func (exec *execCtx) splitInfo() *objectSDK.SplitInfo {

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -141,6 +141,11 @@ func (t *distributedTarget) Close() (*transformer.AccessIdentifiers, error) {
 		return nil, fmt.Errorf("(%T) could not validate payload content: %w", t, err)
 	}
 
+	if len(t.obj.Children()) > 0 {
+		// enabling extra broadcast for linking objects
+		t.traversal.extraBroadcastEnabled = true
+	}
+
 	return t.iteratePlacement(t.sendObject)
 }
 


### PR DESCRIPTION
In master:
`network/cache`-related changes will be replaced with gRPC-native keepalive mechanism.
Client cache separation should be approached more rigourously. It seems like a good idea, but we need to evaluate it further.