### PR TITLE
morph: Try all endpoints on client creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 - IR does not wait for HTTP servers to stop gracefully before exiting (#2704)
 - Zero exit code if IR fails (#2704)
+- Neo RPC client failure when the first endpoint is unavailable even if there are more endpoints to try (#2703)
 
 ### Changed
 - Created files are not group writable (#2589)

--- a/pkg/morph/client/constructor.go
+++ b/pkg/morph/client/constructor.go
@@ -160,8 +160,14 @@ func New(key *keys.PrivateKey, opts ...Option) (*Client, error) {
 		}
 
 		cli.endpoints = cfg.endpoints
+		for _, e := range cli.endpoints {
+			cli.client, act, err = cli.newCli(e)
+			if err != nil {
+				cli.logger.Warn("Neo RPC connection failure", zap.String("endpoint", e), zap.Error(err))
+				continue
+			}
+		}
 
-		cli.client, act, err = cli.newCli(cli.endpoints[0])
 		if err != nil {
 			return nil, fmt.Errorf("could not create RPC client: %w", err)
 		}


### PR DESCRIPTION
Do not fail if the first one is unavailable but more endpoints are provided.