### PR TITLE
pkg/morph/container: Do not create client with notary status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Attribute ACL checks for the first split object (#2820)
+- Container size estimation contract writing (#2819)
 
 ### Changed
 

--- a/pkg/morph/client/container/client.go
+++ b/pkg/morph/client/container/client.go
@@ -60,10 +60,6 @@ func NewFromMorph(cli *client.Client, contract util.Uint160, fee fixedn.Fixed8, 
 		o.staticOpts = append(o.staticOpts, client.WithCustomFee(putNamedMethod, o.feePutNamed))
 	}
 
-	if !o.disableNotarySigning {
-		o.staticOpts = append(o.staticOpts, client.TryNotary())
-	}
-
 	sc, err := client.NewStatic(cli, contract, fee, o.staticOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("can't create container static client: %w", err)

--- a/pkg/morph/client/container/client.go
+++ b/pkg/morph/client/container/client.go
@@ -86,24 +86,11 @@ type opts struct {
 	feePutNamedSet bool
 	feePutNamed    fixedn.Fixed8
 
-	disableNotarySigning bool
-
 	staticOpts []client.StaticClientOption
 }
 
 func defaultOpts() *opts {
 	return new(opts)
-}
-
-// DisableNotarySigning returns option to disable
-// notary request signing. With that option, every
-// call will be created, signed with provided key
-// (a single regular sign) and sent to the side
-// chain.
-func DisableNotarySigning() Option {
-	return func(o *opts) {
-		o.disableNotarySigning = true
-	}
 }
 
 // AsAlphabet returns option to sign main TX

--- a/pkg/morph/client/container/delete.go
+++ b/pkg/morph/client/container/delete.go
@@ -20,6 +20,7 @@ func Delete(c *Client, witness core.RemovalWitness) error {
 
 	prm.SetCID(binCnr)
 	prm.SetSignature(witness.Signature())
+	prm.RequireAlphabetSignature()
 
 	if tok := witness.SessionToken(); tok != nil {
 		prm.SetToken(tok.Marshal())
@@ -66,6 +67,11 @@ func (c *Client) Delete(p DeletePrm) error {
 	prm.SetMethod(deleteMethod)
 	prm.SetArgs(p.cnr, p.signature, p.token)
 	prm.InvokePrmOptional = p.InvokePrmOptional
+
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
 
 	err := c.client.Invoke(prm)
 	if err != nil {

--- a/pkg/morph/client/container/eacl_set.go
+++ b/pkg/morph/client/container/eacl_set.go
@@ -30,6 +30,7 @@ func PutEACL(c *Client, eaclInfo containercore.EACL) error {
 
 	prm.SetKey(eaclInfo.Signature.PublicKeyBytes())
 	prm.SetSignature(eaclInfo.Signature.Value())
+	prm.RequireAlphabetSignature()
 
 	return c.PutEACL(prm)
 }
@@ -77,6 +78,11 @@ func (c *Client) PutEACL(p PutEACLPrm) error {
 	prm.SetMethod(setEACLMethod)
 	prm.SetArgs(p.table, p.sig, p.key, p.token)
 	prm.InvokePrmOptional = p.InvokePrmOptional
+
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
 
 	err := c.client.Invoke(prm)
 	if err != nil {

--- a/pkg/morph/client/container/estimations.go
+++ b/pkg/morph/client/container/estimations.go
@@ -34,6 +34,11 @@ func (c *Client) StartEstimation(p StartEstimationPrm) error {
 	prm.SetArgs(p.epoch)
 	prm.InvokePrmOptional = p.InvokePrmOptional
 
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
+
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", startEstimationMethod, err)
 	}
@@ -46,6 +51,11 @@ func (c *Client) StopEstimation(p StopEstimationPrm) error {
 	prm.SetMethod(stopEstimationMethod)
 	prm.SetArgs(p.epoch)
 	prm.InvokePrmOptional = p.InvokePrmOptional
+
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
 
 	if err := c.client.Invoke(prm); err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", stopEstimationMethod, err)

--- a/pkg/morph/client/container/put.go
+++ b/pkg/morph/client/container/put.go
@@ -108,6 +108,11 @@ func (c *Client) Put(p PutPrm) error {
 	prm.SetMethod(method)
 	prm.InvokePrmOptional = p.InvokePrmOptional
 
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
+
 	err := c.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", method, err)

--- a/pkg/morph/client/static.go
+++ b/pkg/morph/client/static.go
@@ -87,6 +87,8 @@ type InvokePrmOptional struct {
 	// `validUntilBlock` values by all notification
 	// receivers.
 	hash *util.Uint256
+
+	signByAlphabet bool
 }
 
 // SetHash sets optional hash of the transaction.
@@ -95,6 +97,14 @@ type InvokePrmOptional struct {
 // calculation.
 func (i *InvokePrmOptional) SetHash(hash util.Uint256) {
 	i.hash = &hash
+}
+
+// RequireAlphabetSignature makes client send notary request instead of a
+// regular signed transaction. Such a request should be received and signed by
+// the Alphabet, otherwise the plug (empty) transaction will be added to the
+// chain.
+func (i *InvokePrmOptional) RequireAlphabetSignature() {
+	i.signByAlphabet = true
 }
 
 // Invoke calls Invoke method of Client with static internal script hash and fee.
@@ -109,7 +119,7 @@ func (i *InvokePrmOptional) SetHash(hash util.Uint256) {
 func (s StaticClient) Invoke(prm InvokePrm) error {
 	fee := s.fees.feeForMethod(prm.method)
 
-	if s.tryNotary {
+	if s.tryNotary || prm.signByAlphabet {
 		if s.alpha {
 			var (
 				nonce uint32 = 1


### PR DESCRIPTION
Provide notary signature status with explicit parameter. Some calls are always expected to be Alphabet signed (at least for the current contracts), make it explicit for a code reader, that is more error proof. This commit also fixes container size estimations writing: they were tried to be notary signed, but the Alphabet does not handle such requests. This is also the reason why this kinda refactor does not touch other contracts; general client improvements can be done with another PR.