### PR TITLE
engine: Be ready to delete objects on unexpected shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Custom contract deployment with custom zone via neofs-adm (#2827)
 - Errors in neofs-adm morph dump-names output (#2831)
 - GC stops if any non-critical "content" errors happen (#2823)
+- Endless GC cycle if an object is stored on an unexpected shard (#2821)
 
 ### Changed
 

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -235,6 +235,13 @@ func (e *StorageEngine) iterateOverUnsortedShards(handler func(hashedShard) (sto
 	}
 }
 
+func (e *StorageEngine) getShard(id string) shardWrapper {
+	e.mtx.RLock()
+	defer e.mtx.RUnlock()
+
+	return e.shards[id]
+}
+
 // SetShardMode sets mode of the shard with provided identifier.
 //
 // Returns an error if shard mode was not set, or shard was not found in storage engine.


### PR DESCRIPTION
It is possible to store an object on a shard that is not the first one after object address hash sorting and not-found-object-inhuming is also errorless, so the actual shard does not delete objects in such cases. Closes #2821.