### PR TITLE
IR: Do not set default value for Sidechain RPC endpoints in Viper

### DIFF
--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -47,7 +47,6 @@ func defaultConfiguration(cfg *viper.Viper) {
 
 	cfg.SetDefault("node.persistent_state.path", ".neofs-ir-state")
 
-	cfg.SetDefault("morph.endpoint.client", []string{})
 	cfg.SetDefault("morph.dial_timeout", 15*time.Second)
 	cfg.SetDefault("morph.validators", []string{})
 	cfg.SetDefault("morph.switch_interval", 2*time.Minute)


### PR DESCRIPTION
* continues #2298