### PR TITLE
fix/Restart SN services after `neo-go` is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog for NeoFS Node
 - `renew-domain` command for adm
 
 ### Fixed
-- `neo-go` RPC connection lost handling by IR (#1337)
+- `neo-go` RPC connection loss handling (#1337)
 - Concurrent morph cache misses (#1248)
 
 ### Removed

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -349,6 +349,11 @@ type shared struct {
 	putClientCache *cache.ClientCache
 	localAddr      network.AddressGroup
 
+	containerCache     *ttlContainerStorage
+	eaclCache          *ttlEACLStorage
+	containerListCache *ttlContainerLister
+	netmapCache        *lruNetmapSource
+
 	key            *keys.PrivateKey
 	binPublicKey   []byte
 	ownerIDFromKey user.ID // user ID calculated from key
@@ -369,6 +374,21 @@ type shared struct {
 	treeService *tree.Service
 
 	metricsCollector *metrics.NodeMetrics
+}
+
+func (s shared) resetCaches() {
+	if s.containerCache != nil {
+		s.containerCache.reset()
+	}
+	if s.eaclCache != nil {
+		s.eaclCache.reset()
+	}
+	if s.containerListCache != nil {
+		s.containerListCache.reset()
+	}
+	if s.netmapCache != nil {
+		s.netmapCache.reset()
+	}
 }
 
 // dynamicConfiguration stores parameters of the

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -76,6 +76,10 @@ func initContainerService(c *cfg) {
 		cachedEACLStorage := newCachedEACLStorage(eACLFetcher, c.cfgMorph.cacheTTL)
 		cachedContainerLister := newCachedContainerLister(wrap, c.cfgMorph.cacheTTL)
 
+		c.shared.containerCache = cachedContainerStorage
+		c.shared.eaclCache = cachedEACLStorage
+		c.shared.containerListCache = cachedContainerLister
+
 		subscribeToContainerCreation(c, func(e event.Event) {
 			ev := e.(containerEvent.PutSuccess)
 

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -154,6 +154,8 @@ func (c *cfg) onShutdown(f func()) {
 }
 
 func (c *cfg) restartMorph() error {
+	c.log.Info("restarting internal services because of RPC connection loss...")
+
 	c.shared.resetCaches()
 
 	epoch, ni, err := getNetworkState(c)
@@ -179,6 +181,8 @@ func (c *cfg) restartMorph() error {
 	if err != nil {
 		c.log.Warn("failed to re-bootstrap", zap.Error(err))
 	}
+
+	c.log.Info("internal services have been restarted after RPC connection loss")
 
 	return nil
 }

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -152,3 +152,7 @@ func shutdown(c *cfg) {
 func (c *cfg) onShutdown(f func()) {
 	c.closers = append(c.closers, f)
 }
+
+func (c *cfg) restartMorph() error {
+	return nil
+}

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -154,5 +154,7 @@ func (c *cfg) onShutdown(f func()) {
 }
 
 func (c *cfg) restartMorph() error {
+	c.shared.resetCaches()
+
 	return nil
 }

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -156,5 +156,12 @@ func (c *cfg) onShutdown(f func()) {
 func (c *cfg) restartMorph() error {
 	c.shared.resetCaches()
 
+	epoch, ni, err := getNetworkState(c)
+	if err != nil {
+		return fmt.Errorf("getting network state: %w", err)
+	}
+
+	updateLocalState(c, epoch, ni)
+
 	return nil
 }

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -163,5 +163,19 @@ func (c *cfg) restartMorph() error {
 
 	updateLocalState(c, epoch, ni)
 
+	// bootstrap node after every reconnection cause the longevity of
+	// a connection downstate is unpredictable and bootstrap TX is a
+	// way to make a heartbeat so nothing is wrong in making sure the
+	// node is online (if it should be)
+
+	if !c.needBootstrap() || c.cfgNetmap.reBoostrapTurnedOff.Load() {
+		return nil
+	}
+
+	err = c.bootstrap()
+	if err != nil {
+		c.log.Warn("failed to re-bootstrap", zap.Error(err))
+	}
+
 	return nil
 }

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -163,6 +163,9 @@ func (c *cfg) restartMorph() error {
 
 	updateLocalState(c, epoch, ni)
 
+	// drop expired sessions if any has appeared while node was sleeping
+	c.shared.privateTokenStore.RemoveOld(epoch)
+
 	// bootstrap node after every reconnection cause the longevity of
 	// a connection downstate is unpredictable and bootstrap TX is a
 	// way to make a heartbeat so nothing is wrong in making sure the

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -90,8 +90,10 @@ func initMorphComponents(c *cfg) {
 	if c.cfgMorph.cacheTTL < 0 {
 		netmapSource = wrap
 	} else {
+		c.shared.netmapCache = newCachedNetmapStorage(c.cfgNetmap.state, wrap)
+
 		// use RPC node as source of netmap (with caching)
-		netmapSource = newCachedNetmapStorage(c.cfgNetmap.state, wrap)
+		netmapSource = c.shared.netmapCache
 	}
 
 	c.netMapSource = netmapSource

--- a/cmd/neofs-node/morph.go
+++ b/cmd/neofs-node/morph.go
@@ -37,6 +37,12 @@ func initMorphComponents(c *cfg) {
 		client.WithEndpoints(addresses),
 		client.WithReconnectionRetries(morphconfig.ReconnectionRetriesNumber(c.appCfg)),
 		client.WithReconnectionsDelay(morphconfig.ReconnectionRetriesDelay(c.appCfg)),
+		client.WithConnSwitchCallback(func() {
+			err = c.restartMorph()
+			if err != nil {
+				c.internalErr <- fmt.Errorf("restarting after morph connection was lost: %w", err)
+			}
+		}),
 		client.WithConnLostCallback(func() {
 			c.internalErr <- errors.New("morph connection has been lost")
 		}),


### PR DESCRIPTION
Closes #1337. The https://github.com/nspcc-dev/neofs-node/pull/2406 but for SN. Also tested with https://github.com/notimetoname/neofs-dev-env/tree/local/add-rpc-morph-node.