### PR TITLE
adm: Read GAS from the correct flag in `generate-storage-wallet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - Access to `PUT` objects no longer grants `DELETE` rights (#2261)
 - Storage nodes no longer reject GET w/ TTL=1 requests to read complex objects (#2447)
 - Response exceeding the deadline for TLS errors (#2561)
+- `neofs-adm morph generate-storage-wallet` was not able to read `--initial-gas` flag (#2766)
 
 ### Changed
 - IR now checks format of NULL and numeric eACL filters specified in the protocol (#2742)

--- a/cmd/neofs-adm/internal/modules/morph/generate.go
+++ b/cmd/neofs-adm/internal/modules/morph/generate.go
@@ -156,7 +156,7 @@ func generateStorageCreds(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	gasAmount, err := parseGASAmount(viper.GetString(refillGasAmountFlag))
+	gasAmount, err := parseGASAmount(viper.GetString(storageGasConfigFlag))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A copy-paste regression from the d41d7a7d37ecec6a86bed9352e92d177a6f8f41b.