### PR TITLE
cli: drop support for binary keys, use wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog for NeoFS Node
 ### Removed
 - Non-notary mode support for sidechain (#2321)
 - Priority switching b/w RPC endpoints in the morph client (#2306)
+- Support for binary keys in the CLI (#2357)
 
 ### Updated
 - Update minimal supported Go version up to v1.18 (#2340)
@@ -36,6 +37,12 @@ Changelog for NeoFS Node
 - `morph.switch_interval` IR and SN config value is not used anymore.
 - `morph.rpc_endpoint` SN config value and `morph.endpoint.client` IR config value has been deprecated and will be 
   removed with the next minor release. Use `morph.endpoints` for both instead (NOTE: it does not have priorities now).
+- If you're using binary keys with neofs-cli (`-w`), convert them to proper
+  NEP-6 wallets like this:
+    $ xxd -p < path_to_binary.wallet # outputs hex-encoded key
+    $ neofs-cli util keyer <hex_key> # outputs WIF
+    $ neo-go wallet import -w <wallet_file> --wif <wif_key>
+  or just generate/use new keys.
 
 ## [0.36.1] - 2023-04-26
 

--- a/cmd/neofs-cli/internal/commonflags/flags.go
+++ b/cmd/neofs-cli/internal/commonflags/flags.go
@@ -18,7 +18,7 @@ const (
 	WalletPath          = "wallet"
 	WalletPathShorthand = "w"
 	WalletPathDefault   = ""
-	WalletPathUsage     = "Path to the wallet or binary key"
+	WalletPathUsage     = "Path to the wallet"
 
 	Account          = "address"
 	AccountShorthand = ""

--- a/cmd/neofs-cli/internal/key/key_test.go
+++ b/cmd/neofs-cli/internal/key/key_test.go
@@ -98,10 +98,21 @@ func Test_getOrGenerate(t *testing.T) {
 	})
 
 	t.Run("raw key", func(t *testing.T) {
-		checkKey(t, keyPath, rawKey)
+		checkKeyError(t, keyPath, ErrInvalidKey)
 	})
 
 	t.Run("generate", func(t *testing.T) {
+		viper.Set(commonflags.GenerateKey, true)
+		actual, err := getOrGenerate(testCmd)
+		require.NoError(t, err)
+		require.NotNil(t, actual)
+		for _, p := range []*keys.PrivateKey{nep2Key, rawKey, wifKey, acc1.PrivateKey(), acc2.PrivateKey()} {
+			require.NotEqual(t, p, actual, "expected new key to be generated")
+		}
+	})
+	t.Run("generate implicitly", func(t *testing.T) {
+		viper.Set(commonflags.GenerateKey, false)
+		viper.Set(commonflags.WalletPath, "")
 		actual, err := getOrGenerate(testCmd)
 		require.NoError(t, err)
 		require.NotNil(t, actual)

--- a/cmd/neofs-cli/internal/key/raw.go
+++ b/cmd/neofs-cli/internal/key/raw.go
@@ -35,21 +35,15 @@ func get(cmd *cobra.Command) (*ecdsa.PrivateKey, error) {
 	if keyDesc == "" {
 		return nil, errMissingFlag
 	}
-
-	data, err := os.ReadFile(keyDesc)
+	w, err := wallet.NewWalletFromFile(keyDesc)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrFs, err)
-	}
-
-	priv, err := keys.NewPrivateKeyFromBytes(data)
-	if err != nil {
-		w, err := wallet.NewWalletFromFile(keyDesc)
-		if err == nil {
-			return FromWallet(cmd, w, viper.GetString(commonflags.Account))
+		var perr = new(*os.PathError)
+		if errors.As(err, perr) {
+			return nil, fmt.Errorf("%w: %v", ErrFs, err)
 		}
 		return nil, fmt.Errorf("%w: %v", ErrInvalidKey, err)
 	}
-	return &priv.PrivateKey, nil
+	return FromWallet(cmd, w, viper.GetString(commonflags.Account))
 }
 
 // GetOrGenerate is similar to get but generates a new key if commonflags.GenerateKey is set.

--- a/cmd/neofs-cli/internal/key/wallet.go
+++ b/cmd/neofs-cli/internal/key/wallet.go
@@ -17,7 +17,7 @@ import (
 // Key-related errors.
 var (
 	ErrFs              = errors.New("unable to read file from given path")
-	ErrInvalidKey      = errors.New("provided key is incorrect, only wallet or binary key supported")
+	ErrInvalidKey      = errors.New("provided wallet is incorrect")
 	ErrInvalidAddress  = errors.New("--address option must be specified and valid")
 	ErrInvalidPassword = errors.New("invalid password for the encrypted key")
 )


### PR DESCRIPTION
Wallets were introduced way back when in 0.27.5 and that's the way keys should be stored. We've had enough transition period for people to adjust to using them. Binary keys are dangerous and inconvenient (NEP-6 is common for all of the Neo tooling, everyone knows how to use it), therefore we shouldn't provide support for them.

Related to #2136.