### PR TITLE
ir: Always enable RPC sessions in local consensus launch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Validation of excessive positional arguments to `neofs-cli` commands (#1941)
 - `--lifetime` flag to `bearer create` and `object put` CLI commands  (#1574) 
 - `--expired-at` flag to `session create` and `storagegroup put` CLI commands (#1574)
+- Sessions to RPC server running in IR's local consensus mode (#2532)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -370,6 +370,9 @@ func New(cfg Config) (res *Blockchain, err error) {
 	cfgBaseApp.P2PNotary.UnlockWallet = cfg.Wallet
 	cfgBaseApp.RPC.StartWhenSynchronized = true
 	cfgBaseApp.RPC.MaxGasInvoke = fixedn.Fixed8FromInt64(100)
+	cfgBaseApp.RPC.SessionEnabled = true
+	// MaxIteratorResultItems must be explicitly set for rpcsrv.New because it doesn't set default
+	cfgBaseApp.RPC.MaxIteratorResultItems = config.DefaultMaxIteratorResultItems
 	cfgBaseApp.P2P.Addresses = cfg.P2P.ListenAddresses
 	cfgBaseApp.P2P.DialTimeout = cfg.P2P.DialTimeout
 	cfgBaseApp.P2P.ProtoTickInterval = cfg.P2P.ProtoTickInterval


### PR DESCRIPTION
@roman-khimov @AnnaShaleva note that i've left other session-related configurations unset https://pkg.go.dev/github.com/nspcc-dev/neo-go@v0.101.4/pkg/config#RPC, if u have any suggestions about non-default values pls let me know

* see also https://github.com/nspcc-dev/neo-go/issues/3106