### PR TITLE
workflow: Change neofs-dev-env ref

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nspcc-dev/neofs-dev-env
-          ref: 'feat/make-health-check-not-depend-on-shell'
+          ref: 'master'
           path: neofs-dev-env
 
       - name: Checkout neofs-node repository


### PR DESCRIPTION
Because the PR https://github.com/nspcc-dev/neofs-dev-env/pull/272 is already merged, we need to change the ref from the temporary branch back to the master.