### PR TITLE
workflows: Change test report publication

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,20 +23,14 @@ on:
 
 permissions: write-all
 
+env:
+  ALLURE_RESULTS_DIR: ${{ github.workspace }}/allure-results
+
 jobs:
   run_system_tests:
     runs-on: ubuntu-latest
     timeout-minutes: 500
     steps:
-      - name: Get the current date
-        id: date
-        run: echo "::set-output name=timestamp::$(date +%s)"
-
-      - name: Set RUN_ID
-        env:
-          TIMESTAMP: ${{ steps.date.outputs.timestamp }}
-        run: echo "RUN_ID=${{ github.run_number }}-$TIMESTAMP" >> $GITHUB_ENV
-
       - name: Checkout neofs-testcases repository
         uses: actions/checkout@v3
         with:
@@ -55,19 +49,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: neofs-node
-
-      - name: Download latest stable neofs-cli for uploading reports to NeoFS
-        uses: dsaltares/fetch-gh-release-asset@1.1.1
-        with:
-          repo: 'nspcc-dev/neofs-node'
-          version: 'tags/v0.37.0'
-          file: 'neofs-cli-amd64'
-          target: 'neofs-node-stable/neofs-cli'
-
-      - name: Chmod latest stable neofs-cli
-        run: |
-          sudo chmod a+x neofs-cli
-        working-directory: neofs-node-stable
 
 #################################################################
       - name: Set up Go
@@ -228,101 +209,51 @@ jobs:
       - name: Run Sanity tests for pull requests
         timeout-minutes: 120
         if: github.event_name == 'pull_request'
+        env:
+          ALLURE_RESULTS_DIR: ${{ env.ALLURE_RESULTS_DIR }}
         run: |
-          source venv.local-pytest/bin/activate && pytest --show-capture=no -m "sanity" --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
+          source venv.local-pytest/bin/activate && pytest --show-capture=no -m "sanity" --alluredir="$ALLURE_RESULTS_DIR" pytest_tests/testsuites
         working-directory: neofs-testcases
 
       - name: Run all tests for other events
         timeout-minutes: 480
         if: github.event_name != 'pull_request'
-        run: |
-          source venv.local-pytest/bin/activate && pytest --alluredir=${GITHUB_WORKSPACE}/allure-results pytest_tests/testsuites
-        working-directory: neofs-testcases
-
-################################################################
-      - name: Generate Allure report
-        timeout-minutes: 60
-        uses: simple-elf/allure-report-action@v1.6
-        if: always()
-        id: allure-report
-        with:
-          keep_reports: 100000
-          allure_results: allure-results
-          allure_report: allure-report
-          allure_history: allure-history
-
-      - name: Remove testing neofs-cli
-        if: always()
-        run: |
-          make clean
-        working-directory: neofs-node
-
-      - name: Enable stable neofs-cli
-        if: always()
-        run: |
-          echo "$(pwd)" >> $GITHUB_PATH
-        working-directory: neofs-node-stable
-
-      - name: Create wallet
-        if: always()
         env:
-          TEST_RESULTS_WALLET: ${{ secrets.TEST_RESULTS_WALLET }}
+          ALLURE_RESULTS_DIR: ${{ env.ALLURE_RESULTS_DIR }}
         run: |
-          echo "$TEST_RESULTS_WALLET" | base64 -d > wallet.json
+          source venv.local-pytest/bin/activate && pytest --alluredir="$ALLURE_RESULTS_DIR" pytest_tests/testsuites
         working-directory: neofs-testcases
 
-      - name: Define expiration
-        if: always()
-        env:
-          TEST_RESULTS_NEOFS_NETWORK_DOMAIN: ${{ vars.TEST_RESULTS_NEOFS_NETWORK_DOMAIN }}
-          MASTER_EXPIRATION_PERIOD: ${{ vars.MASTER_EXPIRATION_PERIOD }}
-          PR_EXPIRATION_PERIOD: ${{ vars.PR_EXPIRATION_PERIOD }}
-          MANUAL_RUN_EXPIRATION_PERIOD: ${{ vars.MANUAL_RUN_EXPIRATION_PERIOD }}
-          OTHER_EXPIRATION_PERIOD: ${{ vars.OTHER_EXPIRATION_PERIOD }}
-        run: |
-          CURRENT_EPOCH=$(neofs-cli netmap epoch --rpc-endpoint st1.$TEST_RESULTS_NEOFS_NETWORK_DOMAIN:8080)
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            EXP_EPOCH=$((MASTER_EXPIRATION_PERIOD + CURRENT_EPOCH))
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            EXP_EPOCH=$((PR_EXPIRATION_PERIOD + CURRENT_EPOCH))
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            EXP_EPOCH=0 # For test reports from releases - no expiration period
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            EXP_EPOCH=$((MANUAL_RUN_EXPIRATION_PERIOD + CURRENT_EPOCH))
-          else
-            EXP_EPOCH=$((OTHER_EXPIRATION_PERIOD + CURRENT_EPOCH))
-          fi
-          echo "EXP_EPOCH=$EXP_EPOCH" >> $GITHUB_ENV
-        working-directory: neofs-testcases
-
-      - name: Put allure report to NeoFS
+      - name: Publish to NeoFS
         id: put_report
         if: always() && steps.prepare_test_env.outcome == 'success'
