### PR TITLE
ir/config: Fix unenforced `morph.consensus.p2p.peers.min` config default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Unenforced IR `morph.consensus.p2p.peers.min` config default (#2856)
 
 ### Changed
 


### PR DESCRIPTION
_Originally posted by @evgeniiz321_

following P2P config
```yaml
p2p:
  listen:
    - localhost:59893
```
led to no consensus for 4x setup although it should have. Making it
```yaml
p2p:
  listen:
    - localhost:59893
  peers:
    min: 2
```
fixed the problem. Thus, the declared default was not fulfilled https://github.com/nspcc-dev/neofs-node/blob/9a9a5d5f4a9452cbb566d51548390d31f9038e5d/config/example/ir.yaml#L76-L78