### PR TITLE
node/client-cache: Log errors that led to a connection drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Node
 ## [Unreleased]
 
 ### Added
+- Logs on a connection drop in the cache of NeoFS API clients (#2694)
 
 ### Fixed
 

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -551,6 +551,7 @@ func initCfg(appCfg *config.Config) *cfg {
 		AllowExternal:    apiclientconfig.AllowExternal(appCfg),
 		ReconnectTimeout: apiclientconfig.ReconnectTimeout(appCfg),
 		Buffers:          &buffers,
+		Logger:           c.internals.log,
 	}
 	c.shared = shared{
 		key:            key,

--- a/pkg/innerring/rpc.go
+++ b/pkg/innerring/rpc.go
@@ -47,9 +47,18 @@ type (
 )
 
 func newClientCache(p *clientCacheParams) *ClientCache {
+	log := p.Log
+	if log == nil {
+		log = zap.NewNop()
+	}
+
 	return &ClientCache{
-		log:          p.Log,
-		cache:        cache.NewSDKClientCache(cache.ClientCacheOpts{AllowExternal: p.AllowExternal, Buffers: p.Buffers}),
+		log: p.Log,
+		cache: cache.NewSDKClientCache(
+			cache.ClientCacheOpts{
+				AllowExternal: p.AllowExternal,
+				Buffers:       p.Buffers,
+				Logger:        log}),
 		key:          p.Key,
 		sgTimeout:    p.SGTimeout,
 		headTimeout:  p.HeadTimeout,

--- a/pkg/network/cache/client.go
+++ b/pkg/network/cache/client.go
@@ -6,6 +6,7 @@ import (
 
 	clientcore "github.com/nspcc-dev/neofs-node/pkg/core/client"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
+	"go.uber.org/zap"
 )
 
 // DefaultBufferSize describes default max GRPC message size. Unfortunately GRPC lib contains this const in private.
@@ -27,6 +28,7 @@ type (
 		ResponseCallback func(client.ResponseMetaInfo) error
 		AllowExternal    bool
 		Buffers          *sync.Pool
+		Logger           *zap.Logger
 	}
 )
 


### PR DESCRIPTION
It simplifies connection drop inspection cause after the first connection drop, there are a lot of `client has recently failed, skipping` logs, and it is not clear what exact reason did not allow the node to communicate with a "problem" one. It could be dropped in the future, but a connection loss for 30s (default reconnection interval for now) is not a normal situation in general, and it causes replication processes, data duplication, etc., so logs about it can be kept.