### PR TITLE
cli: do not overwrite parsed eacl rules

### DIFF
--- a/cmd/neofs-cli/modules/util/acl.go
+++ b/cmd/neofs-cli/modules/util/acl.go
@@ -236,7 +236,7 @@ func parseEACLTable(tb *eacl.Table, args []string) error {
 		records = append(records, record)
 	}
 
-	tb.SetRecords(records)
+	tb.SetRecords(append(tb.Records(), records...))
 
 	return nil
 }


### PR DESCRIPTION
Regression from c72af12127e852779d4c3dddd648a5b6326da048. As I have already said in associated PR, new SDK turned out to be a counter-CLI thing.