### PR TITLE
.github: Remove flag RESYNC_METABASE

### DIFF
--- a/.github/testcases-env
+++ b/.github/testcases-env
@@ -7,9 +7,6 @@ CA_CERTS_TRUSTED_STORE=${PWD}/vendor/certs
 BASTION_VERSION=10
 BASTION_IMAGE=debian
 
-# Flag to enable metabase resync on start
-RESYNC_METABASE=false
-
 # NeoGo privnet
 #CHAIN_PATH="/path/to/devenv.dump.gz"
 CHAIN_URL="https://github.com/nspcc-dev/neofs-contract/releases/download/v0.17.0/devenv_mainchain.gz"


### PR DESCRIPTION
This commit rolls back e1aed14226c5ec28f71fa942bd82d2f07a952e3d It was a mistake to make that change.
Now it is not necessary, https://github.com/nspcc-dev/neofs-testcases/pull/608 allows you to do without a separate flag.