### PR TITLE
ir: lower default max_traceable_blocks to 17280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - neofs-cli allows several objects deletion at a time (#2774)
 - `ObjectService.Put` server of in-container node places objects using new `ObjectService.Replicate` RPC (#2802)
 - `ObjectService`'s `Put` and `Replicate` RPC handlers cache up to 1000 lists of container nodes (#2892)
+- Default max_traceable_blocks Morph setting lowered to 17280 from 2102400 (#2897)
 
 ### Removed
 

--- a/config/example/ir.yaml
+++ b/config/example/ir.yaml
@@ -36,7 +36,7 @@ morph:
       path: ./db/morph.bolt # File system path to the storage. Ignored for 'inmemory' storage.
     time_per_block: 1s # Optional time period (approximate) between two adjacent blocks. Defaults to 15s.
       # Must not be negative
-    max_traceable_blocks: 2102400 # Optional length of the chain accessible to smart contracts. Defaults to 2102400.
+    max_traceable_blocks: 11520 # Optional length of the chain accessible to smart contracts. Defaults to 17280.
       # Must not be greater than 4294967295
     seed_nodes: # Optional list of existing nodes to communicate with over Neo P2P protocol. By default, node runs as standalone
       # Same format as 'p2p.listen'

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -203,7 +203,7 @@ type Config struct {
 
 	// Length of the chain accessible to smart contracts.
 	//
-	// Optional: defaults to 2102400.
+	// Optional: defaults to 17280.
 	TraceableChainLength uint32
 
 	// Maps hard-fork's name to the appearance chain height.
@@ -322,7 +322,7 @@ func New(cfg Config) (res *Blockchain, err error) {
 		cfg.P2P.ProtoTickInterval = 2 * time.Second
 	}
 	if cfg.TraceableChainLength == 0 {
-		cfg.TraceableChainLength = 2102400
+		cfg.TraceableChainLength = 17280
 	}
 	if cfg.P2P.Ping.Interval == 0 {
 		cfg.P2P.Ping.Interval = 30 * time.Second


### PR DESCRIPTION
Follow https://github.com/nspcc-dev/neo-go/pull/3518 for new and otherwise default setups, we don't need this long history of chain.