### PR TITLE
adm: Allow generation more than one SN wallet per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Added
+- `neofs-adm morph generate-storage-wallet` now supports more than one wallet generation per call (#2425)
 
 ### Fixed
 - Fund transfer deadlock in NeoFS chain auto-deploy/update procedure (#2681)


### PR DESCRIPTION
Add `wallets-number` flag that "duplicates" requests to the `neofs-adm`. Passwords and labels are the same for all the wallets being created. Names differ with the suffix-numbers.