### PR TITLE
node: Support wildcard for container sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
-- Inability to deploy contract with non-standard zone via neofs-adm
+- Inability to deploy contract with non-standard zone via neofs-adm (#2740)
+- Container session token's `wildcard` field support (#2741) 
 
 ### Changed
 


### PR DESCRIPTION
Do not require container ID to be set if wildcard is true. Also, for all containers case check that a requested operation relates a container that belongs to the attached token's issuer.