### PR TITLE
ir: Do not hash public keys to check orig/announced SN diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - Zero exit code if IR fails (#2704)
 - Neo RPC client failure when the first endpoint is unavailable even if there are more endpoints to try (#2703)
 - Incorrect address mapping of the Alphabet contracts in NNS produced by deployment procedure (#2713)
+- IR compares and logs public keys difference, not hash of keys difference at SN verification check (#2711)
 
 ### Changed
 - Created files are not group writable (#2589)

--- a/pkg/innerring/processors/netmap/nodevalidation/availability/validator.go
+++ b/pkg/innerring/processors/netmap/nodevalidation/availability/validator.go
@@ -85,8 +85,8 @@ func compareNodeInfos(niExp, niGot netmap.NodeInfo) error {
 
 	var err error
 
-	if exp, got := niExp.Hash(), niGot.Hash(); exp != got {
-		return fmt.Errorf("hash: got %d, expect %d", got, exp)
+	if exp, got := niExp.PublicKey(), niGot.PublicKey(); !bytes.Equal(exp, got) {
+		return fmt.Errorf("public key: got %x, expect %x", got, exp)
 	}
 
 	if exp, got := niExp.NumberOfAttributes(), niGot.NumberOfAttributes(); exp != got {


### PR DESCRIPTION
Logs like "*number* differs *number*" may confuse, public keys are more common.