### PR TITLE
node/acl: fix acl checks for non-container nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - Control service's Drop call does not clean metabase (#2822)
 - It was impossible to specify memory amount as "1b" (one byte) in config, default was used instead (#2899)
 - Container session token's lifetime was not checked (#2898)
+- ACL checks for split objects could be forced by a node than might lack access (#2909) 
 
 ### Changed
 - neofs-cli allows several objects deletion at a time (#2774)

--- a/pkg/services/object/acl/v2/opts.go
+++ b/pkg/services/object/acl/v2/opts.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
-	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	objectSvc "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"go.uber.org/zap"
 )
@@ -14,9 +13,9 @@ func WithLogger(v *zap.Logger) Option {
 	}
 }
 
-// WithNetmapSource return option to set
+// WithNetmapper return option to set
 // netmap source.
-func WithNetmapSource(v netmap.Source) Option {
+func WithNetmapper(v Netmapper) Option {
 	return func(c *cfg) {
 		c.nm = v
 	}


### PR DESCRIPTION
Split objects are validated and it required to do some additional requests for it. Such operation can be restricted for a non-container node, so checking for it is an unsolvable problem, skip ACL checks in such cases. Closes #2909.