### PR TITLE
.github: remove 'community' from default issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: community, triage
+labels: triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: community, triage
+labels: triage
 assignees: ''
 
 ---


### PR DESCRIPTION
 * it makes zero sense
 * we treat all issues equal
 * most of them come from NSPCC