### PR TITLE
Revert "cli, node: Do not treat `EOF` as a network error"

### DIFF
--- a/cmd/neofs-cli/internal/client/client.go
+++ b/cmd/neofs-cli/internal/client/client.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -440,7 +439,7 @@ func PutObject(ctx context.Context, prm PutObjectPrm) (*PutObjectRes, error) {
 		buf := make([]byte, sz)
 
 		_, err = io.CopyBuffer(wrt, prm.rdr, buf)
-		if err != nil && !errors.Is(err, io.EOF) {
+		if err != nil {
 			return nil, fmt.Errorf("copy data into object stream: %w", err)
 		}
 	}

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -403,7 +403,7 @@ func PutObject(prm PutObjectPrm) (*PutObjectRes, error) {
 	}
 
 	_, err = w.Write(prm.obj.Payload())
-	if err != nil && !errors.Is(err, io.EOF) {
+	if err != nil {
 		return nil, fmt.Errorf("write object payload into stream: %w", err)
 	}
 


### PR DESCRIPTION
This reverts commit 4909a08d53b5f1a920006642ae63fe99c240197c. This error is not expected anymore. See https://github.com/nspcc-dev/neofs-sdk-go/issues/496. Closes #2520.