### PR TITLE
go.mod: Downgrade SDK to the version without split changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.105.1
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240227143122-fb2ed146aef8
 	github.com/nspcc-dev/neofs-contract v0.19.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240228093204-8099e0fc964b
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240221185518-cbaf23c6aa7a
 	github.com/nspcc-dev/tzhash v1.8.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/nspcc-dev/neofs-contract v0.19.1 h1:U1Uh+MlzfkalO0kRJ2pADZyHrmAOroC6K
 github.com/nspcc-dev/neofs-contract v0.19.1/go.mod h1:ZOGouuwuHpgvYkx/LCGufGncIzEUhYEO18LL4cWEbyw=
 github.com/nspcc-dev/neofs-crypto v0.4.1 h1:B6S0zXMWrVFlf/GlII6xKRGWU0VE7dHM+QkoKAO7AQA=
 github.com/nspcc-dev/neofs-crypto v0.4.1/go.mod h1:0SHn+sSn+lrrIvonLR8MgbOlBhXZKhc4rw/l2htYeA0=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240228093204-8099e0fc964b h1:hR1sVQW44HGpKNy+tijbCO/j5bwq+92OCNOJnqbNLW4=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240228093204-8099e0fc964b/go.mod h1:GVT/EQclHBByHhpf4VQnnXWtAWdbcUXkfBSLJ3Pp6+I=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240221185518-cbaf23c6aa7a h1:vmN8Sm8Wna5BrgkGBvt5cnPTzU4Fu0JzC6VnwDNiDIA=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.11.0.20240221185518-cbaf23c6aa7a/go.mod h1:icGhc6HFg+yKivBUoP7cut62SASuijDiWD5Txd6vWqY=
 github.com/nspcc-dev/rfc6979 v0.2.1 h1:8wWxkamHWFmO790GsewSoKUSJjVnL1fmdRpokU/RgRM=
 github.com/nspcc-dev/rfc6979 v0.2.1/go.mod h1:Tk7h5kyUWkhjyO3zUgFFhy1v2vQv3BvQEntakdtqrWc=
 github.com/nspcc-dev/tzhash v1.8.0 h1:pJvzME2mZzP/h5rcy/Wb6amT9FJBFeKbJ3HEnWEeUpY=

--- a/pkg/services/object/acl/v2/service.go
+++ b/pkg/services/object/acl/v2/service.go
@@ -12,7 +12,6 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/container/acl"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	objectsdk "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	sessionSDK "github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
@@ -540,8 +539,8 @@ func (p putStreamBasicChecker) Send(request *objectV2.PutRequest) error {
 			// should not prevent the replication of objects created before.
 			// See also https://github.com/nspcc-dev/neofs-api/issues/293
 			hdrLen := part.GetHeader().StableSize()
-			if hdrLen > objectsdk.MaxHeaderLen {
-				return fmt.Errorf("object header length exceeds the limit: %d>%d", hdrLen, objectsdk.MaxHeaderLen)
+			if hdrLen > 16<<10 {
+				return fmt.Errorf("object header length exceeds the limit: %d>%d", hdrLen, 16<<10)
 			}
 		}
 


### PR DESCRIPTION
Node code is not ready for them, will be updated via another PR.