### PR TITLE
neofs-adm: fix displaying values and improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Fixed
+- `neofs-cli netmap netinfo` documentation (#2555)
 
 ### Changed
 - FSTree storage now uses more efficient and safe temporary files under Linux (#2566)

--- a/cmd/neofs-adm/internal/modules/morph/root.go
+++ b/cmd/neofs-adm/internal/modules/morph/root.go
@@ -131,6 +131,9 @@ var (
 		Use:                   "set-config key1=val1 [key2=val2 ...]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Add/update global config value in the NeoFS network",
+		Long: `Add/update global config value in the NeoFS network. 
+				If key is unknown, it will be added to the config only with --force flag.
+Values for unknown keys are added exactly the way they're provided, no conversion is made ("123" will be stored as "313233" hexadecimal).`,
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -14,8 +14,9 @@ import (
 var netInfoCmd = &cobra.Command{
 	Use:   "netinfo",
 	Short: "Get information about NeoFS network",
-	Long:  "Get information about NeoFS network",
-	Args:  cobra.NoArgs,
+	Long: `Get information about NeoFS network.
+		Unknown configuration settings are displayed in hexadecimal format.`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, _ []string) {
 		ctx, cancel := commonflags.GetCommandContext(cmd)
 		defer cancel()


### PR DESCRIPTION
 Comments about the obligatory usage of the `--force` flag for setting unknown parameters have been added. `neofs-cli netmap netinfo` now displays it correctly.

Closes #2555.