### PR TITLE
ir/config: assign default to missing port in TCP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - When an error is returned, no additional help output is displayed in cobra-based programs (#2942)
 - Use org-wide linter (#2943)
 - Timestamps are no longer produced in logs if not running with TTY (#2964)
+- In inner ring config, default ports for TCP addresses are used if they are missing (#2969)
 
 ### Removed
 - Support for node.key configuration (#2959)

--- a/config/example/ir.yaml
+++ b/config/example/ir.yaml
@@ -40,7 +40,7 @@ morph:
       # Must not be greater than 4294967295
     seed_nodes: # Optional list of existing nodes to communicate with over Neo P2P protocol. By default, node runs as standalone
       # Same format as 'p2p.listen'
-      - node2:20333
+      - node2
       - node3:20333
     hardforks: # Optional hard-forks
       name: 1730000 # Maps name to chain height. Heights must not be greater than 4294967295
@@ -53,13 +53,13 @@ morph:
       12: 4
     rpc: # Optional RPC settings
       listen: # Optional list of network addresses to listen Neo RPC on. By default, protocol is not served
-        # TCP addresses in 'host:port' format
-        - localhost:30333
+        # TCP addresses in 'host:port' format, or just 'host', then it will use the default port ':30333'.
+        - localhost
         - localhost:30334
       tls: # Additional addresses to listen to using TLS setup; must not overlap with `listen` section
         enabled: false # Additional TLS serving switcher
         listen: # Addresses to listen to; required to be at least 1-length if 'enabled' is 'true'
-          # TCP addresses in 'host:port' format
+          # TCP addresses in 'host:port' format, or just 'host', then it will use the default port ':30333'.
           - localhost:30335
           - localhost:30336
         cert_file: serv.crt # TLS certificate file path; required if 'enabled' is 'true'
@@ -69,8 +69,8 @@ morph:
       proto_tick_interval: 2s # Optional time period between protocol ticks with each connected peer. Defaults to 2s.
         # Must not be negative
       listen: # Optional list of network addresses to listen Neo P2P on. By default, protocol is not served
-        # TCP addresses in 'host:port' format
-        - localhost:20333
+        # TCP addresses in 'host:port' format, or just 'host', then it will use the default port ':20333'.
+        - localhost
         - localhost:20334
       peers: # Optional peer settings
         min: 1 # Optional minimum number of peers a node needs for normal operation. Defaults to consensus minimum

--- a/pkg/innerring/config_test.go
+++ b/pkg/innerring/config_test.go
@@ -37,6 +37,7 @@ const validBlockchainConfigOptions = `
     seed_nodes:
       - localhost:20000
       - localhost:20001
+      - localhost
     hardforks:
       name: 1730000
     validators_history:
@@ -47,11 +48,13 @@ const validBlockchainConfigOptions = `
       listen:
         - localhost:30000
         - localhost:30001
+        - localhost
       tls:
         enabled: true
         listen:
           - localhost:30002
           - localhost:30003
+          - localhost
         cert_file: /path/to/cert
         key_file: /path/to/key
     p2p:
@@ -60,6 +63,7 @@ const validBlockchainConfigOptions = `
       listen:
         - localhost:20100
         - localhost:20101
+        - localhost
       peers:
         min: 1
         max: 5
@@ -171,6 +175,7 @@ func TestParseBlockchainConfig(t *testing.T) {
 				Addresses: []string{
 					"localhost:30000",
 					"localhost:30001",
+					"localhost:30333",
 				},
 				TLSConfig: blockchain.TLSConfig{
 					Enabled:  true,
@@ -179,6 +184,7 @@ func TestParseBlockchainConfig(t *testing.T) {
 					Addresses: []string{
 						"localhost:30002",
 						"localhost:30003",
+						"localhost:30333",
 					},
 				},
 			},
@@ -189,6 +195,7 @@ func TestParseBlockchainConfig(t *testing.T) {
 			SeedNodes: []string{
 				"localhost:20000",
 				"localhost:20001",
+				"localhost:20333",
 			},
 			P2P: blockchain.P2PConfig{
 				MinPeers:         1,
@@ -203,6 +210,7 @@ func TestParseBlockchainConfig(t *testing.T) {
 				ListenAddresses: []string{
 					"localhost:20100",
 					"localhost:20101",
+					"localhost:20333",
 				},
 			},
 			Storage: blockchain.BoltDB("chain.db"),
@@ -258,7 +266,6 @@ func TestParseBlockchainConfig(t *testing.T) {
 			{kvF("max_traceable_blocks", -1)},
 			{kvF("max_traceable_blocks", math.MaxUint32+1)},
 			{kvF("seed_nodes", []string{"not a TCP address"})},
-			{kvF("seed_nodes", []string{"127.0.0.1"})}, // missing port
 			{kvF("hardforks", "not a dictionary")},
 			{kvF("hardforks", map[string]any{"": 1})},
 			{kvF("hardforks", map[string]any{"name": "not a number"})},
@@ -272,13 +279,11 @@ func TestParseBlockchainConfig(t *testing.T) {
 			{kvF("validators_history", map[string]any{"0": len(validCommittee) + 1})},
 			{kvF("validators_history", map[string]any{"0": 1, "3": 1})}, // height is not a multiple
 			{kvF("rpc.listen", []string{"not a TCP address"})},
-			{kvF("rpc.listen", []string{"127.0.0.1"})},                                                         // missing port
 			{kvF("rpc.tls.enabled", true), kvF("rpc.tls.cert_file", "")},                                       // enabled but no cert file is provided
 			{kvF("rpc.tls.enabled", true), kvF("rpc.tls.cert_file", " \t")},                                    // enabled but no but blank cert is provided
 			{kvF("rpc.tls.enabled", true), kvF("rpc.tls.cert_file", "/path/"), kvF("rpc.tls.key_file", "")},    // enabled but no key is provided
 			{kvF("rpc.tls.enabled", true), kvF("rpc.tls.cert_file", "/path/"), kvF("rpc.tls.key_file", " \t")}, // enabled but no but blank key is provided
 			{kvF("p2p.listen", []string{"not a TCP address"})},
-			{kvF("p2p.listen", []string{"127.0.0.1"})}, // missing port
 			{kvF("p2p.dial_timeout", "not a duration")},
 			{kvF("p2p.dial_timeout", -time.Second)},
 			{kvF("p2p.proto_tick_interval", "not a duration")},


### PR DESCRIPTION
Closes #2420.

Is it necessary to document default ports, except the example config?