### PR TITLE
metrics: set the highest priority for metrics service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog for NeoFS Node
 - New optimized SDK version is integrated (#2622)
 - IR uses internal LOCODE DB from Go package (#2610)
 - Contract group for the committee is no longer registered/used in the Sidechain auto-deployment (#2642)
+- The priority of metrics service is increased (#2428)
 
 ### Removed
 - deprecated `no-precheck` flag of `neofs-cli container set-eacl` (#2496)


### PR DESCRIPTION
Metrics port should be opened before all other ports, and start served before all other services.

 Closes: #2428.