### PR TITLE
acl: drop unused unmarshalPublicKey

### DIFF
--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -1,11 +1,9 @@
 package acl
 
 import (
-	"crypto/elliptic"
 	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
@@ -261,12 +259,4 @@ func isOwnerFromKey(id user.ID, key []byte) bool {
 	}
 
 	return id.Equals(id2)
-}
-
-func unmarshalPublicKey(bs []byte) *keys.PublicKey {
-	pub, err := keys.NewPublicKeyFromBytes(bs, elliptic.P256())
-	if err != nil {
-		return nil
-	}
-	return pub
 }

--- a/pkg/services/object/acl/v2/util.go
+++ b/pkg/services/object/acl/v2/util.go
@@ -1,11 +1,9 @@
 package v2
 
 import (
-	"crypto/elliptic"
 	"errors"
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	objectV2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	refsV2 "github.com/nspcc-dev/neofs-api-go/v2/refs"
 	sessionV2 "github.com/nspcc-dev/neofs-api-go/v2/session"
@@ -142,10 +140,6 @@ func originalBodySignature(v *sessionV2.RequestVerificationHeader) *refsV2.Signa
 	}
 
 	return v.GetBodySignature()
-}
-
-func unmarshalPublicKey(bs []byte) (*keys.PublicKey, error) {
-	return keys.NewPublicKeyFromBytes(bs, elliptic.P256())
 }
 
 func isOwnerFromKey(id user.ID, key []byte) bool {


### PR DESCRIPTION
Linter:
  Error: func `unmarshalPublicKey` is unused (unused)
  Error: func `unmarshalPublicKey` is unused (unused)