### PR TITLE
neofs-adm: init and update-contracts are the only commands for wallets creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Storage node no longer ignores unhealthy shards on startup (#2464)
 - Processing of status errors returned by API client from NeoFS SDK RC-9 (#2465)
 - `neofs-lens write-cache list` command duplication (#2505)
+- `neofs-adm` works with contract wallet in `init` and `update-contracts` commands only (#2134)
 
 ### Removed
 - Deprecated `morph.rpc_endpoint` SN and `morph.endpoint.client` IR config sections (#2400)

--- a/cmd/neofs-adm/internal/modules/morph/initialize.go
+++ b/cmd/neofs-adm/internal/modules/morph/initialize.go
@@ -114,7 +114,7 @@ func newInitializeContext(cmd *cobra.Command, v *viper.Viper) (*initializeContex
 	}
 
 	var w *wallet.Wallet
-	if cmd.Name() != "deploy" {
+	if cmd.Name() == "update-contracts" || cmd.Name() == "init" {
 		w, err = openContractWallet(v, cmd, walletDir)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
added checks for commands before wallet creation

Closes #2134.