### PR TITLE
.github: Add flag to enable metabase resync

### DIFF
--- a/.github/testcases-env
+++ b/.github/testcases-env
@@ -7,6 +7,9 @@ CA_CERTS_TRUSTED_STORE=./vendor/certs
 BASTION_VERSION=10
 BASTION_IMAGE=debian
 
+# Flag to enable metabase resync on start
+RESYNC_METABASE=false
+
 # NeoGo privnet
 #CHAIN_PATH="/path/to/devenv.dump.gz"
 CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.17.0/devenv_mainchain.gz"


### PR DESCRIPTION
Add flag to enable metabase resync on start.
This flag will be false by default and will not change the behavior of the system in any way.
These changes are needed for system tests, tests will change the RESYNC_METABASE flag.
https://github.com/nspcc-dev/neofs-testcases/issues/556

See also:
https://github.com/nspcc-dev/neofs-dev-env/pull/285