### PR TITLE
fix/`EndpointInfo` serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - `neofs-adm` works with contract wallet in `init` and `update-contracts` commands only (#2134)
 - Missing removed but locked objects in `SEARCH`'s results (#2526)
 - LOCK objects and regular objects expiration conflicts (#2392)
+- SN responds with a different node information compared to a bootstrapping contract call's argument (#2568)
 
 ### Removed
 - Deprecated `morph.rpc_endpoint` SN and `morph.endpoint.client` IR config sections (#2400)

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -900,7 +900,15 @@ func (c *cfg) handleLocalNodeInfo(ni *netmap.NodeInfo) {
 // with the binary-encoded information from the current node's configuration.
 // The state is set using the provided setter which MUST NOT be nil.
 func (c *cfg) bootstrapWithState(stateSetter func(*netmap.NodeInfo)) error {
-	ni := c.cfgNodeInfo.localInfo
+	var ni netmap.NodeInfo
+	if niAtomic := c.cfgNetmap.state.nodeInfo.Load(); niAtomic != nil {
+		// node has already been bootstrapped successfully
+		ni = niAtomic.(netmap.NodeInfo)
+	} else {
+		// unknown network state
+		ni = c.cfgNodeInfo.localInfo
+	}
+
 	stateSetter(&ni)
 
 	prm := nmClient.AddPeerPrm{}


### PR DESCRIPTION
Be a flexible storage node: take the updated by the Alphabet `NodeInfo` as the
source of truth and bootstrap with it (if this info is available and SN does not
bootstrap for the first time).