### PR TITLE
morph: Fix subscription deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Incorrect address mapping of the Alphabet contracts in NNS produced by deployment procedure (#2713)
 - IR compares and logs public keys difference, not hash of keys difference at SN verification check (#2711)
 - Incorrect handling of notary request leading to inability to collect signatures in some cases (#2715)
+- Deadlock in autodeploy routine (#2720)
 
 ### Changed
 - Created files are not group writable (#2589)


### PR DESCRIPTION
Scenario:

0. at least one subscription has been performed
1. another subscription is being done
2. a notification from one of the `0.` point's subs is received

If `2.` happens b/w `0.` and `1.` a deadlock appears since the notification routing process is locked on the subscription lock while the subscription lock cannot be unlocked since the subscription RPC cannot be done before the just-arrived notification is handled (read from the neo-go subscription channel).
Relates #2559.