### PR TITLE
fix/allow "1b" config values for memory amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Control service's Drop call does not clean metabase (#2822)
+- It was impossible to specify memory amount as "1b" (one byte) in config, default was used instead (#2899)
 
 ### Changed
 - neofs-cli allows several objects deletion at a time (#2774)

--- a/cmd/neofs-node/config/cast.go
+++ b/cmd/neofs-node/config/cast.go
@@ -199,7 +199,7 @@ func parseSizeInBytes(sizeStr string) uint64 {
 		if sizeStr[lastChar] == 'b' || sizeStr[lastChar] == 'B' {
 			lastChar--
 		}
-		if lastChar > 0 {
+		if lastChar >= 0 {
 			switch unicode.ToLower(rune(sizeStr[lastChar])) {
 			case 'k':
 				multiplier = 1 << 10

--- a/cmd/neofs-node/config/cast_test.go
+++ b/cmd/neofs-node/config/cast_test.go
@@ -134,6 +134,8 @@ func TestSizeInBytes(t *testing.T) {
 		require.EqualValues(t, tb/2, config.SizeInBytesSafe(c, "size_float"))
 		require.EqualValues(t, uint64(14*gb+(gb*123/1000/mb*mb)), config.SizeInBytesSafe(c, "size_float_big"))
 		require.EqualValues(t, 2048, config.SizeInBytesSafe(c, "size_bytes"))
+		require.EqualValues(t, 1, config.SizeInBytesSafe(c, "size_bytes_single_char"))
+		require.EqualValues(t, 1, config.SizeInBytesSafe(c, "size_bytes_single_char_no_space"))
 		require.EqualValues(t, 123456, config.SizeInBytesSafe(c, "size_bytes_no_suffix"))
 	})
 }

--- a/cmd/neofs-node/config/test/config.json
+++ b/cmd/neofs-node/config/test/config.json
@@ -58,6 +58,8 @@
     "size_float_big": "14.123 gb",
     "size_i_am_not_very_clever": "12.12345678",
     "size_bytes": "2048b",
+    "size_bytes_single_char": "1 b",
+    "size_bytes_single_char_no_space": "1b",
     "size_bytes_no_suffix": 123456
   },
 

--- a/cmd/neofs-node/config/test/config.yaml
+++ b/cmd/neofs-node/config/test/config.yaml
@@ -51,6 +51,8 @@ sizes:
   size_float_big: 14.123 gb
   size_i_am_not_very_clever: 12.12345678
   size_bytes: 2048b
+  size_bytes_single_char: 1 b
+  size_bytes_single_char_no_space: 1b
   size_bytes_no_suffix: 123456
 
 with_default:


### PR DESCRIPTION
It was not used in practice before, so no issues were opened, or tests were written, but it still looks like a valid configuration value.