### PR TITLE
Fix error format in `neofs-adm`

### DIFF
--- a/cmd/neofs-adm/main.go
+++ b/cmd/neofs-adm/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/cmd/internal/cmderr"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-adm/internal/modules"
 )
 
 func main() {
 	err := modules.Execute()
-	cmderr.ExitOnErr(err)
+	if err != nil {
+		cmderr.ExitOnErr(fmt.Errorf("Error: %w\n", err))
+	}
 }


### PR DESCRIPTION
Fix error format, that is broken from #2942, becuse of `SilenceErrors` in `cobra` command.