### PR TITLE
workflows: Fix invalid test report link

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -209,4 +209,4 @@ jobs:
           context: 'Test report'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${{ github.repository_owner }}.github.io/${{ github.repository }}/allure-history/${{ github.run_number }}
+          target_url: https://${{ github.repository_owner }}.github.io/neofs-node/${{ github.run_number }}


### PR DESCRIPTION
This commit fixes the invalid test report link in the Test report section.

This link will now link to the correct report:
![image](https://user-images.githubusercontent.com/126654550/236168090-c91cb67c-915a-4052-82b7-7ed375c33282.png)
