### PR TITLE
cmd: fix copyLocks issue

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,4 +50,3 @@ jobs:
         with:
           version: v1.54.0
           args: --timeout=5m
-          only-new-issues: true

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -311,7 +311,7 @@ type shared struct {
 	metricsCollector *metrics.NodeMetrics
 }
 
-func (s shared) resetCaches() {
+func (s *shared) resetCaches() {
 	if s.containerCache != nil {
 		s.containerCache.reset()
 	}


### PR DESCRIPTION
  copylocks: resetCaches passes lock by value: github.com/nspcc-dev/neofs-node/cmd/neofs-node.shared contains sync/atomic.Bool contains sync/atomic.noCopy (govet)

Introduced by #2485.