### PR TITLE
boltdb: increase timeout to 1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - FSTree storage now uses more efficient and safe temporary files under Linux (#2566)
+- BoltDB open timeout increased from 100ms to 1s (#2499)
 
 ### Removed
 

--- a/cmd/neofs-lens/internal/meta/root.go
+++ b/cmd/neofs-lens/internal/meta/root.go
@@ -46,7 +46,7 @@ func openMeta(cmd *cobra.Command, readOnly bool) *meta.DB {
 		meta.WithPath(vPath),
 		meta.WithBoltDBOptions(&bbolt.Options{
 			ReadOnly: readOnly,
-			Timeout:  100 * time.Millisecond,
+			Timeout:  time.Second,
 		}),
 		meta.WithEpochState(epochState{}),
 	)

--- a/cmd/neofs-lens/internal/storage/root.go
+++ b/cmd/neofs-lens/internal/storage/root.go
@@ -246,7 +246,7 @@ func openEngine(cmd *cobra.Command) *engine.StorageEngine {
 				meta.WithMaxBatchSize(shCfg.MetaCfg.MaxBatchSize),
 				meta.WithMaxBatchDelay(shCfg.MetaCfg.MaxBatchDelay),
 				meta.WithBoltDBOptions(&bbolt.Options{
-					Timeout: 100 * time.Millisecond,
+					Timeout: time.Second,
 				}),
 
 				meta.WithEpochState(epochState{}),

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -701,7 +701,7 @@ func (c *cfg) shardOpts() []shardOptsWithID {
 				meta.WithMaxBatchSize(shCfg.MetaCfg.MaxBatchSize),
 				meta.WithMaxBatchDelay(shCfg.MetaCfg.MaxBatchDelay),
 				meta.WithBoltDBOptions(&bbolt.Options{
-					Timeout: 100 * time.Millisecond,
+					Timeout: time.Second,
 				}),
 
 				meta.WithLogger(c.log),

--- a/cmd/neofs-node/session.go
+++ b/cmd/neofs-node/session.go
@@ -30,7 +30,7 @@ func initSessionService(c *cfg) {
 	if persistentSessionPath := nodeconfig.PersistentSessions(c.appCfg).Path(); persistentSessionPath != "" {
 		persisessions, err := persistent.NewTokenStore(persistentSessionPath,
 			persistent.WithLogger(c.log),
-			persistent.WithTimeout(100*time.Millisecond),
+			persistent.WithTimeout(time.Second),
 			persistent.WithEncryptionKey(&c.key.PrivateKey),
 		)
 		if err != nil {

--- a/pkg/local_object_storage/blobovnicza/blobovnicza.go
+++ b/pkg/local_object_storage/blobovnicza/blobovnicza.go
@@ -45,7 +45,7 @@ func defaultCfg(c *cfg) {
 		boltDBCfg: boltDBCfg{
 			perm: os.ModePerm, // 0777
 			boltOptions: &bbolt.Options{
-				Timeout: 100 * time.Millisecond,
+				Timeout: time.Second,
 			},
 		},
 		fullSizeLimit: 1 << 30, // 1GB

--- a/pkg/local_object_storage/blobstor/peapod/peapod.go
+++ b/pkg/local_object_storage/blobstor/peapod/peapod.go
@@ -199,7 +199,7 @@ func (x *Peapod) Open(readOnly bool) error {
 
 	x.bolt, err = bbolt.Open(x.path, x.perm, &bbolt.Options{
 		ReadOnly: readOnly,
-		Timeout:  100 * time.Millisecond, // to handle flock
+		Timeout:  time.Second, // to handle flock
 	})
 	if err != nil {
 		return fmt.Errorf("open BoltDB instance: %w", err)

--- a/pkg/local_object_storage/engine/control_test.go
+++ b/pkg/local_object_storage/engine/control_test.go
@@ -47,7 +47,7 @@ func TestInitializationFailure(t *testing.T) {
 					newStorages(c.blobstor, 1<<20))),
 			shard.WithMetaBaseOptions(
 				meta.WithBoltDBOptions(&bbolt.Options{
-					Timeout: 100 * time.Millisecond,
+					Timeout: time.Second,
 				}),
 				meta.WithPath(c.metabase),
 				meta.WithPermissions(0700),

--- a/pkg/local_object_storage/pilorama/boltdb.go
+++ b/pkg/local_object_storage/pilorama/boltdb.go
@@ -106,7 +106,7 @@ func (t *boltForest) Open(readOnly bool) error {
 	opts := *bbolt.DefaultOptions
 	opts.ReadOnly = readOnly
 	opts.NoSync = t.noSync
-	opts.Timeout = 100 * time.Millisecond
+	opts.Timeout = time.Second
 
 	t.db, err = bbolt.Open(t.path, t.perm, &opts)
 	if err != nil {

--- a/pkg/local_object_storage/writecache/util.go
+++ b/pkg/local_object_storage/writecache/util.go
@@ -13,6 +13,6 @@ func OpenDB(p string, ro bool) (*bbolt.DB, error) {
 	return bbolt.Open(filepath.Join(p, dbName), os.ModePerm, &bbolt.Options{
 		NoFreelistSync: true,
 		ReadOnly:       ro,
-		Timeout:        100 * time.Millisecond,
+		Timeout:        time.Second,
 	})
 }

--- a/pkg/services/session/storage/persistent/options.go
+++ b/pkg/services/session/storage/persistent/options.go
@@ -19,7 +19,7 @@ type Option func(*cfg)
 func defaultCfg() *cfg {
 	return &cfg{
 		l:       zap.L(),
-		timeout: 100 * time.Millisecond,
+		timeout: time.Second,
 	}
 }
 


### PR DESCRIPTION
Previously, we always use 100ms timeout for BoltDB flocks.

Closes: #2499.