### PR TITLE
meta: Do not stop iteration in GC on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for NeoFS Node
 - Container size estimation contract writing (#2819)
 - Custom contract deployment with custom zone via neofs-adm (#2827)
 - Errors in neofs-adm morph dump-names output (#2831)
+- GC stops if any non-critical "content" errors happen (#2823)
 
 ### Changed
 


### PR DESCRIPTION
Errors in GC cycle can be logged, and the cycle can be continued, there is no reason not to handle leftover garbage. Make it async (up to 1000 concurrent calls) cause most of the meta code is performed in bbolt transaction, so blocking will slow general performance.