### PR TITLE
workflows: switch to post-0.30.0 S3 test gateway

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: nspcc-dev/neofs-s3-gw
-          ref: v0.30.0
+          ref: c03a980232a19f2150c540b7f4e7034a4367ab7d
           path: neofs-s3-gw
 
       - name: Checkout neofs-rest-gw repository


### PR DESCRIPTION
With updated SDK and NeoGo dependencies, 0.30.0 fails to start currently.