### PR TITLE
neofs-cli: netmap netinfo displays ContainerAliasFee network config paramenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Fetching container estimations via iterators to prevent NeoVM stack overflow (#2173)
 - `neofs-adm morph netmap-candidates` CLI command (#1889)
 - SN network validation (is available by its announced addresses) on bootstrap by the IR (#2475)
+- Display of container alias fee info in `neofs-cli netmap netinfo` (#2553)
 
 ### Fixed
 - `neo-go` RPC connection loss handling (#1337)

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -43,6 +43,7 @@ var netInfoCmd = &cobra.Command{
 		cmd.Printf(format, "Audit fee", netInfo.AuditFee())
 		cmd.Printf(format, "Storage price", netInfo.StoragePrice())
 		cmd.Printf(format, "Container fee", netInfo.ContainerFee())
+		cmd.Printf(format, "Container alias fee", netInfo.NamedContainerFee())
 		cmd.Printf(format, "EigenTrust alpha", netInfo.EigenTrustAlpha())
 		cmd.Printf(format, "Number of EigenTrust iterations", netInfo.NumberOfEigenTrustIterations())
 		cmd.Printf(format, "Epoch duration", netInfo.EpochDuration())


### PR DESCRIPTION
By calling `neofs-cli netmap netinfo`, the user can get information about the container alias fee. NeoFS network configuration has a ContainerAliasFee parameter which is displayed.

Closes #2553.