### PR TITLE
Feat/Add version metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Added
+- `neofs_[node|ir]_version` with `version` label (#2326)
 
 ### Changed
 
@@ -25,6 +26,7 @@ Changelog for NeoFS Node
 ### Updating from v0.36.1
 - `neofs_node_object_epoch` metric for IR and SN (the same for both) has been deprecated and will be removed with the
   next minor release. Use `neofs_node_state_epoch` for SN and `neofs_ir_state_epoch` for IR instead.
+- Storage and Inner-ring nodes exposes their version via the `neofs_[node|ir]_version` metric now.
 
 ## [0.36.1] - 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - Tree service panics when cleaning up failed connections (#2335)
 - Dropping small objects on any error on write-cache side (#2336)
 - Iterating over just removed files by FSTree (#98)
+- IR metrics moved to `neofs_ir` namespace and epoch metrics to `object` subsystem (#2344)
 
 ### Removed
 - Non-notary mode support for sidechain (#2321)
@@ -22,6 +23,8 @@ Changelog for NeoFS Node
 - `github.com/hashicorp/golang-lru` to `v2.0.2`
 
 ### Updating from v0.36.1
+- `neofs_node_object_epoch` metric for IR and SN (the same for both) has been deprecated and will be removed with the
+  next minor release. Use `neofs_node_state_epoch` for SN and `neofs_ir_state_epoch` for IR instead.
 
 ## [0.36.1] - 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Dropping small objects on any error on write-cache side (#2336)
 - Iterating over just removed files by FSTree (#98)
 - IR metrics moved to `neofs_ir` namespace and epoch metrics to `object` subsystem (#2344)
+- IR metrics config reading (#2344)
 
 ### Removed
 - Non-notary mode support for sidechain (#2321)

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -30,6 +30,7 @@ import (
 	nodeconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/node"
 	objectconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/object"
 	replicatorconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/replicator"
+	"github.com/nspcc-dev/neofs-node/misc"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	netmapCore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor"
@@ -614,7 +615,7 @@ func initCfg(appCfg *config.Config) *cfg {
 	user.IDFromKey(&c.ownerIDFromKey, key.PrivateKey.PublicKey)
 
 	if metricsconfig.Enabled(c.appCfg) {
-		c.metricsCollector = metrics.NewNodeMetrics()
+		c.metricsCollector = metrics.NewNodeMetrics(misc.Version)
 		netState.metrics = c.metricsCollector
 	}
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
+	"github.com/nspcc-dev/neofs-node/misc"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/config"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/internal/blockchain"
 	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/alphabet"
@@ -966,7 +967,7 @@ func New(ctx context.Context, log *logger.Logger, cfg *viper.Viper, errChan chan
 	})
 
 	if cfg.GetString("metrics.address") != "" {
-		m := metrics.NewInnerRingMetrics()
+		m := metrics.NewInnerRingMetrics(misc.Version)
 		server.metrics = &m
 	}
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -966,7 +966,7 @@ func New(ctx context.Context, log *logger.Logger, cfg *viper.Viper, errChan chan
 		queueSize: cfg.GetUint32("workers.subnet"),
 	})
 
-	if cfg.GetString("metrics.address") != "" {
+	if cfg.GetString("prometheus.address") != "" {
 		m := metrics.NewInnerRingMetrics(misc.Version)
 		server.metrics = &m
 	}

--- a/pkg/metrics/engine.go
+++ b/pkg/metrics/engine.go
@@ -27,77 +27,77 @@ const engineSubsystem = "engine"
 func newEngineMetrics() engineMetrics {
 	var (
 		listContainersDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "list_containers_duration",
 			Help:      "Accumulated duration of engine list containers operations",
 		})
 
 		estimateContainerSizeDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "estimate_container_size_duration",
 			Help:      "Accumulated duration of engine container size estimate operations",
 		})
 
 		deleteDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "delete_duration",
 			Help:      "Accumulated duration of engine delete operations",
 		})
 
 		existsDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "exists_duration",
 			Help:      "Accumulated duration of engine exists operations",
 		})
 
 		getDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "get_duration",
 			Help:      "Accumulated duration of engine get operations",
 		})
 
 		headDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "head_duration",
 			Help:      "Accumulated duration of engine head operations",
 		})
 
 		inhumeDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "inhume_duration",
 			Help:      "Accumulated duration of engine inhume operations",
 		})
 
 		putDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "put_duration",
 			Help:      "Accumulated duration of engine put operations",
 		})
 
 		rangeDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "range_duration",
 			Help:      "Accumulated duration of engine range operations",
 		})
 
 		searchDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "search_duration",
 			Help:      "Accumulated duration of engine search operations",
 		})
 
 		listObjectsDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: engineSubsystem,
 			Name:      "list_objects_duration",
 			Help:      "Accumulated duration of engine list objects operations",

--- a/pkg/metrics/innerring.go
+++ b/pkg/metrics/innerring.go
@@ -1,33 +1,49 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"fmt"
 
-const innerRingSubsystem = "object"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const innerRingNameSpace = "neofs_ir"
+
+// FIXME: drop after v0.38.0 release: #2347.
+const innerRingNameSpaceDeprecated = storageNodeNameSpace
+const innerRingSubsystemDeprecated = objectSubsystem
 
 // InnerRingServiceMetrics contains metrics collected by inner ring.
 type InnerRingServiceMetrics struct {
-	epoch prometheus.Gauge
+	epoch           prometheus.Gauge
+	epochDeprecated prometheus.Gauge
 }
 
 // NewInnerRingMetrics returns new instance of metrics collectors for inner ring.
 func NewInnerRingMetrics() InnerRingServiceMetrics {
-	var (
-		epoch = prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: innerRingSubsystem,
-			Name:      "epoch",
-			Help:      "Current epoch as seen by inner-ring node.",
-		})
-	)
-
+	epoch := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: innerRingNameSpace,
+		Subsystem: stateSubsystem,
+		Name:      "epoch",
+		Help:      "Current epoch as seen by inner-ring node.",
+	})
 	prometheus.MustRegister(epoch)
 
