### PR TITLE
blobstor: Additional context of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - Synchronous objects `PUT` to the local storage (#2607)
 - `copies_number` field was not used in `PUT` request handling (#2607)
 - Neo-go notary deposit data workaround (#2429)
+- Error of missing network endpoint in `neofs-cli object` commands when it is set in the file config (#2608)
 
 ### Changed
 - FSTree storage now uses more efficient and safe temporary files under Linux (#2566)

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -278,8 +278,7 @@ func OpenSessionViaClient(ctx context.Context, cmd *cobra.Command, dst SessionPr
 	const sessionLifetime = 10 // in NeoFS epochs
 
 	common.PrintVerbose(cmd, "Opening remote session with the node...")
-	endpoint, _ := cmd.Flags().GetString(commonflags.RPC)
-	currEpoch, err := internal.GetCurrentEpoch(ctx, endpoint)
+	currEpoch, err := internal.GetCurrentEpoch(ctx, viper.GetString(commonflags.RPC))
 	common.ExitOnErr(cmd, "can't fetch current epoch: %w", err)
 	exp := currEpoch + sessionLifetime
 	err = sessionCli.CreateSession(ctx, &tok, cli, *key, exp, currEpoch)

--- a/cmd/neofs-cli/modules/util/keyer.go
+++ b/cmd/neofs-cli/modules/util/keyer.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
@@ -86,7 +87,7 @@ func keyerGenerate(filename string, d *keyer.Dashboard) error {
 
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	return !os.IsNotExist(err) && !info.IsDir()
+	return !errors.Is(err, fs.ErrNotExist) && !info.IsDir()
 }
 
 func keyerParseFile(filename string, d *keyer.Dashboard) error {

--- a/pkg/local_object_storage/blobstor/fstree/control.go
+++ b/pkg/local_object_storage/blobstor/fstree/control.go
@@ -1,6 +1,8 @@
 package fstree
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 )
 
@@ -14,7 +16,7 @@ func (t *FSTree) Open(ro bool) error {
 func (t *FSTree) Init() error {
 	err := util.MkdirAllX(t.RootPath, t.Permissions)
 	if err != nil {
-		return err
+		return fmt.Errorf("mkdir all for %q: %w", t.RootPath, err)
 	}
 	if !t.readOnly {
 		f := newSpecificWriteData(t.RootPath, t.Permissions, t.noSync)


### PR DESCRIPTION
_Originally posted by @smallhive_
```
warn	engine/engine.go:159	could not put object to shard	{"shard_id": "8TAArEwewr9p3aGppk4GVM", "error count": 24, "error": "could not put object to BLOB storage: operation not supported"}
```