### PR TITLE
Add write permissions to the vendor/hosts file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -127,6 +127,7 @@ jobs:
         run: |
           make get
           sudo ./bin/update_hosts.sh
+          sudo chmod a+w vendor/hosts
         working-directory: neofs-dev-env
 
       - name: Prepare test environment


### PR DESCRIPTION
This is necessary to reduce the number of steps
in the make dev-env.
This saves a few minutes for each test run.

This PR is necessary for:
https://github.com/nspcc-dev/neofs-dev-env/pull/262