### PR TITLE
docs: Add several missing sections to the SN structure table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 ### Fixed
 - Do not search for tombstones when handling their expiration, use local indexes instead (#2929)
 - Unathorized container ops accepted by the IR (#2947)
+- Structure table in the SN-configuration document (#2974)
 
 ### Changed
 - `ObjectService`'s `Put` RPC handler caches up to 10K lists of per-object sorted container nodes (#2901)

--- a/docs/storage-node-configuration.md
+++ b/docs/storage-node-configuration.md
@@ -24,6 +24,9 @@ There are some custom types used for brevity:
 | `policer`    | [Policer service configuration](#policer-section)       |
 | `replicator` | [Replicator service configuration](#replicator-section) |
 | `storage`    | [Storage engine configuration](#storage-section)        |
+| `grpc`       | [gRPC configuration](#grpc-section)                     |
+| `node`       | [Node configuration](#node-section)                     |
+| `object`     | [Object service configuration](#object-section)         |
 
 
 # `control` section


### PR DESCRIPTION
Small improvement to the SN-configuration document. I found several sections that were not included in the structure table at the top of the document, making navigation more difficult without them.  
Feel free to reject if you don't like it.