### PR TITLE
fix/Do not treat `EOF` as a network error

### DIFF
--- a/cmd/neofs-cli/internal/client/client.go
+++ b/cmd/neofs-cli/internal/client/client.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -439,7 +440,7 @@ func PutObject(ctx context.Context, prm PutObjectPrm) (*PutObjectRes, error) {
 		buf := make([]byte, sz)
 
 		_, err = io.CopyBuffer(wrt, prm.rdr, buf)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, fmt.Errorf("copy data into object stream: %w", err)
 		}
 	}

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -409,7 +409,7 @@ func PutObject(prm PutObjectPrm) (*PutObjectRes, error) {
 	}
 
 	_, err = w.Write(prm.obj.Payload())
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("write object payload into stream: %w", err)
 	}
 


### PR DESCRIPTION
That is the only possible way `client.Client` can say stream has been closed (because of internal logic, not the network/unexpected errors) in the current API. It returned `bool` in the previous versions.
Closes #2513, closes #2502.