### PR TITLE
neofs-lens: add new command meta object put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Display of container alias fee info in `neofs-cli netmap netinfo` (#2553)
 - `neofs-lens storage inspect` CLI command (#1336)
 - `neofs-lens` payload-only flag (#2543)
+- `neofs-lens meta put` CLI command (#1816)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-lens/internal/flags.go
+++ b/cmd/neofs-lens/internal/flags.go
@@ -9,6 +9,7 @@ const (
 	flagEnginePath = "path"
 	flagOutFile    = "out"
 	flagConfigFile = "config"
+	flagInFile     = "obj"
 )
 
 // AddAddressFlag adds the address flag to the passed cobra command.
@@ -45,4 +46,12 @@ func AddConfigFileFlag(cmd *cobra.Command, v *string) {
 
 func AddPayloadOnlyFlag(cmd *cobra.Command, v *bool) {
 	cmd.Flags().BoolVar(v, "payload-only", false, "Save only object payload")
+}
+
+// AddInputPathFile adds the input file with object flag to the passed cobra command.
+func AddInputPathFile(cmd *cobra.Command, v *string) {
+	cmd.Flags().StringVar(v, flagInFile, "",
+		"Path to file with object")
+	_ = cmd.MarkFlagFilename(flagInFile)
+	_ = cmd.MarkFlagRequired(flagInFile)
 }

--- a/cmd/neofs-lens/internal/meta/inspect.go
+++ b/cmd/neofs-lens/internal/meta/inspect.go
@@ -30,7 +30,7 @@ func inspectFunc(cmd *cobra.Command, _ []string) {
 	err := addr.DecodeString(vAddress)
 	common.ExitOnErr(cmd, common.Errf("invalid address argument: %w", err))
 
-	db := openMeta(cmd)
+	db := openMeta(cmd, true)
 	defer db.Close()
 
 	storageID := meta.StorageIDPrm{}

--- a/cmd/neofs-lens/internal/meta/list-garbage.go
+++ b/cmd/neofs-lens/internal/meta/list-garbage.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func listGarbageFunc(cmd *cobra.Command, _ []string) {
-	db := openMeta(cmd)
+	db := openMeta(cmd, true)
 	defer db.Close()
 
 	var garbPrm meta.GarbageIterationPrm

--- a/cmd/neofs-lens/internal/meta/list-graveyard.go
+++ b/cmd/neofs-lens/internal/meta/list-graveyard.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func listGraveyardFunc(cmd *cobra.Command, _ []string) {
-	db := openMeta(cmd)
+	db := openMeta(cmd, true)
 	defer db.Close()
 
 	var gravePrm meta.GraveyardIterationPrm

--- a/cmd/neofs-lens/internal/meta/put.go
+++ b/cmd/neofs-lens/internal/meta/put.go
@@ -1,0 +1,57 @@
+package meta
+
+import (
+	"errors"
+	"os"
+
+	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	"github.com/spf13/cobra"
+)
+
+var writeObjectCMD = &cobra.Command{
+	Use:   "put",
+	Short: "Put object to metabase",
+	Long:  "Put object from file to metabase",
+	Args:  cobra.NoArgs,
+	Run:   writeObject,
+}
+
+func init() {
+	common.AddComponentPathFlag(writeObjectCMD, &vPath)
+	common.AddInputPathFile(writeObjectCMD, &vInputObj)
+}
+
+func writeObject(cmd *cobra.Command, _ []string) {
+	db := openMeta(cmd, false)
+	defer db.Close()
+
+	err := db.Init()
+	common.ExitOnErr(cmd, common.Errf("can't init metabase: %w", err))
+
+	buf, err := os.ReadFile(vInputObj)
+	common.ExitOnErr(cmd, common.Errf("unable to read given file: %w", err))
+
+	obj := object.New()
+	common.ExitOnErr(cmd, common.Errf("can't unmarshal object from given file: %w", obj.Unmarshal(buf)))
+
+	id, ok := obj.ID()
+	if !ok {
+		common.ExitOnErr(cmd, errors.New("missing ID in object"))
+	}
+
+	cnr, ok := obj.ContainerID()
+	if !ok {
+		common.ExitOnErr(cmd, errors.New("missing container ID in object"))
+	}
+
+	var pPrm meta.PutPrm
+	pPrm.SetObject(obj)
+
+	_, err = db.Put(pPrm)
+	common.ExitOnErr(cmd, common.Errf("can't put object: %w", err))
+
+	cmd.Printf("[%s] Object successfully stored\n", vInputObj)
+	cmd.Printf("  OID: %s\n  CID: %s\n", id, cnr)
+}

--- a/cmd/neofs-lens/internal/meta/root.go
+++ b/cmd/neofs-lens/internal/meta/root.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"os"
 	"time"
 
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
@@ -10,8 +11,9 @@ import (
 )
 
 var (
-	vAddress string
-	vPath    string
+	vAddress  string
+	vPath     string
+	vInputObj string
 )
 
 type epochState struct{}
@@ -31,19 +33,23 @@ func init() {
 		inspectCMD,
 		listGraveyardCMD,
 		listGarbageCMD,
+		writeObjectCMD,
 	)
 }
 
-func openMeta(cmd *cobra.Command) *meta.DB {
+func openMeta(cmd *cobra.Command, readOnly bool) *meta.DB {
+	_, err := os.Stat(vPath)
+	common.ExitOnErr(cmd, err)
+
 	db := meta.New(
 		meta.WithPath(vPath),
 		meta.WithBoltDBOptions(&bbolt.Options{
-			ReadOnly: true,
+			ReadOnly: readOnly,
 			Timeout:  100 * time.Millisecond,
 		}),
 		meta.WithEpochState(epochState{}),
 	)
-	common.ExitOnErr(cmd, common.Errf("could not open metabase: %w", db.Open(true)))
+	common.ExitOnErr(cmd, common.Errf("could not open metabase: %w", db.Open(readOnly)))
 
 	return db
 }


### PR DESCRIPTION
This command places the object into the metabase. It can be useful if you want to add an object directly to the metabase.
`neofs-lens meta put --obj ./myobj --path ./meta.db`
Now if db doesn't exist it creates a new one, Is it expected behavior?
Closes #1816.