### PR TITLE
.github: update S3 gateway used for tests to 0.30.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -104,7 +104,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-s3-gw'
-          version: 'tags/v0.29.0'
+          version: 'tags/v0.30.0'
           file: 'neofs-s3-gw-linux-amd64'
           target: 'neofs-testcases/neofs-s3-gw'
 
@@ -112,7 +112,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           repo: 'nspcc-dev/neofs-s3-gw'
-          version: 'tags/v0.29.0'
+          version: 'tags/v0.30.0'
           file: 'neofs-s3-authmate-linux-amd64'
           target: 'neofs-testcases/neofs-s3-authmate'
 


### PR DESCRIPTION
Testcases were updated to 0.30.0 behavior in https://github.com/nspcc-dev/neofs-testcases/pull/772 so 0.29.0 will produce false errors. And we should be using the latest stable anyway.