### PR TITLE
node/put: Do not use session keystorage for nothing

### DIFF
--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -253,7 +253,7 @@ func initObjectService(c *cfg) {
 
 	sPutV2 := putsvcV2.NewService(
 		putsvcV2.WithInternalService(sPut),
-		putsvcV2.WithKeyStorage(keyStorage),
+		putsvcV2.WithKey(&c.key.PrivateKey),
 	)
 
 	sSearch := searchsvc.New(

--- a/pkg/services/object/put/v2/service.go
+++ b/pkg/services/object/put/v2/service.go
@@ -2,11 +2,11 @@ package putsvc
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"fmt"
 
 	"github.com/nspcc-dev/neofs-node/pkg/services/object"
 	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put"
-	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
 )
 
 // Service implements Put operation of Object service v2.
@@ -18,8 +18,8 @@ type Service struct {
 type Option func(*cfg)
 
 type cfg struct {
-	svc        *putsvc.Service
-	keyStorage *util.KeyStorage
+	svc *putsvc.Service
+	key *ecdsa.PrivateKey
 }
 
 // NewService constructs Service instance from provided options.
@@ -43,8 +43,8 @@ func (s *Service) Put(ctx context.Context) (object.PutObjectStream, error) {
 	}
 
 	return &streamer{
-		stream:     stream,
-		keyStorage: s.keyStorage,
+		stream: stream,
+		key:    s.key,
 	}, nil
 }
 
@@ -54,8 +54,8 @@ func WithInternalService(v *putsvc.Service) Option {
 	}
 }
 
-func WithKeyStorage(ks *util.KeyStorage) Option {
+func WithKey(k *ecdsa.PrivateKey) Option {
 	return func(c *cfg) {
-		c.keyStorage = ks
+		c.key = k
 	}
 }


### PR DESCRIPTION
It does not work this way since 508a28fdc0c41cc63a64fbfd43fc56719b6e716d.