### PR TITLE
cli/container: Pretty-print creation timestamp in `list-objects` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 - Policer's setting to the SN's application configuration (#2600)
 - Support of verified domains for the storage nodes (#2280)
 - `neofs-lens storage status` CLI command (#2550)
+- Human-readable output of objects' creation timestamp to `neofs-cli container list-objects` (#2653)
 
 ### Fixed
 - `neofs-cli netmap netinfo` documentation (#2555)

--- a/cmd/neofs-cli/modules/container/list_objects.go
+++ b/cmd/neofs-cli/modules/container/list_objects.go
@@ -73,7 +73,15 @@ var listContainerObjectsCmd = &cobra.Command{
 				if err == nil {
 					attrs := resHead.Header().UserAttributes()
 					for i := range attrs {
-						cmd.Printf("  %s: %s\n", attrs[i].Key(), attrs[i].Value())
+						key := attrs[i].Key()
+						val := attrs[i].Value()
+
+						if key == object.AttributeTimestamp {
+							cmd.Printf("  %s: %s (%s)\n", key, val, common.PrettyPrintUnixTime(val))
+							continue
+						}
+
+						cmd.Printf("  %s: %s\n", key, val)
 					}
 				} else {
 					cmd.Printf("  failed to read attributes: %v\n", err)


### PR DESCRIPTION
Previously, `container list-object` command with `--with-attr` flag printed objects' attributes in raw way. In particular, creation timestamp was showed in Unix format (e.g. 1692609422). While this format is widely known, its human-unreadable. To facilitate the user's experience, the output should be supplemented with a readable format similar to the `object head` command.

Use Go `time.Time` stringer and print the result along with Unix time value. From:
```
HKupeALCqk3VUSmuRXTGdJt6ZZQoJsJ3VtNVV8Pu1Xjd
  Timestamp=1692609422
```
to:
```
HKupeALCqk3VUSmuRXTGdJt6ZZQoJsJ3VtNVV8Pu1Xjd
  Timestamp=1692609422 (2023-08-21 11:17:02 +0200 CEST)
```