### PR TITLE
adm: never use GetContractStateByID(1) to retrieve NNS hash

### DIFF
--- a/cmd/neofs-adm/internal/modules/morph/dump_names.go
+++ b/cmd/neofs-adm/internal/modules/morph/dump_names.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/invoker"
-	"github.com/nspcc-dev/neo-go/pkg/rpcclient/nep11"
+	"github.com/nspcc-dev/neofs-contract/rpc/nns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,12 +28,12 @@ func dumpNames(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("can't create N3 client: %w", err)
 	}
-	cs, err := c.GetContractStateByID(1) // NNS.
+	nnsHash, err := nns.InferHash(c)
 	if err != nil {
 		return err
 	}
-	var n11r = nep11.NewNonDivisibleReader(invoker.New(c, nil), cs.Hash)
-	tokIter, err := n11r.Tokens()
+	var nnsReader = nns.NewReader(invoker.New(c, nil), nnsHash)
+	tokIter, err := nnsReader.Tokens()
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func dumpNames(cmd *cobra.Command, _ []string) error {
 			if zone != "" && !strings.HasSuffix(name, "."+zone) {
 				continue
 			}
-			props, err := n11r.Properties(toks[i])
+			props, err := nnsReader.Properties(toks[i])
 			if err != nil {
 				cmd.PrintErrf("Error getting properties for %s: %v\n", name, err)
 				continue

--- a/cmd/neofs-adm/internal/modules/morph/epoch.go
+++ b/cmd/neofs-adm/internal/modules/morph/epoch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
+	"github.com/nspcc-dev/neofs-contract/rpc/nns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -19,12 +20,13 @@ func forceNewEpochCmd(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("can't to initialize context: %w", err)
 	}
 
-	cs, err := wCtx.Client.GetContractStateByID(1)
+	nnsHash, err := nns.InferHash(wCtx.Client)
 	if err != nil {
-		return fmt.Errorf("can't get NNS contract info: %w", err)
+		return fmt.Errorf("can't get NNS hash: %w", err)
 	}
+	var nnsReader = nns.NewReader(wCtx.ReadOnlyInvoker, nnsHash)
 
-	nmHash, err := nnsResolveHash(wCtx.ReadOnlyInvoker, cs.Hash, netmapContract+".neofs")
+	nmHash, err := nnsReader.ResolveFSContract(nns.NameNetmap)
 	if err != nil {
 		return fmt.Errorf("can't get netmap contract hash: %w", err)
 	}

--- a/cmd/neofs-adm/internal/modules/morph/netmap_candidates.go
+++ b/cmd/neofs-adm/internal/modules/morph/netmap_candidates.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/invoker"
+	"github.com/nspcc-dev/neofs-contract/rpc/nns"
 	"github.com/nspcc-dev/neofs-node/cmd/internal/cmdprinter"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	"github.com/spf13/cobra"
@@ -18,12 +19,13 @@ func listNetmapCandidatesNodes(cmd *cobra.Command, _ []string) error {
 
 	inv := invoker.New(c, nil)
 
-	nnsCs, err := c.GetContractStateByID(1)
+	nnsHash, err := nns.InferHash(c)
 	if err != nil {
-		return fmt.Errorf("can't get NNS contract info: %w", err)
+		return fmt.Errorf("can't get NNS hash: %w", err)
 	}
+	var nnsReader = nns.NewReader(inv, nnsHash)
 
-	nmHash, err := nnsResolveHash(inv, nnsCs.Hash, netmapContract+".neofs")
+	nmHash, err := nnsReader.ResolveFSContract(nns.NameNetmap)
 	if err != nil {
 		return fmt.Errorf("can't get netmap contract hash: %w", err)
 	}

--- a/cmd/neofs-adm/internal/modules/morph/remove_node.go
+++ b/cmd/neofs-adm/internal/modules/morph/remove_node.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
 	netmapcontract "github.com/nspcc-dev/neofs-contract/contracts/netmap"
+	"github.com/nspcc-dev/neofs-contract/rpc/nns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -33,12 +34,13 @@ func removeNodesCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer wCtx.close()
 
-	cs, err := wCtx.Client.GetContractStateByID(1)
+	nnsHash, err := nns.InferHash(wCtx.Client)
 	if err != nil {
-		return fmt.Errorf("can't get NNS contract info: %w", err)
+		return fmt.Errorf("can't get NNS hash: %w", err)
 	}
+	var nnsReader = nns.NewReader(wCtx.ReadOnlyInvoker, nnsHash)
 
-	nmHash, err := nnsResolveHash(wCtx.ReadOnlyInvoker, cs.Hash, netmapContract+".neofs")
+	nmHash, err := nnsReader.ResolveFSContract(nns.NameNetmap)
 	if err != nil {
 		return fmt.Errorf("can't get netmap contract hash: %w", err)
 	}


### PR DESCRIPTION
And use a bit more of NNS wrapper.

Notice that this changes "alphabet X" to "alphabetX" in dump output, but I consider this to be an improvement (since that's the contract name).

It also deoptimizes some carefully crafted code to extract a number of names in one call. Likely it's not a performance issue you care about and it's actually somewhat broken in that it assumes one result per invocation (but you can get zero or more than one).

Many more things can be improved, but let's start with this.

Refs. #2826.