### PR TITLE
feat/Announce capacity via the attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Stored payload metric per container (#2116)
 - Stored payload metric per shard (#2023)
 - Histogram metrics for RPC and engine operations (#2351) 
-- SN's version is announced via the attributes automatically but can be overwritten explicitly (#2455)
 - New storage component for small objects named Peapod (#2453)
 - New `blobovnicza-to-peapod` tool providing blobovnicza-to-peapod data migration (#2453)
+- SN's version and capacity is announced via the attributes automatically but can be overwritten explicitly (#2455, #602)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-node/fs_unix.go
+++ b/cmd/neofs-node/fs_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func totalBytes(paths []string) (uint64, error) {
+	var stat unix.Statfs_t
+	var total uint64 // bytes
+	fsIDMap := make(map[unix.Fsid]struct{})
+
+	for _, path := range paths {
+		err := unix.Statfs(path, &stat)
+		if err != nil {
+			return 0, fmt.Errorf("get FS stat by '%s' path: %w", path, err)
+		}
+
+		if _, handled := fsIDMap[stat.Fsid]; handled {
+			continue
+		}
+
+		total += stat.Blocks * uint64(stat.Bsize)
+		fsIDMap[stat.Fsid] = struct{}{}
+	}
+
+	return total, nil
+}

--- a/cmd/neofs-node/fs_windows.go
+++ b/cmd/neofs-node/fs_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func totalBytes(paths []string) (uint64, error) {
+	var total uint64 // bytes
+	diskMap := make(map[string]struct{}, len(paths))
+
+	for _, path := range paths {
+		disk := filepath.VolumeName(path)
+		if _, handled := diskMap[disk]; handled {
+			continue
+		}
+
+		var availB uint64
+		var totalB uint64
+		var freeTotalB uint64
+		var pathP = windows.StringToUTF16Ptr(path)
+
+		err := windows.GetDiskFreeSpaceEx(pathP, &availB, &totalB, &freeTotalB)
+		if err != nil {
+			return 0, fmt.Errorf("get disk stat by '%s' path: %w", path, err)
+		}
+
+		total += totalB
+		diskMap[disk] = struct{}{}
+	}
+
+	return total, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.etcd.io/bbolt v1.3.7
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sys v0.8.0
 	golang.org/x/term v0.5.0
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
@@ -97,7 +98,6 @@ require (
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect


### PR DESCRIPTION
It is done automatically (as a sum of existing space on every file system available on the configured shards) but can be overwritten if `Capacity` attribute is provided via the application configuration. Closes #602.