-        env:
-          TEST_RESULTS_PASSWORD: ${{ secrets.TEST_RESULTS_PASSWORD }}
-          TEST_RESULTS_NEOFS_NETWORK_DOMAIN: ${{ vars.TEST_RESULTS_NEOFS_NETWORK_DOMAIN }}
-          TEST_RESULTS_CID: ${{ vars.TEST_RESULTS_CID }}
-        run: |
-          sudo chmod -R a+rw ${GITHUB_WORKSPACE}/allure-report
-          source venv.local-pytest/bin/activate && python ./tools/src/process-allure-reports.py --expire-at $EXP_EPOCH \
-          --neofs_domain $TEST_RESULTS_NEOFS_NETWORK_DOMAIN --run_id $RUN_ID --cid $TEST_RESULTS_CID \
-          --allure_report ${GITHUB_WORKSPACE}/allure-report --wallet wallet.json
-        working-directory: neofs-testcases
+        uses: nspcc-dev/gh-push-allure-report-to-neofs@master
+        with:
+          NEOFS_WALLET: ${{ secrets.TEST_RESULTS_WALLET }}
+          NEOFS_WALLET_PASSWORD: ${{ secrets.TEST_RESULTS_PASSWORD }}
+          NEOFS_NETWORK_DOMAIN: ${{ vars.TEST_RESULTS_NEOFS_NETWORK_DOMAIN }}
+          NEOFS_HTTP_GATE: ${{ vars.TEST_RESULTS_HTTP_GATE }}
+          STORE_OBJECTS_CID: ${{ vars.TEST_RESULTS_CID }}
+          PR_LIFETIME: ${{ vars.PR_EXPIRATION_PERIOD }}
+          MASTER_LIFETIME: ${{ vars.MASTER_EXPIRATION_PERIOD }}
+          MANUAL_RUN_LIFETIME: ${{ vars.MANUAL_RUN_EXPIRATION_PERIOD }}
+          OTHER_LIFETIME: ${{ vars.OTHER_EXPIRATION_PERIOD }}
+          ALLURE_RESULTS_DIR: ${{ env.ALLURE_RESULTS_DIR }}
+          ALLURE_GENERATED_DIR: 'neofs-test-allure-generated-report'
 
       - name: Post the link to the report
         id: post_report_link
         timeout-minutes: 60
         if: always() && steps.put_report.outcome == 'success'
         env:
-          TEST_RESULTS_HTTP_GATE: ${{ vars.TEST_RESULTS_HTTP_GATE }}
-          TEST_RESULTS_CID: ${{ vars.TEST_RESULTS_CID }}
+          REPORT_NEOFS_URL: ${{ steps.put_report.outputs.REPORT_NEOFS_URL }}index.html
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: 'Test report'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}
-          target_url: https://${{ env.TEST_RESULTS_HTTP_GATE }}/${{ env.TEST_RESULTS_CID }}/${{ env.RUN_ID }}/index.html
+          target_url: ${{ env.REPORT_NEOFS_URL }}
 
       - name: Post only docker logs
         id: post_dockers_logs


### PR DESCRIPTION
Changed test report publishing from custom to using the gh-push-allure-report-to-neofs action.
This reduces the amount of code and unifies workflow with other projects in the organization.

Tests result:
https://github.com/vvarg229/neofs-node/actions/runs/7602847388/job/20703858094?pr=53
https://http.t5.fs.neo.org/86C4P6uJC7gb5n3KkwEGpXRfdczubXyRNW5N9KeJRW73/417-1705859595/index.html

First, this PR should be merged:
https://github.com/nspcc-dev/gh-push-allure-report-to-neofs/pull/4 