### PR TITLE
feat/Announce version via the attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 - Stored payload metric per container (#2116)
 - Stored payload metric per shard (#2023)
 - Histogram metrics for RPC and engine operations (#2351) 
+- SN's version is announced via the attributes automatically but can be overwritten explicitly (#2455)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -532,6 +532,11 @@ var persistateSideChainLastBlockKey = []byte("side_chain_last_processed_block")
 func initCfg(appCfg *config.Config) *cfg {
 	c := &cfg{}
 
+	// attaching version to the node's attributes; do not
+	// move it anywhere below reading the other attributes
+	// since a user should be able to overwrite it.
+	writeAppVersion(c)
+
 	err := c.readConfig(appCfg)
 	if err != nil {
 		panic(fmt.Errorf("config reading: %w", err))
@@ -962,4 +967,10 @@ func (c *cfg) configWatcher(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// writeAppVersion writes app version as defined at compilation
+// step to the node's attributes.
+func writeAppVersion(c *cfg) {
+	c.cfgNodeInfo.localInfo.SetAttribute("Version", misc.Version)
 }


### PR DESCRIPTION
It is done automatically but can be overwritten if `Version` attribute is provided via the application configuration.
Closes #2455.