### PR TITLE
neofs-lens: rename `inspect` commands to `get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 ### Updated
 - Update minimal supported Go version up to v1.19 (#2485)
 - Update `neo-go` to `v0.102.0` (#2221, #2309, #2596)
+- `neofs-lens` `inspect` object commands to `get` with `inspect` deprecation (#2548)
 
 ### Updating from v0.38.1
 

--- a/cmd/neofs-lens/internal/blobovnicza/inspect.go
+++ b/cmd/neofs-lens/internal/blobovnicza/inspect.go
@@ -9,10 +9,18 @@ import (
 )
 
 var inspectCMD = &cobra.Command{
-	Use:   "inspect",
-	Short: "Object inspection",
-	Long:  `Inspect specific object in a blobovnicza.`,
-	Run:   inspectFunc,
+	Use:        "inspect",
+	Short:      "Object inspection",
+	Long:       `Inspect specific object in a blobovnicza.`,
+	Deprecated: "will be removed in the next release. Use `get` instead.",
+	Run:        getFunc,
+}
+
+var getCMD = &cobra.Command{
+	Use:   "get",
+	Short: "Get object",
+	Long:  `Get specific object from a blobovnicza.`,
+	Run:   getFunc,
 }
 
 func init() {
@@ -20,9 +28,14 @@ func init() {
 	common.AddComponentPathFlag(inspectCMD, &vPath)
 	common.AddOutputFileFlag(inspectCMD, &vOut)
 	common.AddPayloadOnlyFlag(inspectCMD, &vPayloadOnly)
+
+	common.AddAddressFlag(getCMD, &vAddress)
+	common.AddComponentPathFlag(getCMD, &vPath)
+	common.AddOutputFileFlag(getCMD, &vOut)
+	common.AddPayloadOnlyFlag(getCMD, &vPayloadOnly)
 }
 
-func inspectFunc(cmd *cobra.Command, _ []string) {
+func getFunc(cmd *cobra.Command, _ []string) {
 	var addr oid.Address
 
 	err := addr.DecodeString(vAddress)

--- a/cmd/neofs-lens/internal/blobovnicza/root.go
+++ b/cmd/neofs-lens/internal/blobovnicza/root.go
@@ -20,7 +20,7 @@ var Root = &cobra.Command{
 }
 
 func init() {
-	Root.AddCommand(listCMD, inspectCMD)
+	Root.AddCommand(listCMD, inspectCMD, getCMD)
 }
 
 func openBlobovnicza(cmd *cobra.Command) *blobovnicza.Blobovnicza {

--- a/cmd/neofs-lens/internal/meta/inspect.go
+++ b/cmd/neofs-lens/internal/meta/inspect.go
@@ -13,18 +13,29 @@ import (
 )
 
 var inspectCMD = &cobra.Command{
-	Use:   "inspect",
+	Use:        "inspect",
+	Short:      "Object inspection",
+	Long:       `Inspect specific object in a metabase.`,
+	Deprecated: "will be removed in the next release. Use `get` instead.",
+	Run:        getFunc,
+}
+
+var getCMD = &cobra.Command{
+	Use:   "get",
 	Short: "Object inspection",
-	Long:  `Inspect specific object in a metabase.`,
-	Run:   inspectFunc,
+	Long:  `Get specific object from a metabase.`,
+	Run:   getFunc,
 }
 
 func init() {
 	common.AddAddressFlag(inspectCMD, &vAddress)
 	common.AddComponentPathFlag(inspectCMD, &vPath)
+
+	common.AddAddressFlag(getCMD, &vAddress)
+	common.AddComponentPathFlag(getCMD, &vPath)
 }
 
-func inspectFunc(cmd *cobra.Command, _ []string) {
+func getFunc(cmd *cobra.Command, _ []string) {
 	var addr oid.Address
 
 	err := addr.DecodeString(vAddress)

--- a/cmd/neofs-lens/internal/meta/root.go
+++ b/cmd/neofs-lens/internal/meta/root.go
@@ -34,6 +34,7 @@ func init() {
 		listGraveyardCMD,
 		listGarbageCMD,
 		writeObjectCMD,
+		getCMD,
 	)
 }
 

--- a/cmd/neofs-lens/internal/peapod/inspect.go
+++ b/cmd/neofs-lens/internal/peapod/inspect.go
@@ -7,10 +7,18 @@ import (
 )
 
 var inspectCMD = &cobra.Command{
-	Use:   "inspect",
-	Short: "Object inspection",
-	Long:  `Inspect specific object in a Peapod.`,
-	Run:   inspectFunc,
+	Use:        "inspect",
+	Short:      "Object inspection",
+	Long:       `Inspect specific object in a Peapod.`,
+	Deprecated: "will be removed in the next release. Use `get` instead.",
+	Run:        getFunc,
+}
+
+var getCMD = &cobra.Command{
+	Use:   "get",
+	Short: "Get object",
+	Long:  `Get specific object from a Peapod.`,
+	Run:   getFunc,
 }
 
 func init() {
@@ -18,9 +26,14 @@ func init() {
 	common.AddComponentPathFlag(inspectCMD, &vPath)
 	common.AddOutputFileFlag(inspectCMD, &vOut)
 	common.AddPayloadOnlyFlag(inspectCMD, &vPayloadOnly)
+
+	common.AddAddressFlag(getCMD, &vAddress)
+	common.AddComponentPathFlag(getCMD, &vPath)
+	common.AddOutputFileFlag(getCMD, &vOut)
+	common.AddPayloadOnlyFlag(getCMD, &vPayloadOnly)
 }
 
-func inspectFunc(cmd *cobra.Command, _ []string) {
+func getFunc(cmd *cobra.Command, _ []string) {
 	var getPrm blobstorcommon.GetPrm
 
 	err := getPrm.Address.DecodeString(vAddress)

--- a/cmd/neofs-lens/internal/peapod/root.go
+++ b/cmd/neofs-lens/internal/peapod/root.go
@@ -21,7 +21,7 @@ var Root = &cobra.Command{
 }
 
 func init() {
-	Root.AddCommand(listCMD, inspectCMD)
+	Root.AddCommand(listCMD, inspectCMD, getCMD)
 }
 
 // open and returns read-only peapod.Peapod located in vPath.

--- a/cmd/neofs-lens/internal/storage/inspect.go
+++ b/cmd/neofs-lens/internal/storage/inspect.go
@@ -8,11 +8,20 @@ import (
 )
 
 var storageInspectObjCMD = &cobra.Command{
-	Use:   "inspect",
+	Use:        "inspect",
+	Short:      "Get object from the NeoFS node's storage snapshot",
+	Long:       "Get object from the NeoFS node's storage snapshot",
+	Deprecated: "will be removed in the next release. Use `get` instead.",
+	Args:       cobra.NoArgs,
+	Run:        getFunc,
+}
+
+var storageGetObjCMD = &cobra.Command{
+	Use:   "get",
 	Short: "Get object from the NeoFS node's storage snapshot",
 	Long:  "Get object from the NeoFS node's storage snapshot",
 	Args:  cobra.NoArgs,
-	Run:   inspectObject,
+	Run:   getFunc,
 }
 
 func init() {
@@ -20,9 +29,14 @@ func init() {
 	common.AddOutputFileFlag(storageInspectObjCMD, &vOut)
 	common.AddConfigFileFlag(storageInspectObjCMD, &vConfig)
 	common.AddPayloadOnlyFlag(storageInspectObjCMD, &vPayloadOnly)
+
+	common.AddAddressFlag(storageGetObjCMD, &vAddress)
+	common.AddOutputFileFlag(storageGetObjCMD, &vOut)
+	common.AddConfigFileFlag(storageGetObjCMD, &vConfig)
+	common.AddPayloadOnlyFlag(storageGetObjCMD, &vPayloadOnly)
 }
 
-func inspectObject(cmd *cobra.Command, _ []string) {
+func getFunc(cmd *cobra.Command, _ []string) {
 	var addr oid.Address
 
 	err := addr.DecodeString(vAddress)

--- a/cmd/neofs-lens/internal/storage/root.go
+++ b/cmd/neofs-lens/internal/storage/root.go
@@ -44,7 +44,7 @@ var Root = &cobra.Command{
 
 func init() {
 	Root.AddCommand(
-		storageInspectObjCMD,
+		storageInspectObjCMD, storageGetObjCMD,
 	)
 }
 

--- a/cmd/neofs-lens/internal/writecache/inspect.go
+++ b/cmd/neofs-lens/internal/writecache/inspect.go
@@ -8,10 +8,18 @@ import (
 )
 
 var inspectCMD = &cobra.Command{
-	Use:   "inspect",
+	Use:        "inspect",
+	Short:      "Object inspection",
+	Long:       `Inspect specific object in a write-cache.`,
+	Deprecated: "will be removed in the next release. Use `get` instead.",
+	Run:        getFunc,
+}
+
+var getCMD = &cobra.Command{
+	Use:   "get",
 	Short: "Object inspection",
-	Long:  `Inspect specific object in a write-cache.`,
-	Run:   inspectFunc,
+	Long:  `Get specific object from a write-cache.`,
+	Run:   getFunc,
 }
 
 func init() {
@@ -19,9 +27,14 @@ func init() {
 	common.AddComponentPathFlag(inspectCMD, &vPath)
 	common.AddOutputFileFlag(inspectCMD, &vOut)
 	common.AddPayloadOnlyFlag(inspectCMD, &vPayloadOnly)
+
+	common.AddAddressFlag(getCMD, &vAddress)
+	common.AddComponentPathFlag(getCMD, &vPath)
+	common.AddOutputFileFlag(getCMD, &vOut)
+	common.AddPayloadOnlyFlag(getCMD, &vPayloadOnly)
 }
 
-func inspectFunc(cmd *cobra.Command, _ []string) {
+func getFunc(cmd *cobra.Command, _ []string) {
 	db := openWC(cmd)
 	defer db.Close()
 

--- a/cmd/neofs-lens/internal/writecache/root.go
+++ b/cmd/neofs-lens/internal/writecache/root.go
@@ -21,7 +21,7 @@ var Root = &cobra.Command{
 }
 
 func init() {
-	Root.AddCommand(listCMD, inspectCMD)
+	Root.AddCommand(listCMD, inspectCMD, getCMD)
 }
 
 func openWC(cmd *cobra.Command) *bbolt.DB {


### PR DESCRIPTION
Deprecated inspect commands are functional but hidden from help and marked when are called.

Example:
```
neofs-lens storage inspect  --address ApueGak8ZwgXtxhhV3Bf97sbuByBDFkJSAZ4921g7hUr/E6bMcEHxjnrMRaRx5fjPe6WGsFS3jW9Q6SmMvHSskmNr  --config ./data/config/config-sn.yaml
Command "inspect" is deprecated, will be removed in the next release. Use `get` instead.
Version: v2.13
Type: REGULAR
CID: ApueGak8ZwgXtxhhV3Bf97sbuByBDFkJSAZ4921g7hUr
ID: E6bMcEHxjnrMRaRx5fjPe6WGsFS3jW9Q6SmMvHSskmNr
Owner: NZ9DJJkHgKTanE8CHWeTbWZNCHZQBsTqhX
CreatedAt: 3
PayloadSize: 404
Attributes:
  FileName: new_wallet.json
  Timestamp: 1693585925

``` 

``` 
neofs-lens storage -h                                                                                                                                                 
Operations with an object

Usage:
  neofs-lens storage [command]

Available Commands:
  get         Get object from the NeoFS node's storage snapshot

Flags:
  -h, --help   help for storage

Use "neofs-lens storage [command] --help" for more information about a command.
``` 

Refs: #2548.