### PR TITLE
.dockerignore: exclude .cache directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.cache
 .idea
 .vscode
 .git


### PR DESCRIPTION
It was 688Mb on my laptop, never cleaned it and never know what exactly is using it but we have it in `.gitignore` since d83f2e8b47e2da1e14c5a6a05db223fc86736b18. Building docker images locally made docker send this full dir as a context. Tried to drop it, and make my ordinary commands (lint, tests, buildings), but nothing created anything new in this dir. Dropping this dir completely (from .gitignore too) is preferable if anybody knows what this is for and also can prove that it is not used anymore.