### PR TITLE
neofs-cli: add check commands positional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - SN's version and capacity is announced via the attributes automatically but can be overwritten explicitly (#2455, #602)
 - `peapod` command for `neofs-lens` (#2507)
 -  New CLI exit code for awaiting timeout (#2380)
+- Validation of excessive positional arguments to `neofs-cli` commands (#1941)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-cli/modules/accounting/balance.go
+++ b/cmd/neofs-cli/modules/accounting/balance.go
@@ -24,7 +24,8 @@ var accountingBalanceCmd = &cobra.Command{
 	Use:   "balance",
 	Short: "Get internal balance of NeoFS account",
 	Long:  `Get internal balance of NeoFS account`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx := context.Background()
 
 		var idUser user.ID

--- a/cmd/neofs-cli/modules/accounting/root.go
+++ b/cmd/neofs-cli/modules/accounting/root.go
@@ -11,7 +11,8 @@ var Cmd = &cobra.Command{
 	Use:   "accounting",
 	Short: "Operations with accounts and balances",
 	Long:  `Operations with accounts and balances`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		flags := cmd.Flags()
 
 		_ = viper.BindPFlag(commonflags.WalletPath, flags.Lookup(commonflags.WalletPath))

--- a/cmd/neofs-cli/modules/acl/extended/create.go
+++ b/cmd/neofs-cli/modules/acl/extended/create.go
@@ -44,7 +44,8 @@ When both '--rule' and '--file' arguments are used, '--rule' records will be pla
 `,
 	Example: `neofs-cli acl extended create --cid EutHBsdT1YCzHxjCfQHnLPL1vFrkSyLSio4vkphfnEk -f rules.txt --out table.json
 neofs-cli acl extended create --cid EutHBsdT1YCzHxjCfQHnLPL1vFrkSyLSio4vkphfnEk -r 'allow get obj:Key=Value others' -r 'deny put others'`,
-	Run: createEACL,
+	Args: cobra.NoArgs,
+	Run:  createEACL,
 }
 
 func init() {

--- a/cmd/neofs-cli/modules/acl/extended/print.go
+++ b/cmd/neofs-cli/modules/acl/extended/print.go
@@ -13,6 +13,7 @@ import (
 var printEACLCmd = &cobra.Command{
 	Use:   "print",
 	Short: "Pretty print extended ACL from the file(in text or json format) or for given container.",
+	Args:  cobra.NoArgs,
 	Run:   printEACL,
 }
 

--- a/cmd/neofs-cli/modules/bearer/create.go
+++ b/cmd/neofs-cli/modules/bearer/create.go
@@ -34,7 +34,8 @@ All epoch flags can be specified relative to the current epoch with the +n synta
 In this case --` + commonflags.RPC + ` flag should be specified and the epoch in bearer token
 is set to current epoch + n.
 `,
-	Run: createToken,
+	Args: cobra.NoArgs,
+	Run:  createToken,
 }
 
 func init() {

--- a/cmd/neofs-cli/modules/container/create.go
+++ b/cmd/neofs-cli/modules/container/create.go
@@ -34,7 +34,8 @@ var createContainerCmd = &cobra.Command{
 	Short: "Create new container",
 	Long: `Create new container and register it in the NeoFS. 
 It will be stored in sidechain when inner ring will accepts it.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := getAwaitContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/delete.go
+++ b/cmd/neofs-cli/modules/container/delete.go
@@ -18,7 +18,8 @@ var deleteContainerCmd = &cobra.Command{
 	Short: "Delete existing container",
 	Long: `Delete existing container. 
 Only owner of the container has a permission to remove container.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := getAwaitContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/get.go
+++ b/cmd/neofs-cli/modules/container/get.go
@@ -30,7 +30,8 @@ var getContainerInfoCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get container field info",
 	Long:  `Get container field info`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/get_eacl.go
+++ b/cmd/neofs-cli/modules/container/get_eacl.go
@@ -13,7 +13,8 @@ var getExtendedACLCmd = &cobra.Command{
 	Use:   "get-eacl",
 	Short: "Get extended ACL table of container",
 	Long:  `Get extended ACL table of container`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/list.go
+++ b/cmd/neofs-cli/modules/container/list.go
@@ -28,7 +28,8 @@ var listContainersCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all created containers",
 	Long:  "List all created containers",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/list_objects.go
+++ b/cmd/neofs-cli/modules/container/list_objects.go
@@ -28,7 +28,8 @@ var listContainerObjectsCmd = &cobra.Command{
 	Use:   "list-objects",
 	Short: "List existing objects in container",
 	Long:  `List existing objects in container`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/nodes.go
+++ b/cmd/neofs-cli/modules/container/nodes.go
@@ -15,7 +15,8 @@ var containerNodesCmd = &cobra.Command{
 	Use:   "nodes",
 	Short: "Show nodes for container",
 	Long:  "Show nodes taking part in a container at the current epoch.",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/container/set_eacl.go
+++ b/cmd/neofs-cli/modules/container/set_eacl.go
@@ -25,7 +25,8 @@ var setExtendedACLCmd = &cobra.Command{
 	Short: "Set new extended ACL table for container",
 	Long: `Set new extended ACL table for container.
 Container ID in EACL table will be substituted with ID from the CLI.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := getAwaitContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/control/drop_objects.go
+++ b/cmd/neofs-cli/modules/control/drop_objects.go
@@ -15,7 +15,8 @@ var dropObjectsCmd = &cobra.Command{
 	Use:   "drop-objects",
 	Short: "Drop objects from the node's local storage",
 	Long:  "Drop objects from the node's local storage",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/control/evacuate_shard.go
+++ b/cmd/neofs-cli/modules/control/evacuate_shard.go
@@ -13,6 +13,7 @@ var evacuateShardCmd = &cobra.Command{
 	Use:   "evacuate",
 	Short: "Evacuate objects from shard",
 	Long:  "Evacuate objects from shard to other shards",
+	Args:  cobra.NoArgs,
 	Run:   evacuateShard,
 }
 

--- a/cmd/neofs-cli/modules/control/flush_cache.go
+++ b/cmd/neofs-cli/modules/control/flush_cache.go
@@ -13,6 +13,7 @@ var flushCacheCmd = &cobra.Command{
 	Use:   "flush-cache",
 	Short: "Flush objects from the write-cache to the main storage",
 	Long:  "Flush objects from the write-cache to the main storage",
+	Args:  cobra.NoArgs,
 	Run:   flushCache,
 }
 

--- a/cmd/neofs-cli/modules/control/healthcheck.go
+++ b/cmd/neofs-cli/modules/control/healthcheck.go
@@ -23,6 +23,7 @@ var healthCheckCmd = &cobra.Command{
 	Use:   "healthcheck",
 	Short: "Health check of the NeoFS node",
 	Long:  "Health check of the NeoFS node. Checks storage node by default, use --ir flag to work with Inner Ring.",
+	Args:  cobra.NoArgs,
 	Run:   healthCheck,
 }
 

--- a/cmd/neofs-cli/modules/control/set_netmap_status.go
+++ b/cmd/neofs-cli/modules/control/set_netmap_status.go
@@ -23,6 +23,7 @@ var setNetmapStatusCmd = &cobra.Command{
 	Use:   "set-status",
 	Short: "Set status of the storage node in NeoFS network map",
 	Long:  "Set status of the storage node in NeoFS network map",
+	Args:  cobra.NoArgs,
 	Run:   setNetmapStatus,
 }
 

--- a/cmd/neofs-cli/modules/control/shards_dump.go
+++ b/cmd/neofs-cli/modules/control/shards_dump.go
@@ -18,6 +18,7 @@ var dumpShardCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Dump objects from shard",
 	Long:  "Dump objects from shard to a file",
+	Args:  cobra.NoArgs,
 	Run:   dumpShard,
 }
 

--- a/cmd/neofs-cli/modules/control/shards_list.go
+++ b/cmd/neofs-cli/modules/control/shards_list.go
@@ -19,6 +19,7 @@ var listShardsCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List shards of the storage node",
 	Long:  "List shards of the storage node",
+	Args:  cobra.NoArgs,
 	Run:   listShards,
 }
 

--- a/cmd/neofs-cli/modules/control/shards_restore.go
+++ b/cmd/neofs-cli/modules/control/shards_restore.go
@@ -18,6 +18,7 @@ var restoreShardCmd = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore objects from shard",
 	Long:  "Restore objects from shard to a file",
+	Args:  cobra.NoArgs,
 	Run:   restoreShard,
 }
 

--- a/cmd/neofs-cli/modules/control/shards_set_mode.go
+++ b/cmd/neofs-cli/modules/control/shards_set_mode.go
@@ -75,6 +75,7 @@ var setShardModeCmd = &cobra.Command{
 	Use:   "set-mode",
 	Short: "Set work mode of the shard",
 	Long:  "Set work mode of the shard",
+	Args:  cobra.NoArgs,
 	Run:   setShardMode,
 }
 

--- a/cmd/neofs-cli/modules/control/synchronize_tree.go
+++ b/cmd/neofs-cli/modules/control/synchronize_tree.go
@@ -23,6 +23,7 @@ var synchronizeTreeCmd = &cobra.Command{
 	Use:   "synchronize-tree",
 	Short: "Synchronize log for the tree",
 	Long:  "Synchronize log for the tree in an object tree service.",
+	Args:  cobra.NoArgs,
 	Run:   synchronizeTree,
 }
 

--- a/cmd/neofs-cli/modules/netmap/get_epoch.go
+++ b/cmd/neofs-cli/modules/netmap/get_epoch.go
@@ -11,7 +11,8 @@ var getEpochCmd = &cobra.Command{
 	Use:   "epoch",
 	Short: "Get current epoch number",
 	Long:  "Get current epoch number",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -15,7 +15,8 @@ var netInfoCmd = &cobra.Command{
 	Use:   "netinfo",
 	Short: "Get information about NeoFS network",
 	Long:  "Get information about NeoFS network",
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/netmap/nodeinfo.go
+++ b/cmd/neofs-cli/modules/netmap/nodeinfo.go
@@ -16,7 +16,8 @@ var nodeInfoCmd = &cobra.Command{
 	Use:   "nodeinfo",
 	Short: "Get target node info",
 	Long:  `Get target node info`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/netmap/snapshot.go
+++ b/cmd/neofs-cli/modules/netmap/snapshot.go
@@ -11,7 +11,8 @@ var snapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Request current local snapshot of the network map",
 	Long:  `Request current local snapshot of the network map`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()
 

--- a/cmd/neofs-cli/modules/object/delete.go
+++ b/cmd/neofs-cli/modules/object/delete.go
@@ -17,6 +17,7 @@ var objectDelCmd = &cobra.Command{
 	Aliases: []string{"del"},
 	Short:   "Delete object from NeoFS",
 	Long:    "Delete object from NeoFS",
+	Args:    cobra.NoArgs,
 	Run:     deleteObject,
 }
 

--- a/cmd/neofs-cli/modules/object/get.go
+++ b/cmd/neofs-cli/modules/object/get.go
@@ -21,6 +21,7 @@ var objectGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get object from NeoFS",
 	Long:  "Get object from NeoFS",
+	Args:  cobra.NoArgs,
 	Run:   getObject,
 }
 

--- a/cmd/neofs-cli/modules/object/hash.go
+++ b/cmd/neofs-cli/modules/object/hash.go
@@ -27,6 +27,7 @@ var objectHashCmd = &cobra.Command{
 	Use:   "hash",
 	Short: "Get object hash",
 	Long:  "Get object hash",
+	Args:  cobra.NoArgs,
 	Run:   getObjectHash,
 }
 

--- a/cmd/neofs-cli/modules/object/head.go
+++ b/cmd/neofs-cli/modules/object/head.go
@@ -21,6 +21,7 @@ var objectHeadCmd = &cobra.Command{
 	Use:   "head",
 	Short: "Get object header",
 	Long:  "Get object header",
+	Args:  cobra.NoArgs,
 	Run:   getObjectHeader,
 }
 

--- a/cmd/neofs-cli/modules/object/lock.go
+++ b/cmd/neofs-cli/modules/object/lock.go
@@ -24,6 +24,7 @@ var objectLockCmd = &cobra.Command{
 	Use:   "lock",
 	Short: "Lock object in container",
 	Long:  "Lock object in container",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()

--- a/cmd/neofs-cli/modules/object/put.go
+++ b/cmd/neofs-cli/modules/object/put.go
@@ -33,6 +33,7 @@ var objectPutCmd = &cobra.Command{
 	Use:   "put",
 	Short: "Put object to NeoFS",
 	Long:  "Put object to NeoFS",
+	Args:  cobra.NoArgs,
 	Run:   putObject,
 }
 

--- a/cmd/neofs-cli/modules/object/range.go
+++ b/cmd/neofs-cli/modules/object/range.go
@@ -23,6 +23,7 @@ var objectRangeCmd = &cobra.Command{
 	Use:   "range",
 	Short: "Get payload range data of an object",
 	Long:  "Get payload range data of an object",
+	Args:  cobra.NoArgs,
 	Run:   getObjectRange,
 }
 

--- a/cmd/neofs-cli/modules/object/search.go
+++ b/cmd/neofs-cli/modules/object/search.go
@@ -22,6 +22,7 @@ var (
 		Use:   "search",
 		Short: "Search object",
 		Long:  "Search object",
+		Args:  cobra.NoArgs,
 		Run:   searchObject,
 	}
 )

--- a/cmd/neofs-cli/modules/root.go
+++ b/cmd/neofs-cli/modules/root.go
@@ -43,7 +43,8 @@ It contains commands for interaction with NeoFS nodes using different versions
 of neofs-api and some useful utilities for compiling ACL rules from JSON
 notation, managing container access through protocol gates, querying network map
 and much more!`,
-	Run: entryPoint,
+	Args: cobra.NoArgs,
+	Run:  entryPoint,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/neofs-cli/modules/session/create.go
+++ b/cmd/neofs-cli/modules/session/create.go
@@ -29,6 +29,7 @@ const defaultLifetime = 10
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create session token",
+	Args:  cobra.NoArgs,
 	Run:   createSession,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		_ = viper.BindPFlag(commonflags.WalletPath, cmd.Flags().Lookup(commonflags.WalletPath))

--- a/cmd/neofs-cli/modules/storagegroup/delete.go
+++ b/cmd/neofs-cli/modules/storagegroup/delete.go
@@ -15,6 +15,7 @@ var sgDelCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete storage group from NeoFS",
 	Long:  "Delete storage group from NeoFS",
+	Args:  cobra.NoArgs,
 	Run:   delSG,
 }
 

--- a/cmd/neofs-cli/modules/storagegroup/get.go
+++ b/cmd/neofs-cli/modules/storagegroup/get.go
@@ -20,6 +20,7 @@ var sgGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get storage group from NeoFS",
 	Long:  "Get storage group from NeoFS",
+	Args:  cobra.NoArgs,
 	Run:   getSG,
 }
 

--- a/cmd/neofs-cli/modules/storagegroup/list.go
+++ b/cmd/neofs-cli/modules/storagegroup/list.go
@@ -15,6 +15,7 @@ var sgListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List storage groups in NeoFS container",
 	Long:  "List storage groups in NeoFS container",
+	Args:  cobra.NoArgs,
 	Run:   listSG,
 }
 

--- a/cmd/neofs-cli/modules/storagegroup/put.go
+++ b/cmd/neofs-cli/modules/storagegroup/put.go
@@ -28,6 +28,7 @@ var sgPutCmd = &cobra.Command{
 	Use:   "put",
 	Short: "Put storage group to NeoFS",
 	Long:  "Put storage group to NeoFS",
+	Args:  cobra.NoArgs,
 	Run:   putSG,
 }
 

--- a/cmd/neofs-cli/modules/tree/add.go
+++ b/cmd/neofs-cli/modules/tree/add.go
@@ -17,6 +17,7 @@ var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a node to the tree service",
 	Run:   add,
+	Args:  cobra.NoArgs,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		commonflags.Bind(cmd)
 	},

--- a/cmd/neofs-cli/modules/tree/add_by_path.go
+++ b/cmd/neofs-cli/modules/tree/add_by_path.go
@@ -16,6 +16,7 @@ import (
 var addByPathCmd = &cobra.Command{
 	Use:   "add-by-path",
 	Short: "Add a node by the path",
+	Args:  cobra.NoArgs,
 	Run:   addByPath,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		commonflags.Bind(cmd)

--- a/cmd/neofs-cli/modules/tree/get_by_path.go
+++ b/cmd/neofs-cli/modules/tree/get_by_path.go
@@ -16,6 +16,7 @@ import (
 var getByPathCmd = &cobra.Command{
 	Use:   "get-by-path",
 	Short: "Get a node by its path",
+	Args:  cobra.NoArgs,
 	Run:   getByPath,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		commonflags.Bind(cmd)

--- a/cmd/neofs-cli/modules/tree/list.go
+++ b/cmd/neofs-cli/modules/tree/list.go
@@ -14,6 +14,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Get tree IDs",
+	Args:  cobra.NoArgs,
 	Run:   list,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		commonflags.Bind(cmd)

--- a/cmd/neofs-cli/modules/util/convert_eacl.go
+++ b/cmd/neofs-cli/modules/util/convert_eacl.go
@@ -11,6 +11,7 @@ import (
 var convertEACLCmd = &cobra.Command{
 	Use:   "eacl",
 	Short: "Convert representation of extended ACL table",
+	Args:  cobra.NoArgs,
 	Run:   convertEACLTable,
 }
 

--- a/cmd/neofs-cli/modules/util/locode_generate.go
+++ b/cmd/neofs-cli/modules/util/locode_generate.go
@@ -35,6 +35,7 @@ var (
 	locodeGenerateCmd = &cobra.Command{
 		Use:   "generate",
 		Short: "Generate UN/LOCODE database for NeoFS",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			locodeDB := csvlocode.New(
 				csvlocode.Prm{

--- a/cmd/neofs-cli/modules/util/locode_info.go
+++ b/cmd/neofs-cli/modules/util/locode_info.go
@@ -19,6 +19,7 @@ var (
 	locodeInfoCmd = &cobra.Command{
 		Use:   "info",
 		Short: "Print information about UN/LOCODE from NeoFS database",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			targetDB := locodebolt.New(locodebolt.Prm{
 				Path: locodeInfoDBPath,

--- a/cmd/neofs-cli/modules/util/sign_bearer.go
+++ b/cmd/neofs-cli/modules/util/sign_bearer.go
@@ -17,6 +17,7 @@ const (
 var signBearerCmd = &cobra.Command{
 	Use:   "bearer-token",
 	Short: "Sign bearer token to use it in requests",
+	Args:  cobra.NoArgs,
 	Run:   signBearerToken,
 }
 

--- a/cmd/neofs-cli/modules/util/sign_session.go
+++ b/cmd/neofs-cli/modules/util/sign_session.go
@@ -17,6 +17,7 @@ import (
 var signSessionCmd = &cobra.Command{
 	Use:   "session-token",
 	Short: "Sign session token to use it in requests",
+	Args:  cobra.NoArgs,
 	Run:   signSessionToken,
 }
 


### PR DESCRIPTION
Added Cobra's check of positional arguments to prevent logically incorrect argument usage and passing redundant arguments to the commands.

Closes #1941.