### PR TITLE
fix/Deny github.com/pkg/errors module usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,11 @@ linters-settings:
   govet:
     # report about shadowed variables
     check-shadowing: false
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/pkg/errors:
+            reason: "Obsolete after the 1.13 release; use the standard `errors` package"
 
 linters:
   enable:
@@ -47,6 +52,7 @@ linters:
     - exportloopref
     - gofmt
     - goimports
+    - gomodguard
     - misspell
     - predeclared
     - reassign

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.8.2
 	github.com/paulmach/orb v0.2.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.6.1
@@ -82,6 +81,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect


### PR DESCRIPTION
It is archived and not needed after the standard `error` package release. Sometimes we (our IDEs) import it by a mistake: 4c1ab5e4a7a0ab38baf131a0fa5bd9798598d6e9.

See https://github.com/nspcc-dev/neofs-node/pull/2622#discussion_r1363565785