### PR TITLE
neofs-cli: fix pass of several object put --attributes flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ minor release, the component will be purged, so be prepared (see `Updating` sect
 - Missing removed but locked objects in `SEARCH`'s results (#2526)
 - LOCK objects and regular objects expiration conflicts (#2392)
 - SN responds with a different node information compared to a bootstrapping contract call's argument (#2568)
+- `neofs-cli object put` command processes multiple `--attributes` flags (#2427)
 
 ### Removed
 - Deprecated `morph.rpc_endpoint` SN and `morph.endpoint.client` IR config sections (#2400)

--- a/cmd/neofs-cli/modules/object/put.go
+++ b/cmd/neofs-cli/modules/object/put.go
@@ -48,7 +48,7 @@ func initObjectPutCmd() {
 
 	flags.String(commonflags.CIDFlag, "", commonflags.CIDFlagUsage)
 
-	flags.String("attributes", "", "User attributes in form of Key1=Value1,Key2=Value2")
+	flags.StringSlice("attributes", []string{}, "User attributes in form of Key1=Value1,Key2=Value2")
 	flags.Bool("disable-filename", false, "Do not set well-known filename attribute")
 	flags.Bool("disable-timestamp", false, "Do not set well-known timestamp attribute")
 	flags.Uint64VarP(&putExpiredOn, commonflags.ExpireAt, "e", 0, "The last active epoch in the life of the object")
@@ -187,10 +187,8 @@ func putObject(cmd *cobra.Command, _ []string) {
 func parseObjectAttrs(cmd *cobra.Command) ([]object.Attribute, error) {
 	var rawAttrs []string
 
-	raw := cmd.Flag("attributes").Value.String()
-	if len(raw) != 0 {
-		rawAttrs = strings.Split(raw, ",")
-	}
+	rawAttrs, err := cmd.Flags().GetStringSlice("attributes")
+	common.ExitOnErr(cmd, "can't get attributes: %w", err)
 
 	attrs := make([]object.Attribute, len(rawAttrs), len(rawAttrs)+2) // name + timestamp attributes
 	for i := range rawAttrs {


### PR DESCRIPTION
The `object put` command previously could only retrieve the last `--attributes` parameter if multiple such parameters were provided. Now, the `object put` command correctly parses all `--attributes` values, whether they are provided as comma-separated or single values.

Closes #2427.