### PR TITLE
Disable aws ec2 metadata

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
   run_system_tests:
     runs-on: ubuntu-latest
     timeout-minutes: 500
+    env:
+      AWS_EC2_METADATA_DISABLED: true
     steps:
       - name: Checkout neofs-testcases repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixed bug https://github.com/nspcc-dev/neofs-s3-gw/issues/798 This bug is only reproducible on ubuntu-latest in github actions. This is a bug specifically of github acions, not the neofs-s3-gw: https://github.com/actions/runner-images/issues/2791 https://github.com/aws/aws-cli/issues/5623