### PR TITLE
meta: fix `Delete` test

### DIFF
--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -43,7 +43,7 @@ func TestDB_Delete(t *testing.T) {
 	err = metaDelete(db, object.AddressOf(parent))
 	require.NoError(t, err)
 
-	// inhume parent and child so they will be on graveyard
+	// inhume child so it will be on graveyard
 	ts := generateObjectWithCID(t, cnr)
 
 	err = metaInhume(db, object.AddressOf(child), object.AddressOf(ts))
@@ -58,14 +58,16 @@ func TestDB_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, l, 0)
 
-	// check if they marked as already removed
+	// check if the child is still inhumed (deletion should not affect
+	// TS status that should be kept for some epochs and be handled
+	// separately) and parent is not found
 
 	ok, err := metaExists(db, object.AddressOf(child))
-	require.Error(t, apistatus.ObjectAlreadyRemoved{})
+	require.ErrorIs(t, err, apistatus.ErrObjectAlreadyRemoved)
 	require.False(t, ok)
 
 	ok, err = metaExists(db, object.AddressOf(parent))
-	require.Error(t, apistatus.ObjectAlreadyRemoved{})
+	require.NoError(t, err)
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
Behavior has changed a few times since the original implementation. Also, the test was broken a little in 8107c8d1a9cc2635510988828e5bfeec13656b4d. Parent/child relations were changed and now are treated differently at higher levels, so this test is not so important (see new `TestDeleteAllChildren` below, it plays a more important role in metabase testing), but keeping it in working condition with correct statements is not a bad idea.