### PR TITLE
neofs-cli: container set-eacl removal of the no-precheck flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - BoltDB open timeout increased from 100ms to 1s (#2499)
 
 ### Removed
+- deprecated `no-precheck` flag of `neofs-cli container set-eacl` (#2496)
 
 ### Updated
 - Update minimal supported Go version up to v1.19 (#2485)

--- a/cmd/neofs-cli/modules/container/set_eacl.go
+++ b/cmd/neofs-cli/modules/container/set_eacl.go
@@ -16,8 +16,6 @@ import (
 )
 
 var flagVarsSetEACL struct {
-	noPreCheck bool
-
 	srcPath string
 }
 
@@ -41,7 +39,7 @@ Container ID in EACL table will be substituted with ID from the CLI.`,
 		pk := key.GetOrGenerate(cmd)
 		cli := internalclient.GetSDKClientByFlag(ctx, cmd, commonflags.RPC)
 		force, _ := cmd.Flags().GetBool(commonflags.ForceFlag)
-		if !(force || flagVarsSetEACL.noPreCheck) {
+		if !force {
 			common.PrintVerbose(cmd, "Validating eACL table...")
 			err := util.ValidateEACLTable(eaclTable)
 			common.ExitOnErr(cmd, "table validation: %w", err)
@@ -151,6 +149,4 @@ func initContainerSetEACLCmd() {
 	flags.BoolVar(&containerAwait, "await", false, fmt.Sprintf("block execution until EACL is persisted. "+
 		"Increases default execution timeout to %.0fs", awaitTimeout.Seconds())) // simple %s notation prints 1m0s https://github.com/golang/go/issues/39064
 	flags.BoolP(commonflags.ForceFlag, commonflags.ForceFlagShorthand, false, "skip validation checks (ownership, extensibility of the container ACL)")
-	flags.BoolVar(&flagVarsSetEACL.noPreCheck, "no-precheck", false, "do not pre-check the extensibility of the container ACL")
-	_ = flags.MarkDeprecated("no-precheck", "use --force flag instead for skipping validation checks")
 }


### PR DESCRIPTION
Remove the "no-precheck" flag, which is equivalent to "force" (skips verification) and has been deprecated since #2490.

Closes: #2496.