### PR TITLE
(almost) Stop using deprecated subscription NeoGo APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Storage node hanging after RPC disconnect (#2304)
 - Using deprecated NeoGo APIs (#2219)
+- Storage node panicking on exit (#2308)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog for NeoFS Node
 ### Changed
 
 ### Fixed
+- Storage node hanging after RPC disconnect (#2304)
+- Using deprecated NeoGo APIs (#2219)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for NeoFS Node
 - Storage node hanging after RPC disconnect (#2304)
 - Using deprecated NeoGo APIs (#2219)
 - Storage node panicking on exit (#2308)
+- Inner ring node panic on exit if internal CN is not enabled (#2308)
 
 ### Removed
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -559,7 +559,7 @@ func initCfg(appCfg *config.Config) *cfg {
 	c.internals = internals{
 		ctx:          context.Background(),
 		appCfg:       appCfg,
-		internalErr:  make(chan error),
+		internalErr:  make(chan error, 10), // We only need one error, but we can have multiple senders.
 		log:          log,
 		wg:           new(sync.WaitGroup),
 		apiVersion:   version.Current(),

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -299,7 +299,9 @@ func (s *Server) Stop() {
 		}
 	}
 
-	s.bc.Stop()
+	if s.bc != nil {
+		s.bc.Stop()
+	}
 }
 
 func (s *Server) registerNoErrCloser(c func()) {

--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -490,7 +490,7 @@ func (c *Client) IsValidScript(script []byte, signers []transaction.Signer) (res
 // notification from the connected RPC node.
 // Channel is closed when connection to the RPC node is lost.
 func (c *Client) NotificationChannel() <-chan rpcclient.Notification {
-	return c.client.Notifications
+	return c.client.Notifications //nolint:staticcheck // SA1019: c.client.Notifications is deprecated
 }
 
 func (c *Client) setActor(act *actor.Actor) {

--- a/pkg/morph/client/client.go
+++ b/pkg/morph/client/client.go
@@ -67,16 +67,8 @@ type Client struct {
 	// on every normal call.
 	switchLock *sync.RWMutex
 
-	// channel for ws notifications
-	notifications chan rpcclient.Notification
-
 	// channel for internal stop
 	closeChan chan struct{}
-
-	// cached subscription information
-	subscribedEvents       map[util.Uint160]string
-	subscribedNotaryEvents map[util.Uint160]string
-	subscribedToNewBlocks  bool
 
 	// indicates that Client is not able to
 	// establish connection to any of the
@@ -496,26 +488,9 @@ func (c *Client) IsValidScript(script []byte, signers []transaction.Signer) (res
 
 // NotificationChannel returns channel than receives subscribed
 // notification from the connected RPC node.
-// Channel is closed when connection to the RPC node has been
-// lost without the possibility of recovery.
+// Channel is closed when connection to the RPC node is lost.
 func (c *Client) NotificationChannel() <-chan rpcclient.Notification {
-	return c.notifications
-}
-
-// inactiveMode switches Client to an inactive mode:
-// - notification channel is closed;
-// - all the new RPC request would return ErrConnectionLost;
-// - inactiveModeCb is called if not nil.
-func (c *Client) inactiveMode() {
-	c.switchLock.Lock()
-	defer c.switchLock.Unlock()
-
-	close(c.notifications)
-	c.inactive = true
-
-	if c.cfg.inactiveModeCb != nil {
-		c.cfg.inactiveModeCb()
-	}
+	return c.client.Notifications
 }
 
 func (c *Client) setActor(act *actor.Actor) {

--- a/pkg/morph/client/constructor.go
+++ b/pkg/morph/client/constructor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/actor"
-	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/nspcc-dev/neofs-node/pkg/util/logger"
 	"go.uber.org/zap"
@@ -97,16 +96,13 @@ func New(key *keys.PrivateKey, opts ...Option) (*Client, error) {
 	}
 
 	cli := &Client{
-		cache:                  newClientCache(),
-		logger:                 cfg.logger,
-		acc:                    acc,
-		accAddr:                accAddr,
-		cfg:                    *cfg,
-		switchLock:             &sync.RWMutex{},
-		notifications:          make(chan rpcclient.Notification),
-		subscribedEvents:       make(map[util.Uint160]string),
-		subscribedNotaryEvents: make(map[util.Uint160]string),
-		closeChan:              make(chan struct{}),
+		cache:      newClientCache(),
+		logger:     cfg.logger,
+		acc:        acc,
+		accAddr:    accAddr,
+		cfg:        *cfg,
+		switchLock: &sync.RWMutex{},
+		closeChan:  make(chan struct{}),
 	}
 
 	var err error
@@ -139,7 +135,7 @@ func New(key *keys.PrivateKey, opts ...Option) (*Client, error) {
 	}
 	cli.setActor(act)
 
-	go cli.notificationLoop()
+	go cli.closeWaiter()
 
 	return cli, nil
 }

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -228,9 +228,6 @@ loop:
 				l.log.Warn("stop event listener by notification channel")
 				res = errors.New("event subscriber connection has been terminated")
 				break loop
-			} else if notifyEvent == nil {
-				l.log.Warn("nil notification event was caught")
-				continue loop
 			}
 
 			if err := l.pool.Submit(func() {
@@ -244,9 +241,6 @@ loop:
 				l.log.Warn("stop event listener by notary channel")
 				res = errors.New("notary event subscriber connection has been terminated")
 				break loop
-			} else if notaryEvent == nil {
-				l.log.Warn("nil notary event was caught")
-				continue loop
 			}
 
 			if err := l.pool.Submit(func() {
@@ -260,9 +254,6 @@ loop:
 				l.log.Warn("stop event listener by block channel")
 				res = errors.New("new block notification channel is closed")
 				break loop
-			} else if b == nil {
-				l.log.Warn("nil block was caught")
-				continue loop
 			}
 
 			if err := l.pool.Submit(func() {

--- a/pkg/morph/event/listener.go
+++ b/pkg/morph/event/listener.go
@@ -131,7 +131,7 @@ var (
 // Returns an error if listener was already started.
 func (l *listener) Listen(ctx context.Context) {
 	l.startOnce.Do(func() {
-		if err := l.listen(ctx, nil); err != nil {
+		if err := l.listen(ctx); err != nil {
 			l.log.Error("could not start listen to events",
 				zap.String("error", err.Error()),
 			)
@@ -147,7 +147,7 @@ func (l *listener) Listen(ctx context.Context) {
 // Returns an error if listener was already started.
 func (l *listener) ListenWithError(ctx context.Context, intError chan<- error) {
 	l.startOnce.Do(func() {
-		if err := l.listen(ctx, intError); err != nil {
+		if err := l.listen(ctx); err != nil {
 			l.log.Error("could not start listen to events",
 				zap.String("error", err.Error()),
 			)
@@ -156,7 +156,7 @@ func (l *listener) ListenWithError(ctx context.Context, intError chan<- error) {
 	})
 }
 
-func (l *listener) listen(ctx context.Context, intError chan<- error) error {
+func (l *listener) listen(ctx context.Context) error {
 	// mark listener as started
 	l.started = true
 
@@ -164,9 +164,7 @@ func (l *listener) listen(ctx context.Context, intError chan<- error) error {
 
 	go l.subscribe(subErrCh)
 
-	l.listenLoop(ctx, intError, subErrCh)
-
-	return nil
+	return l.listenLoop(ctx, subErrCh)
 }
 
 func (l *listener) subscribe(errCh chan error) {
@@ -210,19 +208,15 @@ func (l *listener) subscribe(errCh chan error) {
 	}
 }
 
-func (l *listener) listenLoop(ctx context.Context, intErr chan<- error, subErrCh chan error) {
+func (l *listener) listenLoop(ctx context.Context, subErrCh chan error) error {
 	chs := l.subscriber.NotificationChannels()
+	var res error
 
 loop:
 	for {
 		select {
-		case err := <-subErrCh:
-			if intErr != nil {
-				intErr <- err
-			} else {
-				l.log.Error("stop event listener by error", zap.Error(err))
-			}
-
+		case res = <-subErrCh:
+			l.log.Error("stop event listener by error", zap.Error(res))
 			break loop
 		case <-ctx.Done():
 			l.log.Info("stop event listener by context",
@@ -232,10 +226,7 @@ loop:
 		case notifyEvent, ok := <-chs.NotificationsCh:
 			if !ok {
 				l.log.Warn("stop event listener by notification channel")
-				if intErr != nil {
-					intErr <- errors.New("event subscriber connection has been terminated")
-				}
-
+				res = errors.New("event subscriber connection has been terminated")
 				break loop
 			} else if notifyEvent == nil {
 				l.log.Warn("nil notification event was caught")
@@ -251,10 +242,7 @@ loop:
 		case notaryEvent, ok := <-chs.NotaryRequestsCh:
 			if !ok {
 				l.log.Warn("stop event listener by notary channel")
-				if intErr != nil {
-					intErr <- errors.New("notary event subscriber connection has been terminated")
-				}
-
+				res = errors.New("notary event subscriber connection has been terminated")
 				break loop
 			} else if notaryEvent == nil {
 				l.log.Warn("nil notary event was caught")
@@ -270,10 +258,7 @@ loop:
 		case b, ok := <-chs.BlockCh:
 			if !ok {
 				l.log.Warn("stop event listener by block channel")
-				if intErr != nil {
-					intErr <- errors.New("new block notification channel is closed")
-				}
-
+				res = errors.New("new block notification channel is closed")
 				break loop
 			} else if b == nil {
 				l.log.Warn("nil block was caught")
@@ -290,6 +275,7 @@ loop:
 			}
 		}
 	}
+	return res
 }
 
 func (l *listener) parseAndHandleNotification(notifyEvent *state.ContainedNotificationEvent) {

--- a/pkg/morph/subscriber/subscriber.go
+++ b/pkg/morph/subscriber/subscriber.go
@@ -26,7 +26,6 @@ type (
 	// Subscriber is an interface of the NotificationEvent listener.
 	Subscriber interface {
 		SubscribeForNotification(...util.Uint160) error
-		UnsubscribeForNotification()
 		BlockNotifications() error
 		SubscribeForNotaryRequests(mainTXSigner util.Uint160) error
 
@@ -94,14 +93,6 @@ func (s *subscriber) SubscribeForNotification(contracts ...util.Uint160) error {
 	}
 
 	return nil
-}
-
-func (s *subscriber) UnsubscribeForNotification() {
-	err := s.client.UnsubscribeAll()
-	if err != nil {
-		s.log.Error("unsubscribe for notification",
-			zap.Error(err))
-	}
 }
 
 func (s *subscriber) Close() {

--- a/pkg/morph/subscriber/subscriber.go
+++ b/pkg/morph/subscriber/subscriber.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
-	"github.com/nspcc-dev/neo-go/pkg/neorpc"
 	"github.com/nspcc-dev/neo-go/pkg/neorpc/result"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
@@ -40,10 +39,17 @@ type (
 		client *client.Client
 
 		notifyChan chan *state.ContainedNotificationEvent
-
-		blockChan chan *block.Block
-
+		blockChan  chan *block.Block
 		notaryChan chan *result.NotaryRequestEvent
+
+		curNotifyChan chan *state.ContainedNotificationEvent
+		curBlockChan  chan *block.Block
+		curNotaryChan chan *result.NotaryRequestEvent
+
+		// cached subscription information
+		subscribedEvents       map[util.Uint160]bool
+		subscribedNotaryEvents map[util.Uint160]bool
+		subscribedToNewBlocks  bool
 	}
 
 	// Params is a group of Subscriber constructor parameters.
@@ -74,22 +80,28 @@ func (s *subscriber) SubscribeForNotification(contracts ...util.Uint160) error {
 	s.Lock()
 	defer s.Unlock()
 
-	notifyIDs := make(map[util.Uint160]struct{}, len(contracts))
+	notifyIDs := make([]string, 0, len(contracts))
 
 	for i := range contracts {
+		if s.subscribedEvents[contracts[i]] {
+			continue
+		}
 		// subscribe to contract notifications
-		err := s.client.SubscribeForExecutionNotifications(contracts[i])
+		id, err := s.client.ReceiveExecutionNotifications(contracts[i], s.curNotifyChan)
 		if err != nil {
 			// if there is some error, undo all subscriptions and return error
-			for hash := range notifyIDs {
-				_ = s.client.UnsubscribeContract(hash)
+			for _, id := range notifyIDs {
+				_ = s.client.Unsubscribe(id)
 			}
 
 			return err
 		}
 
 		// save notification id
-		notifyIDs[contracts[i]] = struct{}{}
+		notifyIDs = append(notifyIDs, id)
+	}
+	for i := range contracts {
+		s.subscribedEvents[contracts[i]] = true
 	}
 
 	return nil
@@ -100,80 +112,32 @@ func (s *subscriber) Close() {
 }
 
 func (s *subscriber) BlockNotifications() error {
-	if err := s.client.SubscribeForNewBlocks(); err != nil {
+	s.Lock()
+	defer s.Unlock()
+	if s.subscribedToNewBlocks {
+		return nil
+	}
+	if _, err := s.client.ReceiveBlocks(s.curBlockChan); err != nil {
 		return fmt.Errorf("could not subscribe for new block events: %w", err)
 	}
+
+	s.subscribedToNewBlocks = true
 
 	return nil
 }
 
 func (s *subscriber) SubscribeForNotaryRequests(mainTXSigner util.Uint160) error {
-	if err := s.client.SubscribeForNotaryRequests(mainTXSigner); err != nil {
+	s.Lock()
+	defer s.Unlock()
+	if s.subscribedNotaryEvents[mainTXSigner] {
+		return nil
+	}
+	if _, err := s.client.ReceiveNotaryRequests(mainTXSigner, s.curNotaryChan); err != nil {
 		return fmt.Errorf("could not subscribe for notary request events: %w", err)
 	}
 
+	s.subscribedNotaryEvents[mainTXSigner] = true
 	return nil
-}
-
-func (s *subscriber) routeNotifications(ctx context.Context) {
-	notificationChan := s.client.NotificationChannel()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case notification, ok := <-notificationChan:
-			if !ok {
-				s.log.Warn("remote notification channel has been closed")
-				close(s.notifyChan)
-				close(s.blockChan)
-				close(s.notaryChan)
-
-				return
-			}
-
-			switch notification.Type {
-			case neorpc.NotificationEventID:
-				notifyEvent, ok := notification.Value.(*state.ContainedNotificationEvent)
-				if !ok {
-					s.log.Error("can't cast notify event value to the notify struct",
-						zap.String("received type", fmt.Sprintf("%T", notification.Value)),
-					)
-					continue
-				}
-
-				s.log.Debug("new notification event from sidechain",
-					zap.String("name", notifyEvent.Name),
-				)
-
-				s.notifyChan <- notifyEvent
-			case neorpc.BlockEventID:
-				b, ok := notification.Value.(*block.Block)
-				if !ok {
-					s.log.Error("can't cast block event value to block",
-						zap.String("received type", fmt.Sprintf("%T", notification.Value)),
-					)
-					continue
-				}
-
-				s.blockChan <- b
-			case neorpc.NotaryRequestEventID:
-				notaryRequest, ok := notification.Value.(*result.NotaryRequestEvent)
-				if !ok {
-					s.log.Error("can't cast notify event value to the notary request struct",
-						zap.String("received type", fmt.Sprintf("%T", notification.Value)),
-					)
-					continue
-				}
-
-				s.notaryChan <- notaryRequest
-			default:
-				s.log.Debug("unsupported notification from the chain",
-					zap.Uint8("type", uint8(notification.Type)),
-				)
-			}
-		}
-	}
 }
 
 // New is a constructs Neo:Morph event listener and returns Subscriber interface.
@@ -199,14 +163,159 @@ func New(ctx context.Context, p *Params) (Subscriber, error) {
 		notifyChan: make(chan *state.ContainedNotificationEvent),
 		blockChan:  make(chan *block.Block),
 		notaryChan: make(chan *result.NotaryRequestEvent),
-	}
 
-	// Worker listens all events from neo-go websocket and puts them
-	// into corresponding channel. It may be notifications, transactions,
-	// new blocks. For now only notifications.
+		curNotifyChan: make(chan *state.ContainedNotificationEvent),
+		curBlockChan:  make(chan *block.Block),
+		curNotaryChan: make(chan *result.NotaryRequestEvent),
+
+		subscribedEvents:       make(map[util.Uint160]bool),
+		subscribedNotaryEvents: make(map[util.Uint160]bool),
+	}
+	// Worker listens all events from temporary NeoGo channel and puts them
+	// into corresponding permanent channels.
 	go sub.routeNotifications(ctx)
 
 	return sub, nil
+}
+
+func (s *subscriber) routeNotifications(ctx context.Context) {
+	var (
+		// TODO: not needed after nspcc-dev/neo-go#2980.
+		cliCh             = s.client.NotificationChannel()
+		restoreCh         chan bool
+		restoreInProgress bool
+	)
+
+routeloop:
+	for {
+		var connLost bool
+		s.RLock()
+		notifCh := s.curNotifyChan
+		blCh := s.curBlockChan
+		notaryCh := s.curNotaryChan
+		s.RUnlock()
+		select {
+		case <-ctx.Done():
+			break routeloop
+		case ev, ok := <-notifCh:
+			if ok {
+				s.notifyChan <- ev
+			} else {
+				connLost = true
+			}
+		case ev, ok := <-blCh:
+			if ok {
+				s.blockChan <- ev
+			} else {
+				connLost = true
+			}
+		case ev, ok := <-notaryCh:
+			if ok {
+				s.notaryChan <- ev
+			} else {
+				connLost = true
+			}
+		case _, ok := <-cliCh:
+			connLost = !ok
+		case ok := <-restoreCh:
+			restoreInProgress = false
+			if !ok {
+				connLost = true
+			}
+		}
+		if connLost {
+			if !restoreInProgress {
+				s.log.Info("RPC connection lost, attempting reconnect")
+				if !s.client.SwitchRPC() {
+					s.log.Error("can't switch RPC node")
+					break routeloop
+				}
+				cliCh = s.client.NotificationChannel()
+
+				s.Lock()
+				s.curNotifyChan = make(chan *state.ContainedNotificationEvent)
+				s.curBlockChan = make(chan *block.Block)
+				s.curNotaryChan = make(chan *result.NotaryRequestEvent)
+				go s.restoreSubscriptions(s.curNotifyChan, s.curBlockChan, s.curNotaryChan, restoreCh)
+				s.Unlock()
+				restoreInProgress = true
+			drainloop:
+				for {
+					select {
+					case _, ok := <-notifCh:
+						if !ok {
+							notifCh = nil
+						}
+					case _, ok := <-blCh:
+						if !ok {
+							blCh = nil
+						}
+					case _, ok := <-notaryCh:
+						if !ok {
+							notaryCh = nil
+						}
+					default:
+						break drainloop
+					}
+				}
+			} else { // Avoid getting additional !ok events.
+				s.Lock()
+				s.curNotifyChan = nil
+				s.curBlockChan = nil
+				s.curNotaryChan = nil
+				s.Unlock()
+			}
+		}
+	}
+	close(s.notifyChan)
+	close(s.blockChan)
+	close(s.notaryChan)
+}
+
+// restoreSubscriptions restores subscriptions according to
+// cached information about them.
+func (s *subscriber) restoreSubscriptions(notifCh chan<- *state.ContainedNotificationEvent,
+	blCh chan<- *block.Block, notaryCh chan<- *result.NotaryRequestEvent, resCh chan<- bool) {
+	var err error
+
+	// new block events restoration
+	if s.subscribedToNewBlocks {
+		_, err = s.client.ReceiveBlocks(blCh)
+		if err != nil {
+			s.log.Error("could not restore block subscription",
+				zap.Error(err),
+			)
+			resCh <- false
+			return
+		}
+	}
+
+	// notification events restoration
+	for contract := range s.subscribedEvents {
+		contract := contract // See https://github.com/nspcc-dev/neo-go/issues/2890
+		_, err = s.client.ReceiveExecutionNotifications(contract, notifCh)
+		if err != nil {
+			s.log.Error("could not restore notification subscription after RPC switch",
+				zap.Error(err),
+			)
+			resCh <- false
+			return
+		}
+	}
+
+	// notary notification events restoration
+	for signer := range s.subscribedNotaryEvents {
+		signer := signer // See https://github.com/nspcc-dev/neo-go/issues/2890
+		_, err = s.client.ReceiveNotaryRequests(signer, notaryCh)
+		if err != nil {
+			s.log.Error("could not restore notary notification subscription after RPC switch",
+				zap.Error(err),
+			)
+			resCh <- false
+			return
+		}
+	}
+	resCh <- true
 }
 
 // awaitHeight checks if remote client has least expected block height and


### PR DESCRIPTION
Part of #2219, fixes #2304. Enough for 0.36.1 and we have a set of related tasks to do for 0.37.0.