### PR TITLE
neofs-adm: use registerTLD to register TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Inability to deploy contract with non-standard zone via neofs-adm
 
 ### Changed
 

--- a/cmd/neofs-adm/internal/modules/morph/deploy.go
+++ b/cmd/neofs-adm/internal/modules/morph/deploy.go
@@ -126,8 +126,8 @@ func deployContractCmd(cmd *cobra.Command, args []string) error {
 		} else if !ok {
 			needRecord = true
 
-			emit.AppCall(bw.BinWriter, nnsCs.Hash, "register", callflag.All,
-				zone, c.CommitteeAcc.Contract.ScriptHash(),
+			emit.AppCall(bw.BinWriter, nnsCs.Hash, "registerTLD", callflag.All,
+				zone,
 				"ops@nspcc.ru", int64(3600), int64(600), int64(defaultExpirationTime), int64(3600))
 			emit.Opcodes(bw.BinWriter, opcode.ASSERT)
 


### PR DESCRIPTION
It's the only way since neofs-contract 0.18.0, "register" just fails with

    Error: could not perform test invocation: script failed (FAULT state) due to an error: at instruction 1794 (THROW): unhandled exception: "TLD denied"