### PR TITLE
shard: drop more of context from local stores

### DIFF
--- a/pkg/local_object_storage/engine/inhume.go
+++ b/pkg/local_object_storage/engine/inhume.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"errors"
 
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
@@ -324,7 +323,7 @@ func (e *StorageEngine) isLocked(addr oid.Address) (bool, error) {
 	return locked, outErr
 }
 
-func (e *StorageEngine) processExpiredObjects(_ context.Context, addrs []oid.Address) {
+func (e *StorageEngine) processExpiredObjects(addrs []oid.Address) {
 	var prm InhumePrm
 	prm.MarkAsGarbage(addrs...)
 
@@ -334,17 +333,10 @@ func (e *StorageEngine) processExpiredObjects(_ context.Context, addrs []oid.Add
 	}
 }
 
-func (e *StorageEngine) processExpiredLocks(ctx context.Context, lockers []oid.Address) {
+func (e *StorageEngine) processExpiredLocks(lockers []oid.Address) {
 	e.iterateOverUnsortedShards(func(sh hashedShard) (stop bool) {
 		sh.HandleExpiredLocks(lockers)
-
-		select {
-		case <-ctx.Done():
-			e.log.Info("interrupt processing the expired locks by context")
-			return true
-		default:
-			return false
-		}
+		return false
 	})
 }
 

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -141,7 +141,6 @@ func (s *Shard) Init() error {
 		eventChan:   make(chan Event),
 		mEventHandler: map[eventType]*eventHandlers{
 			eventNewEpoch: {
-				cancelFunc: func() {},
 				handlers: []eventHandler{
 					s.collectExpiredObjects,
 					s.collectExpiredTombstones,

--- a/pkg/local_object_storage/shard/gc_test.go
+++ b/pkg/local_object_storage/shard/gc_test.go
@@ -1,7 +1,6 @@
 package shard_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -64,7 +63,7 @@ func TestGC_ExpiredObjectWithExpiredLock(t *testing.T) {
 		shard.WithDeletedLockCallback(func(aa []oid.Address) {
 			sh.HandleDeletedLocks(aa)
 		}),
-		shard.WithExpiredLocksCallback(func(_ context.Context, aa []oid.Address) {
+		shard.WithExpiredLocksCallback(func(aa []oid.Address) {
 			sh.HandleExpiredLocks(aa)
 		}),
 		shard.WithGCWorkerPoolInitializer(func(sz int) util.WorkerPool {
@@ -205,7 +204,7 @@ func TestExpiration(t *testing.T) {
 			meta.WithEpochState(epochState{Value: math.MaxUint64 / 2}),
 		),
 		shard.WithExpiredObjectsCallback(
-			func(_ context.Context, addresses []oid.Address) {
+			func(addresses []oid.Address) {
 				var p shard.InhumePrm
 				p.MarkAsGarbage(addresses...)
 				_, err := sh.Inhume(p)

--- a/pkg/local_object_storage/shard/shard.go
+++ b/pkg/local_object_storage/shard/shard.go
@@ -1,7 +1,6 @@
 package shard
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -34,10 +33,10 @@ type Shard struct {
 type Option func(*cfg)
 
 // ExpiredTombstonesCallback is a callback handling list of expired tombstones.
-type ExpiredTombstonesCallback func(context.Context, []meta.TombstonedObject)
+type ExpiredTombstonesCallback func([]meta.TombstonedObject)
 
 // ExpiredObjectsCallback is a callback handling list of expired objects.
-type ExpiredObjectsCallback func(context.Context, []oid.Address)
+type ExpiredObjectsCallback func([]oid.Address)
 
 // DeletedLockCallback is a callback handling list of deleted LOCK objects.
 type DeletedLockCallback func([]oid.Address)


### PR DESCRIPTION
Similar to edc447f530cd040ab4c2e79e06235b8271680183, we can't have any meaninful context here and current context checks are broken. Fixes #1911, the last case of

  Error in `cmd/neofs-node/config.go`: `Function `Reload->Init->init->listenEvents` should pass the context parameter`.

goes away with this.