### PR TITLE
fix/Panic in `storagegroup put`

### DIFF
--- a/cmd/neofs-cli/modules/storagegroup/put.go
+++ b/cmd/neofs-cli/modules/storagegroup/put.go
@@ -95,6 +95,7 @@ func putSG(cmd *cobra.Command, _ []string) {
 	headPrm.SetClient(cli)
 
 	sg, err := storagegroup.CollectMembers(sgHeadReceiver{
+		ctx:     ctx,
 		cmd:     cmd,
 		key:     pk,
 		ownerID: &ownerID,


### PR DESCRIPTION
Context was added in #2135 but not initialized.

BTW, another argument for https://github.com/nspcc-dev/neo-go/issues/3026#issuecomment-1569124458. I doubt it would have happened if the interface had been `Head(context.Context, oid.Address)`.

Closes #2398.