### PR TITLE
github: drop obsolete cache step from test run

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,14 +30,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Cache go mod
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go }}-
-
       - name: Run go test
         run: go test -coverprofile=coverage.txt -covermode=atomic ./...
 


### PR DESCRIPTION
It's handled by setup-go now and it doesn't work anyway:
  Restore cache failed: Dependencies file is not found in /home/runner/work/neofs-node/neofs-node. Supported file pattern: go.sum