### PR TITLE
node/put: Fix fetching first object for a first object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Attribute ACL checks for the first split object (#2820)
 
 ### Changed
 


### PR DESCRIPTION
If we are checking a first object, it is impossible to HEAD the first object to check ACL rules, get its parent directly from the header instead. It is also an optimization for last and LINK object ACL checks (they have a parent in the header too).