+	epochDeprecated := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: innerRingNameSpaceDeprecated,
+		Subsystem: innerRingSubsystemDeprecated,
+		Name:      "epoch",
+		Help:      fmt.Sprintf("Current epoch as seen by inner-ring node. DEPRECATED: use [%s_%s_epoch] instead.", innerRingNameSpace, stateSubsystem),
+	})
+	prometheus.MustRegister(epochDeprecated)
+
 	return InnerRingServiceMetrics{
-		epoch: epoch,
+		epoch:           epoch,
+		epochDeprecated: epochDeprecated,
 	}
 }
 
 // SetEpoch updates epoch metrics.
 func (m InnerRingServiceMetrics) SetEpoch(epoch uint64) {
 	m.epoch.Set(float64(epoch))
+	m.epochDeprecated.Set(float64(epoch))
 }

--- a/pkg/metrics/innerring.go
+++ b/pkg/metrics/innerring.go
@@ -19,7 +19,9 @@ type InnerRingServiceMetrics struct {
 }
 
 // NewInnerRingMetrics returns new instance of metrics collectors for inner ring.
-func NewInnerRingMetrics() InnerRingServiceMetrics {
+func NewInnerRingMetrics(version string) InnerRingServiceMetrics {
+	registerVersionMetric(innerRingNameSpace, version)
+
 	epoch := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: innerRingNameSpace,
 		Subsystem: stateSubsystem,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,7 +16,9 @@ type NodeMetrics struct {
 	epochDeprecated prometheus.Gauge
 }
 
-func NewNodeMetrics() *NodeMetrics {
+func NewNodeMetrics(version string) *NodeMetrics {
+	registerVersionMetric(storageNodeNameSpace, version)
+
 	objectService := newObjectServiceMetrics()
 	objectService.register()
 

--- a/pkg/metrics/object.go
+++ b/pkg/metrics/object.go
@@ -48,13 +48,13 @@ const (
 func newMethodCallCounter(name string) methodCount {
 	return methodCount{
 		success: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      fmt.Sprintf("%s_req_count_success", name),
 			Help:      fmt.Sprintf("The number of successful %s requests processed", name),
 		}),
 		total: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      fmt.Sprintf("%s_req_count", name),
 			Help:      fmt.Sprintf("Total number of %s requests processed", name),
@@ -87,49 +87,49 @@ func newObjectServiceMetrics() objectServiceMetrics {
 
 	var ( // Request duration metrics.
 		getDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "get_req_duration",
 			Help:      "Accumulated get request process duration",
 		})
 
 		putDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "put_req_duration",
 			Help:      "Accumulated put request process duration",
 		})
 
 		headDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "head_req_duration",
 			Help:      "Accumulated head request process duration",
 		})
 
 		searchDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "search_req_duration",
 			Help:      "Accumulated search request process duration",
 		})
 
 		deleteDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "delete_req_duration",
 			Help:      "Accumulated delete request process duration",
 		})
 
 		rangeDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "range_req_duration",
 			Help:      "Accumulated range request process duration",
 		})
 
 		rangeHashDuration = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "range_hash_req_duration",
 			Help:      "Accumulated range hash request process duration",
@@ -138,21 +138,21 @@ func newObjectServiceMetrics() objectServiceMetrics {
 
 	var ( // Object payload metrics.
 		putPayload = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "put_payload",
 			Help:      "Accumulated payload size at object put method",
 		})
 
 		getPayload = prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "get_payload",
 			Help:      "Accumulated payload size at object get method",
 		})
 
 		shardsMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "counter",
 			Help:      "Objects counters per shards",
@@ -161,7 +161,7 @@ func newObjectServiceMetrics() objectServiceMetrics {
 		)
 
 		shardsReadonly = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: objectSubsystem,
 			Name:      "readonly",
 			Help:      "Shard state",

--- a/pkg/metrics/state.go
+++ b/pkg/metrics/state.go
@@ -11,7 +11,7 @@ type stateMetrics struct {
 func newStateMetrics() stateMetrics {
 	return stateMetrics{
 		healthCheck: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Namespace: storageNodeNameSpace,
 			Subsystem: stateSubsystem,
 			Name:      "health",
 			Help:      "Current Node state",

--- a/pkg/metrics/version.go
+++ b/pkg/metrics/version.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func registerVersionMetric(namespace string, version string) {
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "version",
+		ConstLabels: prometheus.Labels{
+			"version": version,
+		},
+	})
+
+	prometheus.MustRegister(g)
+	g.Set(1)
+}


### PR DESCRIPTION
Closes #2326. Gonna look smth like that:

```
# HELP neofs_node_build_info 
# TYPE neofs_node_build_info gauge
neofs_node_build_info{version="v0.36.1-32-gb20018c6-dirty"} 1
```

@roman-khimov, @cthulhu-rider, @532910, @aprasolova, @anyone_looking_at_metrics, please, look at the first commit. Something was certainly wrong, pay attention to it and make me know if some SW depends on it and we are not able to make such changes OR such changes must be synced before the merge.