### PR TITLE
workflow: disable all capturing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -212,7 +212,7 @@ jobs:
         timeout-minutes: 480
         if: github.event_name != 'pull_request'
         run: |
-          source venv.local-pytest/bin/activate && pytest --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
+          source venv.local-pytest/bin/activate && pytest --show-capture=no --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
         working-directory: neofs-testcases
 
 ################################################################


### PR DESCRIPTION
Disabling all captures when running full system tests, as when running sanity tests after PR.