### PR TITLE
cli: unify usage of expired-at flag instead of lifetime flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - `peapod` command for `neofs-lens` (#2507)
 -  New CLI exit code for awaiting timeout (#2380)
 - Validation of excessive positional arguments to `neofs-cli` commands (#1941)
+- `--lifetime` flag to `bearer create` and `object put` CLI commands  (#1574) 
+- `--expired-at` flag to `session create` and `storagegroup put` CLI commands (#1574)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -54,7 +54,7 @@ var objectLockCmd = &cobra.Command{
 		exp, _ := cmd.Flags().GetUint64(commonflags.ExpireAt)
 		lifetime, _ := cmd.Flags().GetUint64(commonflags.Lifetime)
 		if exp == 0 && lifetime == 0 { // mutual exclusion is ensured by cobra
-			common.ExitOnErr(cmd, "", errors.New("either expiration epoch of a lifetime is required"))
+			common.ExitOnErr(cmd, "", errors.New("expiration epoch or lifetime period is required"))
 		}
 
 		if lifetime != 0 {

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -278,8 +278,11 @@ func OpenSessionViaClient(ctx context.Context, cmd *cobra.Command, dst SessionPr
 	const sessionLifetime = 10 // in NeoFS epochs
 
 	common.PrintVerbose(cmd, "Opening remote session with the node...")
-
-	err := sessionCli.CreateSession(ctx, &tok, cli, *key, sessionLifetime)
+	endpoint, _ := cmd.Flags().GetString(commonflags.RPC)
+	currEpoch, err := internal.GetCurrentEpoch(ctx, endpoint)
+	common.ExitOnErr(cmd, "can't fetch current epoch: %w", err)
+	exp := currEpoch + sessionLifetime
+	err = sessionCli.CreateSession(ctx, &tok, cli, *key, exp, currEpoch)
 	common.ExitOnErr(cmd, "open remote session: %w", err)
 
 	common.PrintVerbose(cmd, "Session successfully opened.")


### PR DESCRIPTION
The expired-at flag replaces the deprecated lifetime flag. 

Closes #1574.