### PR TITLE
workflows: Fix invalid test report link

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -209,4 +209,4 @@ jobs:
           context: 'Test report'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${{ github.repository_owner }}.github.io/${{ github.repository }}/allure-history/${{ github.run_number }}
+          target_url: https://${{ github.repository_owner }}.github.io/neofs-node/${{ github.run_number }}


### PR DESCRIPTION
This commit fixes the invalid test report link in the Test report section.
This link will now link to the correct report:

![image](https://user-images.githubusercontent.com/126654550/236170274-8f5a6cdf-27b6-4fa5-a7fb-ed82e2f5edd1.png)
