### PR TITLE
fix/Create files without group write permissions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 ### Changed
+- Created files are not group writable (#2589)
 
 ### Removed
 

--- a/cmd/blobovnicza-to-peapod/main.go
+++ b/cmd/blobovnicza-to-peapod/main.go
@@ -253,7 +253,7 @@ func migrateConfigToPeapod(dstPath, srcPath string) error {
 		return fmt.Errorf("encode modified config into YAML: %w", err)
 	}
 
-	err = os.WriteFile(dstPath, data, 0640)
+	err = os.WriteFile(dstPath, data, 0o640)
 	if err != nil {
 		return fmt.Errorf("write resulting config to the destination file: %w", err)
 	}

--- a/cmd/blobovnicza-to-peapod/main_test.go
+++ b/cmd/blobovnicza-to-peapod/main_test.go
@@ -66,7 +66,7 @@ storage:
   shard_ro_error_threshold: 0
 `
 
-	err := os.WriteFile(srcConfigFile, []byte(configYAML), 0600)
+	err := os.WriteFile(srcConfigFile, []byte(configYAML), 0o600)
 	require.NoError(t, err)
 
 	err = migrateConfigToPeapod(filepath.Join(dir, "config_peapod.yaml"), srcConfigFile)

--- a/cmd/neofs-adm/internal/modules/config/config.go
+++ b/cmd/neofs-adm/internal/modules/config/config.go
@@ -53,12 +53,12 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 	}
 
 	pathDir := filepath.Dir(configPath)
-	err = os.MkdirAll(pathDir, 0700)
+	err = os.MkdirAll(pathDir, 0o700)
 	if err != nil {
 		return fmt.Errorf("create dir %s: %w", pathDir, err)
 	}
 
-	f, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0600)
+	f, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", configPath, err)
 	}

--- a/cmd/neofs-adm/internal/modules/morph/container.go
+++ b/cmd/neofs-adm/internal/modules/morph/container.go
@@ -124,7 +124,7 @@ func dumpContainers(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filename, out, 0o660)
+	return os.WriteFile(filename, out, 0o640)
 }
 
 func listContainers(cmd *cobra.Command, _ []string) error {

--- a/cmd/neofs-adm/internal/modules/morph/local_client.go
+++ b/cmd/neofs-adm/internal/modules/morph/local_client.go
@@ -81,7 +81,7 @@ func newLocalClient(cmd *cobra.Command, v *viper.Viper, wallets []*wallet.Wallet
 
 	dumpPath := v.GetString(localDumpFlag)
 	if cmd.Name() != "init" {
-		f, err := os.OpenFile(dumpPath, os.O_RDONLY, 0600)
+		f, err := os.OpenFile(dumpPath, os.O_RDONLY, 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("can't open local dump: %w", err)
 		}

--- a/cmd/neofs-adm/internal/modules/storagecfg/root.go
+++ b/cmd/neofs-adm/internal/modules/storagecfg/root.go
@@ -207,7 +207,7 @@ func storageConfig(cmd *cobra.Command, args []string) {
 	}
 
 	out := applyTemplate(c)
-	fatalOnErr(os.WriteFile(outPath, out, 0644))
+	fatalOnErr(os.WriteFile(outPath, out, 0o644))
 
 	cmd.Println("Node is ready for work! Run `neofs-node -config " + outPath + "`")
 }

--- a/cmd/neofs-cli/modules/acl/extended/create.go
+++ b/cmd/neofs-cli/modules/acl/extended/create.go
@@ -110,7 +110,7 @@ func createEACL(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	err = os.WriteFile(outArg, buf.Bytes(), 0644)
+	err = os.WriteFile(outArg, buf.Bytes(), 0o644)
 	if err != nil {
 		cmd.PrintErrln(err)
 		os.Exit(1)

--- a/cmd/neofs-cli/modules/bearer/create.go
+++ b/cmd/neofs-cli/modules/bearer/create.go
@@ -130,6 +130,6 @@ func createToken(cmd *cobra.Command, _ []string) {
 	}
 
 	out, _ := cmd.Flags().GetString(outFlag)
-	err = os.WriteFile(out, data, 0644)
+	err = os.WriteFile(out, data, 0o644)
 	common.ExitOnErr(cmd, "can't write token to file: %w", err)
 }

--- a/cmd/neofs-cli/modules/object/get.go
+++ b/cmd/neofs-cli/modules/object/get.go
@@ -57,7 +57,7 @@ func getObject(cmd *cobra.Command, _ []string) {
 	if filename == "" {
 		out = os.Stdout
 	} else {
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			common.ExitOnErr(cmd, "", fmt.Errorf("can't open file '%s': %w", filename, err))
 		}

--- a/cmd/neofs-cli/modules/session/create.go
+++ b/cmd/neofs-cli/modules/session/create.go
@@ -97,7 +97,7 @@ func createSession(cmd *cobra.Command, _ []string) {
 	}
 
 	filename, _ := cmd.Flags().GetString(outFlag)
-	err = os.WriteFile(filename, data, 0644)
+	err = os.WriteFile(filename, data, 0o644)
 	common.ExitOnErr(cmd, "can't write token to file: %w", err)
 }
 

--- a/cmd/neofs-cli/modules/util/convert_eacl.go
+++ b/cmd/neofs-cli/modules/util/convert_eacl.go
@@ -48,7 +48,7 @@ func convertEACLTable(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	err = os.WriteFile(to, data, 0644)
+	err = os.WriteFile(to, data, 0o644)
 	common.ExitOnErr(cmd, "can't write exteded ACL table to file: %w", err)
 
 	cmd.Printf("extended ACL table was successfully dumped to %s\n", to)

--- a/cmd/neofs-cli/modules/util/keyer.go
+++ b/cmd/neofs-cli/modules/util/keyer.go
@@ -79,7 +79,7 @@ func keyerGenerate(filename string, d *keyer.Dashboard) error {
 	}
 
 	if filename != "" {
-		return os.WriteFile(filename, key, 0600)
+		return os.WriteFile(filename, key, 0o600)
 	}
 
 	return nil

--- a/cmd/neofs-cli/modules/util/sign_bearer.go
+++ b/cmd/neofs-cli/modules/util/sign_bearer.go
@@ -57,7 +57,7 @@ func signBearerToken(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	err = os.WriteFile(to, data, 0644)
+	err = os.WriteFile(to, data, 0o644)
 	common.ExitOnErr(cmd, "can't write signed bearer token to file: %w", err)
 
 	cmd.Printf("signed bearer token was successfully dumped to %s\n", to)

--- a/cmd/neofs-cli/modules/util/sign_session.go
+++ b/cmd/neofs-cli/modules/util/sign_session.go
@@ -76,7 +76,7 @@ func signSessionToken(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	err = os.WriteFile(to, data, 0644)
+	err = os.WriteFile(to, data, 0o644)
 	if err != nil {
 		common.ExitOnErr(cmd, "", fmt.Errorf("can't write signed session token to %s: %w", to, err))
 	}

--- a/cmd/neofs-lens/internal/printers.go
+++ b/cmd/neofs-lens/internal/printers.go
@@ -61,7 +61,7 @@ func WriteObjectToFile(cmd *cobra.Command, path string, data []byte, payloadOnly
 	}
 
 	ExitOnErr(cmd, Errf("could not write file: %w",
-		os.WriteFile(path, data, 0644)))
+		os.WriteFile(path, data, 0o644)))
 
 	if payloadOnly {
 		cmd.Printf("\nSaved payload to '%s' file\n", path)

--- a/cmd/neofs-node/config/engine/shard/blobstor/storage/config.go
+++ b/cmd/neofs-node/config/engine/shard/blobstor/storage/config.go
@@ -9,7 +9,7 @@ import (
 type Config config.Config
 
 // PermDefault are default permission bits for BlobStor data.
-const PermDefault = 0660
+const PermDefault = 0640
 
 func From(x *config.Config) *Config {
 	return (*Config)(x)

--- a/cmd/neofs-node/config/engine/shard/blobstor/storage/config.go
+++ b/cmd/neofs-node/config/engine/shard/blobstor/storage/config.go
@@ -9,7 +9,7 @@ import (
 type Config config.Config
 
 // PermDefault are default permission bits for BlobStor data.
-const PermDefault = 0640
+const PermDefault = 0o640
 
 func From(x *config.Config) *Config {
 	return (*Config)(x)

--- a/cmd/neofs-node/config/engine/shard/boltdb/boltdb.go
+++ b/cmd/neofs-node/config/engine/shard/boltdb/boltdb.go
@@ -13,7 +13,7 @@ type Config config.Config
 
 const (
 	// PermDefault is a default permission bits for metabase file.
-	PermDefault = 0660
+	PermDefault = 0640
 )
 
 // Perm returns the value of "perm" config parameter as a fs.FileMode.

--- a/cmd/neofs-node/config/engine/shard/boltdb/boltdb.go
+++ b/cmd/neofs-node/config/engine/shard/boltdb/boltdb.go
@@ -13,7 +13,7 @@ type Config config.Config
 
 const (
 	// PermDefault is a default permission bits for metabase file.
-	PermDefault = 0640
+	PermDefault = 0o640
 )
 
 // Perm returns the value of "perm" config parameter as a fs.FileMode.

--- a/cmd/neofs-node/config/engine/shard/pilorama/config.go
+++ b/cmd/neofs-node/config/engine/shard/pilorama/config.go
@@ -13,7 +13,7 @@ type Config config.Config
 
 const (
 	// PermDefault is a default permission bits for metabase file.
-	PermDefault = 0640
+	PermDefault = 0o640
 )
 
 // From wraps config section into Config.

--- a/cmd/neofs-node/config/engine/shard/pilorama/config.go
+++ b/cmd/neofs-node/config/engine/shard/pilorama/config.go
@@ -13,7 +13,7 @@ type Config config.Config
 
 const (
 	// PermDefault is a default permission bits for metabase file.
-	PermDefault = 0660
+	PermDefault = 0640
 )
 
 // From wraps config section into Config.

--- a/cmd/neofs-node/validate.go
+++ b/cmd/neofs-node/validate.go
@@ -61,7 +61,7 @@ func validateConfig(c *config.Config) error {
 				return fmt.Errorf("unexpected storage type: %s (shard %d)",
 					blobstor[i].Type(), shardNum)
 			}
-			if blobstor[i].Perm()&0600 != 0600 {
+			if blobstor[i].Perm()&0o600 != 0o600 {
 				return fmt.Errorf("invalid permissions for blobstor component: %s, "+
 					"expected at least rw- for the owner (shard %d)",
 					blobstor[i].Perm(), shardNum)

--- a/docs/storage-node-configuration.md
+++ b/docs/storage-node-configuration.md
@@ -296,16 +296,16 @@ node:
     ca: /path/to/ca.pem
 ```
 
-| Parameter             | Type                                                          | Default value | Description                                                             |
-|-----------------------|---------------------------------------------------------------|---------------|-------------------------------------------------------------------------|
-| `key`                 | `string`                                                      |               | Path to the binary-encoded private key.                                 |
-| `wallet`              | [Wallet config](#wallet-subsection)                           |               | Wallet configuration. Has no effect if `key` is provided.               |
-| `addresses`           | `[]string`                                                    |               | Addresses advertised in the netmap.                                     |
-| `attribute`           | `[]string`                                                    |               | Node attributes as a list of key-value pairs in `<key>:<value>` format. See also docs about verified nodes' domains.|
-| `relay`               | `bool`                                                        |               | Enable relay mode.                                                      |
-| `persistent_sessions` | [Persistent sessions config](#persistent_sessions-subsection) |               | Persistent session token store configuration.                           |
-| `persistent_state`    | [Persistent state config](#persistent_state-subsection)       |               | Persistent state configuration.                                         |
-| `notification`        | [Notification config](#notification-subsection)               |               | NATS configuration.                                                     |
+| Parameter             | Type                                                          | Default value | Description                                                                                                          |
+|-----------------------|---------------------------------------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------|
+| `key`                 | `string`                                                      |               | Path to the binary-encoded private key.                                                                              |
+| `wallet`              | [Wallet config](#wallet-subsection)                           |               | Wallet configuration. Has no effect if `key` is provided.                                                            |
+| `addresses`           | `[]string`                                                    |               | Addresses advertised in the netmap.                                                                                  |
+| `attribute`           | `[]string`                                                    |               | Node attributes as a list of key-value pairs in `<key>:<value>` format. See also docs about verified nodes' domains. |
+| `relay`               | `bool`                                                        |               | Enable relay mode.                                                                                                   |
+| `persistent_sessions` | [Persistent sessions config](#persistent_sessions-subsection) |               | Persistent session token store configuration.                                                                        |
+| `persistent_state`    | [Persistent state config](#persistent_state-subsection)       |               | Persistent state configuration.                                                                                      |
+| `notification`        | [Notification config](#notification-subsection)               |               | NATS configuration.                                                                                                  |
 
 
 ## `wallet` subsection

--- a/docs/storage-node-configuration.md
+++ b/docs/storage-node-configuration.md
@@ -196,20 +196,20 @@ blobstor:
 | Parameter                           | Type                                          | Default value | Description                                                                                                                                                                                                       |
 |-------------------------------------|-----------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`                              | `string`                                      |               | Path to the root of the blobstor.                                                                                                                                                                                 |
-| `perm`                              | file mode                                     | `0660`        | Default permission for created files and directories.                                                                                                                                                             |
+| `perm`                              | file mode                                     | `0640`        | Default permission for created files and directories.                                                                                                                                                             |
 
 #### `fstree` type options
 | Parameter           | Type      | Default value | Description                                           |
 |---------------------|-----------|---------------|-------------------------------------------------------|
 | `path`              | `string`  |               | Path to the root of the blobstor.                     |
-| `perm`              | file mode | `0660`        | Default permission for created files and directories. |
+| `perm`              | file mode | `0640`        | Default permission for created files and directories. |
 | `depth`             | `int`     | `4`           | File-system tree depth.                               |
 
 #### `peapod` type options
 | Parameter           | Type      | Default value | Description                                           |
 |---------------------|-----------|---------------|-------------------------------------------------------|
 | `path`              | `string`  |               | Path to the Peapod database file.                     |
-| `perm`              | file mode | `0660`        | Default permission for created files and directories. |
+| `perm`              | file mode | `0640`        | Default permission for created files and directories. |
 | `flush_interval`    | `duration`| `10ms`        | Time interval between batch writes to disk.           |
 
 ### `gc` subsection
@@ -240,7 +240,7 @@ metabase:
 | Parameter         | Type       | Default value | Description                                                            |
 |-------------------|------------|---------------|------------------------------------------------------------------------|
 | `path`            | `string`   |               | Path to the metabase file.                                             |
-| `perm`            | file mode  | `0660`        | Permissions to set for the database file.                              |
+| `perm`            | file mode  | `0640`        | Permissions to set for the database file.                              |
 | `max_batch_size`  | `int`      | `1000`        | Maximum amount of write operations to perform in a single transaction. |
 | `max_batch_delay` | `duration` | `10ms`        | Maximum delay before a batch starts.                                   |
 

--- a/pkg/local_object_storage/blobstor/bench_test.go
+++ b/pkg/local_object_storage/blobstor/bench_test.go
@@ -20,7 +20,7 @@ func testPeapodPath(tb testing.TB) string {
 }
 
 func newTestPeapod(tb testing.TB) common.Storage {
-	return peapod.New(testPeapodPath(tb), 0600, 10*time.Millisecond)
+	return peapod.New(testPeapodPath(tb), 0o600, 10*time.Millisecond)
 }
 
 func newTestFSTree(tb testing.TB) common.Storage {

--- a/pkg/local_object_storage/blobstor/blobstor_test.go
+++ b/pkg/local_object_storage/blobstor/blobstor_test.go
@@ -17,7 +17,7 @@ import (
 func defaultStorages(p string, smallSizeLimit uint64) []SubStorage {
 	return []SubStorage{
 		{
-			Storage: peapod.New(filepath.Join(p, "peapod.db"), 0600, 10*time.Millisecond),
+			Storage: peapod.New(filepath.Join(p, "peapod.db"), 0o600, 10*time.Millisecond),
 			Policy: func(_ *objectSDK.Object, data []byte) bool {
 				return uint64(len(data)) <= smallSizeLimit
 			},
@@ -108,7 +108,7 @@ func TestBlobstor_needsCompression(t *testing.T) {
 			WithUncompressableContentTypes(ct),
 			WithStorages([]SubStorage{
 				{
-					Storage: peapod.New(filepath.Join(dir, "peapod.db"), 0600, 10*time.Millisecond),
+					Storage: peapod.New(filepath.Join(dir, "peapod.db"), 0o600, 10*time.Millisecond),
 					Policy: func(_ *objectSDK.Object, data []byte) bool {
 						return uint64(len(data)) < smallSizeLimit
 					},

--- a/pkg/local_object_storage/blobstor/common/storage_test.go
+++ b/pkg/local_object_storage/blobstor/common/storage_test.go
@@ -40,7 +40,7 @@ func TestCopy(t *testing.T) {
 
 	require.NoError(t, src.Close())
 
-	dst := peapod.New(filepath.Join(dir, "peapod.db"), 0600, 10*time.Millisecond)
+	dst := peapod.New(filepath.Join(dir, "peapod.db"), 0o600, 10*time.Millisecond)
 
 	err := common.Copy(dst, src)
 	require.NoError(t, err)

--- a/pkg/local_object_storage/blobstor/peapod/peapod_test.go
+++ b/pkg/local_object_storage/blobstor/peapod/peapod_test.go
@@ -21,20 +21,20 @@ func TestGeneric(t *testing.T) {
 	}
 
 	blobstortest.TestAll(t, func(t *testing.T) common.Storage {
-		return peapod.New(newPath(), 0600, 10*time.Millisecond)
+		return peapod.New(newPath(), 0o600, 10*time.Millisecond)
 	}, 2048, 16*1024)
 
 	t.Run("info", func(t *testing.T) {
 		path := newPath()
 		blobstortest.TestInfo(t, func(t *testing.T) common.Storage {
-			return peapod.New(path, 0600, 10*time.Millisecond)
+			return peapod.New(path, 0o600, 10*time.Millisecond)
 		}, peapod.Type, path)
 	})
 }
 
 func TestControl(t *testing.T) {
 	blobstortest.TestControl(t, func(t *testing.T) common.Storage {
-		return peapod.New(filepath.Join(t.TempDir(), "peapod.db"), 0600, 10*time.Millisecond)
+		return peapod.New(filepath.Join(t.TempDir(), "peapod.db"), 0o600, 10*time.Millisecond)
 	}, 2048, 2048)
 }
 
@@ -71,7 +71,7 @@ func newTestPeapodReadOnly(tb testing.TB) (*peapod.Peapod, oid.Address) {
 }
 
 func _newTestPeapod(tb testing.TB, path string, readOnly bool) *peapod.Peapod {
-	ppd := peapod.New(path, 0600, 10*time.Millisecond)
+	ppd := peapod.New(path, 0o600, 10*time.Millisecond)
 	require.NoError(tb, ppd.Open(readOnly))
 	require.NoError(tb, ppd.Init())
 

--- a/pkg/local_object_storage/engine/engine_test.go
+++ b/pkg/local_object_storage/engine/engine_test.go
@@ -99,7 +99,7 @@ func testNewEngineWithShards(shards ...*shard.Shard) *StorageEngine {
 func newStorages(root string, smallSize uint64) []blobstor.SubStorage {
 	return []blobstor.SubStorage{
 		{
-			Storage: peapod.New(filepath.Join(root, "peapod.db"), 0600, 10*time.Millisecond),
+			Storage: peapod.New(filepath.Join(root, "peapod.db"), 0o600, 10*time.Millisecond),
 			Policy: func(_ *object.Object, data []byte) bool {
 				return uint64(len(data)) < smallSize
 			},

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -51,7 +51,7 @@ func newDB(t testing.TB, opts ...meta.Option) *meta.DB {
 	bdb := meta.New(
 		append([]meta.Option{
 			meta.WithPath(path),
-			meta.WithPermissions(0600),
+			meta.WithPermissions(0o600),
 			meta.WithEpochState(epochState{}),
 		}, opts...)...,
 	)

--- a/pkg/local_object_storage/metabase/version_test.go
+++ b/pkg/local_object_storage/metabase/version_test.go
@@ -22,7 +22,7 @@ func TestVersion(t *testing.T) {
 
 	newDB := func(t *testing.T) *DB {
 		return New(WithPath(filepath.Join(dir, t.Name())),
-			WithPermissions(0600), WithEpochState(epochStateImpl{}))
+			WithPermissions(0o600), WithEpochState(epochStateImpl{}))
 	}
 	check := func(t *testing.T, db *DB) {
 		require.NoError(t, db.boltDB.View(func(tx *bbolt.Tx) error {

--- a/pkg/local_object_storage/shard/dump.go
+++ b/pkg/local_object_storage/shard/dump.go
@@ -61,7 +61,7 @@ func (s *Shard) Dump(prm DumpPrm) (DumpRes, error) {
 
 	w := prm.stream
 	if w == nil {
-		f, err := os.OpenFile(prm.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+		f, err := os.OpenFile(prm.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o640)
 		if err != nil {
 			return DumpRes{}, err
 		}

--- a/pkg/local_object_storage/shard/dump_test.go
+++ b/pkg/local_object_storage/shard/dump_test.go
@@ -297,7 +297,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 			blobstor.WithCompressObjects(true),
 			blobstor.WithStorages([]blobstor.SubStorage{
 				{
-					Storage: peapod.New(filepath.Join(bsPath, "peapod.db"), 0600, 10*time.Millisecond),
+					Storage: peapod.New(filepath.Join(bsPath, "peapod.db"), 0o600, 10*time.Millisecond),
 					Policy: func(_ *objectSDK.Object, data []byte) bool {
 						return len(data) < bsSmallObjectSize
 					},
@@ -372,7 +372,7 @@ func TestDumpIgnoreErrors(t *testing.T) {
 		var prm common.PutPrm
 		prm.Address = oid.Address{}
 		prm.RawData = corruptedData
-		b := peapod.New(filepath.Join(bsPath, "peapod2.db"), 0600, 10*time.Millisecond)
+		b := peapod.New(filepath.Join(bsPath, "peapod2.db"), 0o600, 10*time.Millisecond)
 		require.NoError(t, b.Open(false))
 		require.NoError(t, b.Init())
 		_, err := b.Put(prm)

--- a/pkg/local_object_storage/shard/gc_test.go
+++ b/pkg/local_object_storage/shard/gc_test.go
@@ -38,7 +38,7 @@ func TestGC_ExpiredObjectWithExpiredLock(t *testing.T) {
 				{
 					Storage: peapod.New(
 						filepath.Join(rootPath, "blob", "peapod"),
-						0600,
+						0o600,
 						time.Second,
 					),
 					Policy: func(_ *object.Object, data []byte) bool {

--- a/pkg/local_object_storage/shard/lock_test.go
+++ b/pkg/local_object_storage/shard/lock_test.go
@@ -30,7 +30,7 @@ func TestShard_Lock(t *testing.T) {
 		shard.WithBlobStorOptions(
 			blobstor.WithStorages([]blobstor.SubStorage{
 				{
-					Storage: peapod.New(filepath.Join(rootPath, "peapod.db"), 0600, 10*time.Millisecond),
+					Storage: peapod.New(filepath.Join(rootPath, "peapod.db"), 0o600, 10*time.Millisecond),
 					Policy: func(_ *object.Object, data []byte) bool {
 						return len(data) <= 1<<20
 					},

--- a/pkg/local_object_storage/shard/range_test.go
+++ b/pkg/local_object_storage/shard/range_test.go
@@ -68,7 +68,7 @@ func testShardGetRange(t *testing.T, hasWriteCache bool) {
 		[]writecache.Option{writecache.WithMaxObjectSize(writeCacheMaxSize)},
 		[]blobstor.Option{blobstor.WithStorages([]blobstor.SubStorage{
 			{
-				Storage: peapod.New(filepath.Join(t.TempDir(), "peapod.db"), 0600, 10*time.Millisecond),
+				Storage: peapod.New(filepath.Join(t.TempDir(), "peapod.db"), 0o600, 10*time.Millisecond),
 				Policy: func(_ *objectSDK.Object, data []byte) bool {
 					return len(data) <= smallObjectSize
 				},

--- a/pkg/local_object_storage/shard/shard_test.go
+++ b/pkg/local_object_storage/shard/shard_test.go
@@ -53,7 +53,7 @@ func newCustomShard(t testing.TB, rootPath string, enableWriteCache bool, wcOpts
 			blobstor.WithLogger(zaptest.NewLogger(t)),
 			blobstor.WithStorages([]blobstor.SubStorage{
 				{
-					Storage: peapod.New(filepath.Join(rootPath, "peapod.db"), 0600, 10*time.Millisecond),
+					Storage: peapod.New(filepath.Join(rootPath, "peapod.db"), 0o600, 10*time.Millisecond),
 					Policy: func(_ *object.Object, data []byte) bool {
 						return len(data) <= 1<<20
 					},

--- a/pkg/services/session/storage/persistent/storage.go
+++ b/pkg/services/session/storage/persistent/storage.go
@@ -38,7 +38,7 @@ func NewTokenStore(path string, opts ...Option) (*TokenStore, error) {
 		o(cfg)
 	}
 
-	db, err := bbolt.Open(path, 0600,
+	db, err := bbolt.Open(path, 0o600,
 		&bbolt.Options{
 			Timeout: cfg.timeout,
 		})

--- a/pkg/util/state/storage.go
+++ b/pkg/util/state/storage.go
@@ -17,9 +17,9 @@ type PersistentStorage struct {
 
 var stateBucket = []byte("state")
 
-// NewPersistentStorage creates a new instance of a storage with 0600 rights.
+// NewPersistentStorage creates a new instance of a storage with 0o600 rights.
 func NewPersistentStorage(path string) (*PersistentStorage, error) {
-	db, err := bbolt.Open(path, 0600, nil)
+	db, err := bbolt.Open(path, 0o600, nil)
 	if err != nil {
 		return nil, fmt.Errorf("can't open bbolt at %s: %w", path, err)
 	}


### PR DESCRIPTION
Also, sync every octal permissions literals to be in `0oXXX` form. Do not change permissions in the test files. Closes #2589.