### PR TITLE
object/put: Process session token of the original request in ACL checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - Concurrent morph cache misses (#1248)
 - Double voting for validators on IR startup (#2365)
 - Skip unexpected notary events on notary request parsing step (#2315)
+- Session inactivity on object PUT request relay (#2460)
 
 ### Removed
 - Deprecated `morph.rpc_endpoint` SN and `morph.endpoint.client` IR config sections (#2400)

--- a/pkg/services/object/acl/v2/service.go
+++ b/pkg/services/object/acl/v2/service.go
@@ -479,16 +479,12 @@ func (p putStreamBasicChecker) Send(request *objectV2.PutRequest) error {
 			}
 		}
 
-		var sTok *sessionSDK.Object
+		sTok, err := originalSessionToken(request.GetMetaHeader())
+		if err != nil {
+			return err
+		}
 
-		if tokV2 := request.GetMetaHeader().GetSessionToken(); tokV2 != nil {
-			sTok = new(sessionSDK.Object)
-
-			err = sTok.ReadFromV2(*tokV2)
-			if err != nil {
-				return fmt.Errorf("invalid session token: %w", err)
-			}
-
+		if sTok != nil {
 			if sTok.AssertVerb(sessionSDK.VerbObjectDelete) {
 				// if session relates to object's removal, we don't check
 				// relation of the tombstone to the session here since user


### PR DESCRIPTION
* closes #2460