### PR TITLE
feat/Use parsed committee as validator list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - NeoFS CLI generates random private key automatically if wallet is omitted (#2123)
-- `morph.validators` config can be omitted for IR in local consensus mode (#2311)
+- `morph.validators` config can be omitted for IR in local consensus mode but must be non-empty otherwise (#2311)
 
 ### Fixed
 - Inability to restore RPC connection after the second disconnect (#2325)
@@ -46,6 +46,7 @@ Changelog for NeoFS Node
     $ neo-go wallet import -w <wallet_file> --wif <wif_key>
   or just generate/use new keys.
 - In local consensus mode `morph.validators` in IR's config can be omitted now, `morph.consensus.committee` will be used instead.
+  For detached consensus, it is a required config parameter now.
 
 ## [0.36.1] - 2023-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - NeoFS CLI generates random private key automatically if wallet is omitted (#2123)
+- `morph.validators` config can be omitted for IR in local consensus mode (#2311)
 
 ### Fixed
 - Inability to restore RPC connection after the second disconnect (#2325)
@@ -44,6 +45,7 @@ Changelog for NeoFS Node
     $ neofs-cli util keyer <hex_key> # outputs WIF
     $ neo-go wallet import -w <wallet_file> --wif <wif_key>
   or just generate/use new keys.
+- In local consensus mode `morph.validators` in IR's config can be omitted now, `morph.consensus.committee` will be used instead.
 
 ## [0.36.1] - 2023-04-26
 

--- a/config/example/ir.yaml
+++ b/config/example/ir.yaml
@@ -17,7 +17,7 @@ morph:
   endpoints: # List of websocket RPC endpoints in sidechain
       - wss://sidechain1.fs.neo.org:30333/ws
       - wss://sidechain2.fs.neo.org:30333/ws
-  validators: # List of hex-encoded 33-byte public keys of sidechain validators to vote for at application startup
+  validators: # List of hex-encoded 33-byte public keys of sidechain validators to vote for at application startup; can be omitted if equals `consensus.committee`
     - 0283120f4c8c1fc1d792af5063d2def9da5fddc90bc1384de7fcfdda33c3860170
   consensus: # Local consensus launch mode activated only when 'endpoint.client' is unset.
     magic: 15405 # Network magic. Must be unsigned integer in range [1:4294967295]

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -421,6 +421,10 @@ func New(ctx context.Context, log *logger.Logger, cfg *viper.Viper, errChan chan
 			return nil, fmt.Errorf("init internal morph client: %w", err)
 		}
 	} else {
+		if len(server.predefinedValidators) == 0 {
+			return nil, fmt.Errorf("empty '%s' list in config", validatorsConfigKey)
+		}
+
 		// fallback to the pure RPC architecture
 		acc, err := utilConfig.LoadAccount(
 			walletPath,
@@ -1046,8 +1050,10 @@ func createClient(ctx context.Context, p *chainParams, errChan chan<- error) (*c
 	)
 }
 
+const validatorsConfigKey = "morph.validators"
+
 func parsePredefinedValidators(cfg *viper.Viper) (keys.PublicKeys, error) {
-	publicKeyStrings := cfg.GetStringSlice("morph.validators")
+	publicKeyStrings := cfg.GetStringSlice(validatorsConfigKey)
 
 	return ParsePublicKeysFromStrings(publicKeyStrings)
 }


### PR DESCRIPTION
Closes #2311.

@roman-khimov, check, please. I am not sure that i got the issue correctly. In fact, it is not clear to me why we need some voting on the application start. I found "This way alphabet contracts are able to produce more GAS for inner ring and storage nodes." from https://github.com/nspcc-dev/neofs-node/pull/170 but not sure i can understand it.

Also, you mentioned that "currently that's required for IR" (meaning validators) but i don't get how it is _required_ and what exactly the difference is.