### PR TITLE
Fix/Iterating over just removed objects in FSTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for NeoFS Node
 - Inability to restore RPC connection after the second disconnect (#2325)
 - Tree service panics when cleaning up failed connections (#2335)
 - Dropping small objects on any error on write-cache side (#2336)
+- Iterating over just removed files by FSTree (#98)
 
 ### Removed
 - Non-notary mode support for sidechain (#2321)

--- a/pkg/local_object_storage/blobstor/internal/blobstortest/iterate.go
+++ b/pkg/local_object_storage/blobstor/internal/blobstortest/iterate.go
@@ -95,7 +95,7 @@ func TestIterate(t *testing.T, cons Constructor, min, max uint64) {
 		}
 
 		_, err := s.Iterate(iterPrm)
-		require.Equal(t, err, logicErr)
+		require.Equal(t, logicErr, err)
 		require.Equal(t, len(objects)/2, len(seen))
 		for i := range objects {
 			d, ok := seen[objects[i].addr.String()]

--- a/pkg/local_object_storage/writecache/iterate.go
+++ b/pkg/local_object_storage/writecache/iterate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/common"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.etcd.io/bbolt"
 )
@@ -59,7 +60,9 @@ func (c *cache) Iterate(prm IterationPrm) error {
 		}
 		data, err := f()
 		if err != nil {
-			if prm.ignoreErrors {
+			if prm.ignoreErrors || errors.As(err, new(apistatus.ObjectNotFound)) {
+				// an object can be removed b/w iterating over it
+				// and reading its payload; not an error
 				return nil
 			}
 			return err


### PR DESCRIPTION
I tried to write tests for it (i really did) and they do pass for `FSTree` and did not pass for blobovniczas cause it caches every object during the iteration and `LazyHandler` means nothing for them (in other words that fix just does not relate them). So i decided to keep it as is for now since it works and _the only one_ unit test for `FSTree` looks strange IMO, cause we use a general test "framework" for every storage.