### PR TITLE
node/tombstones: Protect first objects from removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ arm64 binaries for you as well now.
 - GC stops if any non-critical "content" errors happen (#2823)
 - Endless GC cycle if an object is stored on an unexpected shard (#2821)
 - Storage node searches for objects even if local state prohibits operation (#1709) 
+- First object in a split chain can de deleted (#2839)
 
 ### Changed
 

--- a/pkg/services/object/tombstone/verify.go
+++ b/pkg/services/object/tombstone/verify.go
@@ -104,6 +104,13 @@ func (v *Verifier) verifyMember(ctx context.Context, cnr cid.ID, member oid.ID) 
 			return fmt.Errorf("verify V1 split: %w", err)
 		}
 	} else {
+		if !firstSet {
+			// checks above say that this is a (non-V1) split object and also
+			// a first object is the only part that does not have a first object
+			// field set, obviously
+			firstChild = addr.Object()
+		}
+
 		err = v.verifyV2Child(ctx, cnr, firstChild)
 		if err != nil {
 			return fmt.Errorf("verify V2 split: %w", err)


### PR DESCRIPTION
First objects do not have `first` field set, so searching with empty ID is a no-op which means no LINK will ever be found => dropping a first object is allowed.