### PR TITLE
feat/Add `object nodes` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - `--lifetime` flag to `bearer create` and `object put` CLI commands  (#1574) 
 - `--expired-at` flag to `session create` and `storagegroup put` CLI commands (#1574)
 - Sessions to RPC server running in IR's local consensus mode (#2532)
+- `neofs-cli object nodes` command to get SNs for an object (#2512)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-cli/modules/object/nodes.go
+++ b/cmd/neofs-cli/modules/object/nodes.go
@@ -1,0 +1,78 @@
+package object
+
+import (
+	internalclient "github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/client"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/commonflags"
+	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/spf13/cobra"
+)
+
+const (
+	shortFlag      = "short"
+	shortFlagUsage = "Short node output info"
+)
+
+// object lock command.
+var objectNodesCmd = &cobra.Command{
+	Use:   "nodes",
+	Short: "Show nodes for an object",
+	Long:  "Show nodes taking part in an object placement at the current epoch.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx, cancel := commonflags.GetCommandContext(cmd)
+		defer cancel()
+
+		var cnrID cid.ID
+		readCID(cmd, &cnrID)
+
+		var oID oid.ID
+		readOID(cmd, &oID)
+
+		cli := internalclient.GetSDKClientByFlag(ctx, cmd, commonflags.RPC)
+
+		var prmSnap internalclient.NetMapSnapshotPrm
+		prmSnap.SetClient(cli)
+
+		resmap, err := internalclient.NetMapSnapshot(ctx, prmSnap)
+		common.ExitOnErr(cmd, "could not get netmap snapshot", err)
+
+		var prmCnr internalclient.GetContainerPrm
+		prmCnr.SetClient(cli)
+		prmCnr.SetContainer(cnrID)
+
+		res, err := internalclient.GetContainer(ctx, prmCnr)
+		common.ExitOnErr(cmd, "could not get container: %w", err)
+
+		cnr := res.Container()
+		policy := cnr.PlacementPolicy()
+
+		var cnrNodes [][]netmap.NodeInfo
+		cnrNodes, err = resmap.NetMap().ContainerNodes(policy, cnrID)
+		common.ExitOnErr(cmd, "could not build container nodes for the given container: %w", err)
+
+		placementNodes, err := resmap.NetMap().PlacementVectors(cnrNodes, oID)
+		common.ExitOnErr(cmd, "could not build placement nodes for the given container: %w", err)
+
+		short, _ := cmd.Flags().GetBool(shortFlag)
+
+		for i := range placementNodes {
+			cmd.Printf("Descriptor #%d, REP %d:\n", i+1, policy.ReplicaNumberByIndex(i))
+			for j := range placementNodes[i] {
+				common.PrettyPrintNodeInfo(cmd, placementNodes[i][j], j, "\t", short)
+			}
+		}
+	},
+}
+
+func initObjectNodesCmd() {
+	ff := objectNodesCmd.Flags()
+
+	ff.StringP(commonflags.RPC, commonflags.RPCShorthand, commonflags.RPCDefault, commonflags.RPCUsage)
+	ff.DurationP(commonflags.Timeout, commonflags.TimeoutShorthand, commonflags.TimeoutDefault, commonflags.TimeoutUsage)
+	ff.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
+	ff.String(commonflags.OIDFlag, "", commonflags.OIDFlagUsage)
+	ff.Bool(shortFlag, false, shortFlagUsage)
+}

--- a/cmd/neofs-cli/modules/object/root.go
+++ b/cmd/neofs-cli/modules/object/root.go
@@ -19,7 +19,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	objectChildCommands := []*cobra.Command{
+	objectRPCs := []*cobra.Command{
 		objectPutCmd,
 		objectDelCmd,
 		objectGetCmd,
@@ -29,9 +29,10 @@ func init() {
 		objectRangeCmd,
 		objectLockCmd}
 
-	Cmd.AddCommand(objectChildCommands...)
+	Cmd.AddCommand(objectNodesCmd)
+	Cmd.AddCommand(objectRPCs...)
 
-	for _, objCommand := range objectChildCommands {
+	for _, objCommand := range objectRPCs {
 		InitBearer(objCommand)
 		commonflags.InitAPI(objCommand)
 	}
@@ -44,4 +45,5 @@ func init() {
 	initObjectHashCmd()
 	initObjectRangeCmd()
 	initCommandObjectLock()
+	initObjectNodesCmd()
 }


### PR DESCRIPTION
It applies placement policy rules to the current network map for the provided object. Works the same way `container nodes` does.