### PR TITLE
Fix/NPE panic on tree services connection close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Inability to restore RPC connection after the second disconnect (#2325)
+- Tree service panics when cleaning up failed connections (#2335)
 
 ### Removed
 

--- a/pkg/services/tree/cache.go
+++ b/pkg/services/tree/cache.go
@@ -35,7 +35,9 @@ var errRecentlyFailed = errors.New("client has recently failed")
 
 func (c *clientCache) init() {
 	l, _ := simplelru.NewLRU(defaultClientCacheSize, func(key, value interface{}) {
-		_ = value.(cacheItem).cc.Close()
+		if conn := value.(cacheItem).cc; conn != nil {
+			_ = conn.Close()
+		}
 	})
 	c.LRU = *l
 }


### PR DESCRIPTION
Error can appear during new connection establishing and the `nil` connection is stored in LRU cache. Not try to close such connections.