### PR TITLE
neofs-lens: Add a simple link objects inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Changelog for NeoFS Node
 - Support of `GT`, `GE`, `LT` and `LE` numeric comparison operators in CLI (#2733)
 - SN eACL processing of NULL and numeric operators (#2742)
 - CLI now allows to create and print eACL with numeric filters (#2742)
-- gRPC connection limits per endpoint (#1240) 
+- gRPC connection limits per endpoint (#1240)
+- `neofs-lens object link` command for the new link object inspection (#2799)
 
 ### Fixed
 - Access to `PUT` objects no longer grants `DELETE` rights (#2261)

--- a/cmd/neofs-lens/internal/object/link.go
+++ b/cmd/neofs-lens/internal/object/link.go
@@ -1,0 +1,53 @@
+package object
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	"github.com/spf13/cobra"
+)
+
+var linkCMD = &cobra.Command{
+	Use:   "link",
+	Short: "Inspect link object",
+	Run:   linkFunc,
+}
+
+func linkFunc(cmd *cobra.Command, _ []string) {
+	if vPath == "" {
+		common.ExitOnErr(cmd, errors.New("empty path to file"))
+	}
+
+	raw, err := os.ReadFile(vPath)
+	common.ExitOnErr(cmd, common.Errf("reading file: %w", err))
+
+	var link object.Link
+	err = link.Unmarshal(raw)
+	if err != nil {
+		cmd.Printf("%q file does not contain raw link payload, trying to decode it as a full NeoFS object", vPath)
+
+		var obj object.Object
+		err = obj.Unmarshal(raw)
+		common.ExitOnErr(cmd, common.Errf("decoding NeoFS object: %w", err))
+
+		if typeGot := obj.Type(); typeGot != object.TypeLink {
+			common.ExitOnErr(cmd, fmt.Errorf("unexpected object type (not %s): %s", object.TypeLink, typeGot))
+		}
+
+		err = obj.ReadLink(&link)
+	}
+	common.ExitOnErr(cmd, common.Errf("decoding link object: %w", err))
+
+	if len(link.Objects()) == 0 {
+		common.ExitOnErr(cmd, errors.New("empty children list"))
+	}
+
+	cmd.Println("Children (sorted according to the read payload):")
+
+	for _, measuredObject := range link.Objects() {
+		cmd.Printf("Size: %d, object ID: %s\n", measuredObject.ObjectSize(), measuredObject.ObjectID())
+	}
+}

--- a/cmd/neofs-lens/internal/object/root.go
+++ b/cmd/neofs-lens/internal/object/root.go
@@ -1,0 +1,33 @@
+package object
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var vPath string
+
+// Root defines root command for operations with NeoFS objects.
+var Root = &cobra.Command{
+	Use:   "object",
+	Short: "NeoFS object inspection",
+}
+
+const filePathFlagKey = "file"
+
+func init() {
+	pFlags := Root.PersistentFlags()
+	pFlags.StringVar(&vPath, filePathFlagKey, "", "Path to file with NeoFS object")
+
+	err := cobra.MarkFlagFilename(pFlags, filePathFlagKey)
+	if err != nil {
+		panic(fmt.Errorf("MarkFlagFilename for %s flag: %w", filePathFlagKey, err))
+	}
+	err = cobra.MarkFlagRequired(pFlags, filePathFlagKey)
+	if err != nil {
+		panic(fmt.Errorf("MarkFlagRequired for %s flag: %w", filePathFlagKey, err))
+	}
+
+	Root.AddCommand(linkCMD)
+}

--- a/cmd/neofs-lens/root.go
+++ b/cmd/neofs-lens/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal/meta"
+	"github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal/object"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal/peapod"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal/storage"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal/writecache"
@@ -40,6 +41,7 @@ func init() {
 		meta.Root,
 		writecache.Root,
 		storage.Root,
+		object.Root,
 		gendoc.Command(command),
 	)
 }


### PR DESCRIPTION
V2 link scheme does not allow analyzing link objects without additional tools due to the missing children info in the split header: children are in the link object's payload. Add a simple command for inspecting new link objects.