### PR TITLE
node/range: Do not request for empty payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- GETRANGE request may fail in certain cases (#2849)
 
 ### Changed
 - SN API server responds with status message even to old clients from now (#2846)

--- a/pkg/services/object/get/assembly_v2.go
+++ b/pkg/services/object/get/assembly_v2.go
@@ -156,7 +156,7 @@ func requiredChildren(rng *objectSDK.Range, children []objectSDK.MeasuredObject)
 		size := uint64(child.ObjectSize())
 		bytesSeen += size
 
-		if bytesSeen < leftBound {
+		if bytesSeen <= leftBound {
 			continue
 		}
 

--- a/pkg/services/object/get/assembly_v2_test.go
+++ b/pkg/services/object/get/assembly_v2_test.go
@@ -77,6 +77,10 @@ func Test_RequiredChildren(t *testing.T) {
 					rightBound = lastChildBound
 				}
 
+				if len(payloads[i]) > 0 {
+					require.NotZero(t, rightBound-leftBound, "do not ask for empty payload ever")
+				}
+
 				payloadFromChild := payloads[i][leftBound:rightBound]
 				res = append(res, payloadFromChild...)
 			}


### PR DESCRIPTION
If small object bounds equal a range request bound, it led to [X:0] requests. Closes #2849.