### PR TITLE
workflows: Exclude "sanity" tests from the full test run

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -213,7 +213,7 @@ jobs:
         timeout-minutes: 480
         if: github.event_name != 'pull_request'
         run: |
-          source venv.local-pytest/bin/activate && pytest --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
+          source venv.local-pytest/bin/activate && pytest -m "not sanity" --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
         working-directory: neofs-testcases
 
 ################################################################


### PR DESCRIPTION
Excluding tests already passed (in the PR phase) will allow us to save about 30 minutes on running a full set of tests.
It will also help to temporarily fix
https://github.com/nspcc-dev/neofs-testcases/issues/574