### PR TITLE
Revert "morph: Close RPC connections if any blocks appeared"

### DIFF
--- a/pkg/morph/client/constructor.go
+++ b/pkg/morph/client/constructor.go
@@ -186,7 +186,6 @@ func (c *Client) newCli(endpoint string) (*rpcclient.WSClient, *actor.Actor, err
 		Options: rpcclient.Options{
 			DialTimeout: c.cfg.dialTimeout,
 		},
-		CloseNotificationChannelIfFull: true,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("WS client creation: %w", err)


### PR DESCRIPTION
This reverts commit 3b1d8cde18dce7809347a5f8f65e4d079dc06533. It seems that the 
morph client is switching RPC nodes too often (even if no block is detected at 
all) with this setting turned on and is not possible to handle (route) 
notifications before the neo-go client closes the channels.  