### PR TITLE
blobovnicza: Add benchmark to test different tree settings

### DIFF
--- a/pkg/local_object_storage/blobstor/blobovniczatree/put_test.go
+++ b/pkg/local_object_storage/blobstor/blobovniczatree/put_test.go
@@ -1,6 +1,9 @@
 package blobovniczatree_test
 
 import (
+	"crypto/rand"
+	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/blobovniczatree"
@@ -36,4 +39,69 @@ func TestSingleDir(t *testing.T) {
 		Address: putPrm.Address,
 	})
 	require.NoError(t, err)
+}
+
+func benchmarkPutMN(b *testing.B, depth, width uint64) {
+	nBlobovniczas := uint64(1)
+	for i := uint64(1); i <= depth+1; i++ {
+		nBlobovniczas *= width
+	}
+
+	const objSizeLimit = 4 << 10
+	const fullSizeLimit = 100 << 20
+
+	bbcz := NewBlobovniczaTree(
+		WithRootPath(b.TempDir()),
+		WithObjectSizeLimit(objSizeLimit),
+		WithBlobovniczaSize(fullSizeLimit/nBlobovniczas),
+		WithBlobovniczaShallowWidth(width),
+		WithBlobovniczaShallowDepth(depth),
+	)
+
+	require.NoError(b, bbcz.Open(false))
+	b.Cleanup(func() { _ = bbcz.Close() })
+	require.NoError(b, bbcz.Init())
+
+	prm := common.PutPrm{
+		RawData: make([]byte, objSizeLimit),
+	}
+
+	rand.Read(prm.RawData)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var err error
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		prm.Address = oidtest.Address()
+		b.StartTimer()
+
+		_, err = bbcz.Put(prm)
+
+		b.StopTimer()
+		if err != nil {
+			if errors.Is(err, common.ErrNoSpace) {
+				break
+			}
+			require.NoError(b, err)
+		}
+		b.StartTimer()
+	}
+}
+
+func BenchmarkBlobovniczas_Put(b *testing.B) {
+	for _, testCase := range []struct {
+		width, depth uint64
+	}{
+		{1, 0},
+		{10, 0},
+		{2, 2},
+		{4, 4},
+	} {
+		b.Run(fmt.Sprintf("tree=%dx%d", testCase.width, testCase.depth), func(b *testing.B) {
+			benchmarkPutMN(b, testCase.depth, testCase.width)
+		})
+	}
 }


### PR DESCRIPTION
current results:
```
goos: linux
goarch: amd64
pkg: github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/blobovniczatree cpu: Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
BenchmarkBlobovniczas_Put/tree=1x0-8                 100          53517515 ns/op         4609697 B/op        109 allocs/op
BenchmarkBlobovniczas_Put/tree=10x0-8                100          53417156 ns/op         5213543 B/op        119 allocs/op
BenchmarkBlobovniczas_Put/tree=2x2-8                 100          52124287 ns/op         5117641 B/op        158 allocs/op
BenchmarkBlobovniczas_Put/tree=4x4-8                 100          37065895 ns/op         2129467 B/op        188 allocs/op
```

according to test, tree management doesn't really help when number of layers is small. 4x4 showed better performance which is suspicious: right now it may be expected since we didn't try to optimize working with single DB instance as described in #2453.

P.S. in current test implementation, it's not obvious do we force to switch to other DBs or not. I tried to reach this using `-benchtime=100x` where `100` is `fullSizeLimit/singleObjectSize`.