### PR TITLE
Fix potential data loss in `Policer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Pretty printer of basic ACL in the NeoFS CLI (#2259)
 - Failing SN and IR transactions because of incorrect scopes (#2230, #2263)
 - Global scope used for some transactions (#2230, #2263)
+- Potential data loss from nodes outside the container or netmap (#2267)
 
 ### Removed
 ### Updated

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -354,6 +354,9 @@ type shared struct {
 	netMap       atomicstd.Value // type netmap.NetMap
 	netMapSource netmapCore.Source
 
+	// whether the local node is in the netMap
+	localNodeInNetmap atomic.Bool
+
 	cnrClient *containerClient.Client
 
 	respSvc *response.Service
@@ -854,6 +857,7 @@ func (c *cfg) LocalNodeInfo() (*netmapV2.NodeInfo, error) {
 // (before entering the network and after leaving it).
 func (c *cfg) handleLocalNodeInfo(ni *netmap.NodeInfo) {
 	c.cfgNetmap.state.setNodeInfo(ni)
+	c.localNodeInNetmap.Store(ni != nil)
 }
 
 // bootstrapWithState calls "addPeer" method of the Sidechain Netmap contract

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -162,6 +162,12 @@ func (x *coreClientConstructor) Get(info coreclient.NodeInfo) (coreclient.MultiA
 	return c.(coreclient.MultiAddressClient), nil
 }
 
+// IsLocalNodeInNetmap looks for the local node in the latest view of the
+// network map.
+func (c *cfg) IsLocalNodeInNetmap() bool {
+	return c.localNodeInNetmap.Load()
+}
+
 func initObjectService(c *cfg) {
 	ls := c.cfgObject.cfgLocalStorage.localStorage
 	keyStorage := util.NewKeyStorage(&c.key.PrivateKey, c.privateTokenStore, c.cfgNetmap.state)
@@ -234,6 +240,7 @@ func initObjectService(c *cfg) {
 		policer.WithMaxCapacity(c.cfgObject.pool.replicatorPoolSize),
 		policer.WithPool(c.cfgObject.pool.replication),
 		policer.WithNodeLoader(c),
+		policer.WithNetwork(c),
 	)
 
 	traverseGen := util.NewTraverserGenerator(c.netMapSource, c.cfgObject.cnrSource, c)

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -111,11 +111,6 @@ func (p *Policer) processObject(ctx context.Context, addrWithType objectcore.Add
 		checkedNodes: newNodeCache(),
 	}
 
-	var numOfContainerNodes int
-	for i := range nn {
-		numOfContainerNodes += len(nn[i])
-	}
-
 	for i := range nn {
 		select {
 		case <-ctx.Done():

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -150,9 +150,7 @@ type processPlacementContext struct {
 }
 
 func (p *Policer) processNodes(ctx *processPlacementContext, nodes []netmap.NodeInfo, shortage uint32) {
-	addr := ctx.object.Address
-	typ := ctx.object.Type
-	prm := new(headsvc.RemoteHeadPrm).WithObjectAddress(addr)
+	prm := new(headsvc.RemoteHeadPrm).WithObjectAddress(ctx.object.Address)
 
 	// Number of copies that are stored on maintenance nodes.
 	var uncheckedCopies int
@@ -172,7 +170,7 @@ func (p *Policer) processNodes(ctx *processPlacementContext, nodes []netmap.Node
 		)
 	}
 
-	if typ == object.TypeLock {
+	if ctx.object.Type == object.TypeLock {
 		// all nodes of a container must store the `LOCK` objects
 		// for correct object removal protection:
 		//   - `LOCK` objects are broadcast on their PUT requests;
@@ -220,7 +218,7 @@ func (p *Policer) processNodes(ctx *processPlacementContext, nodes []netmap.Node
 				handleMaintenance(nodes[i])
 			} else if err != nil {
 				p.log.Error("receive object header to check policy compliance",
-					zap.Stringer("object", addr),
+					zap.Stringer("object", ctx.object.Address),
 					zap.String("error", err.Error()),
 				)
 			} else {
@@ -235,12 +233,12 @@ func (p *Policer) processNodes(ctx *processPlacementContext, nodes []netmap.Node
 
 	if shortage > 0 {
 		p.log.Debug("shortage of object copies detected",
-			zap.Stringer("object", addr),
+			zap.Stringer("object", ctx.object.Address),
 			zap.Uint32("shortage", shortage),
 		)
 
 		var task replicator.Task
-		task.SetObjectAddress(addr)
+		task.SetObjectAddress(ctx.object.Address)
 		task.SetNodes(nodes)
 		task.SetCopiesNumber(shortage)
 

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -127,6 +127,13 @@ func (p *Policer) processObject(ctx context.Context, addrWithType objectcore.Add
 		p.processNodes(c, addrWithType, nn[i], policy.ReplicaNumberByIndex(i), checkedNodes)
 	}
 
+	// if context is done, needLocalCopy might not be able to calculate
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
 	if !c.needLocalCopy {
 		p.log.Info("redundant local object copy detected",
 			zap.Stringer("object", addr),

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -65,6 +65,14 @@ type Option func(*cfg)
 // the redundant local copy of the object.
 type RedundantCopyCallback func(oid.Address)
 
+// Network provides information about the NeoFS network to Policer for work.
+type Network interface {
+	// IsLocalNodeInNetmap checks whether the local node belongs to the current
+	// network map. If it is impossible to check this fact, IsLocalNodeInNetmap
+	// returns false.
+	IsLocalNodeInNetmap() bool
+}
+
 type cfg struct {
 	headTimeout time.Duration
 
@@ -93,6 +101,8 @@ type cfg struct {
 	batchSize, cacheSize uint32
 
 	rebalanceFreq, evictDuration time.Duration
+
+	network Network
 }
 
 func defaultCfg() *cfg {
@@ -214,5 +224,12 @@ func WithPool(p *ants.Pool) Option {
 func WithNodeLoader(l nodeLoader) Option {
 	return func(c *cfg) {
 		c.loader = l
+	}
+}
+
+// WithNetwork provides Network component.
+func WithNetwork(n Network) Option {
+	return func(c *cfg) {
+		c.network = n
 	}
 }


### PR DESCRIPTION
* closes #2267
* closes #1453

I decided to not directly implement #1453 proposal:
* out-of-container (netmap) cases are handled in a special way
* insta replica removal after successful replication doesn't seem very good behavior: some nodes have been already violated storage policy and lost the object, therefore, it is worth waiting for some time interval, and make a decision already at the next check