### PR TITLE
Release guide fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ fmt:
 # Reformat imports
 imports:
 	@echo "⇒ Processing goimports check"
-	@goimports -w cmd/ pkg/ misc/
+	@goimports -w $$(find . -type f -name '*.go' -not -path '*.pb.go')
 
 # Run Unit Test with go test
 test:

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -9,7 +9,7 @@ These should run successfully:
 * `make lint` (should not change any files);
 * `make fmts` (should not change any files);
 * `go mod tidy` (should not change any files);
-* integration tests in [neofs-devenv](https://github.com/nspcc-dev/neofs-devenv).
+* integration tests in [neofs-devenv](https://github.com/nspcc-dev/neofs-dev-env).
 
 ## Make release commit
 
@@ -112,7 +112,7 @@ Look up GitHub [milestones](https://github.com/nspcc-dev/neofs-node/milestones) 
 
 ### Update NeoFS Developer Environment
 
-Prepare pull-request in [neofs-devenv](https://github.com/nspcc-dev/neofs-devenv)
+Prepare pull-request in [neofs-devenv](https://github.com/nspcc-dev/neofs-dev-env)
 with new versions.
 
 ### Announcements

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -40,7 +40,7 @@ $ git checkout -b release/${NEOFS_TAG_PREFIX}${NEOFS_REVISION}
 Write new revision number into the root `VERSION` file:
 
 ```shell
-$ echo ${NEOFS_TAG_PREFIX}${NEOFS_REVISION} > VERSION
+$ echo ${NEOFS_REVISION} > VERSION
 ```
 
 Update version in Debian package changelog file


### PR DESCRIPTION
btw we also have https://github.com/nspcc-dev/neofs-node/blob/df2cc08a08191ce0f6ff84f36c393ed9b26f20da/docs/release-instruction.md?plain=1#L12: need to ref https://github.com/nspcc-dev/neofs-testcases or be removed since we have GH action with integration tests? @roman-khimov 

i always skip this step