### PR TITLE
object: Perform assembly with `TTL=1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Access to `PUT` objects no longer grants `DELETE` rights (#2261)
+- Storage nodes no longer reject GET w/ TTL=1 requests to read complex objects (#2447)
 
 ### Changed
 

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -134,7 +134,7 @@ func (exec execCtx) key() (*ecdsa.PrivateKey, error) {
 }
 
 func (exec *execCtx) canAssemble() bool {
-	return exec.svc.assembly && !exec.isRaw() && !exec.headOnly() && !exec.isLocal()
+	return exec.svc.assembly && !exec.isRaw() && !exec.headOnly()
 }
 
 func (exec *execCtx) splitInfo() *objectSDK.SplitInfo {


### PR DESCRIPTION
This reverts commit 907f427b99768ff010834621578441ef81dc0ff9.

GET requests with TTL=1 are absolutely correct regardless of the need to assemble the object. This TTL blocks request forwarding - it does not happen. At the same time, assembling an object on the server spawns new requests from scratch, which is not forwarding. The original commit does not have a description of the cause, and it was never discovered.

Fixes #2447.