### PR TITLE
docs: add docs about all cli commands

### DIFF
--- a/.github/workflows/cli-docs-update.yml
+++ b/.github/workflows/cli-docs-update.yml
@@ -1,0 +1,24 @@
+name: CLI commands docs check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - support/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: cli-docs-check
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate new CLI doc files
+        run: make cli-gendoc
+
+      - name: Fail if CLI commands files are changed but the documentation is not updated
+        run: |
+          git add -N docs/cli-commands
+          git diff --exit-code -- docs/cli-commands/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - `neofs-lens meta last-resync-epoch` command (#2966)
 - `neofs-lens fstree cleanup-tmp` command (#2967)
 - `neofs-cli control object revive` command (#2968)
+- `--disable-auto-gen-tag` flag for gendoc command (#2983)
 
 ### Fixed
 - Do not search for tombstones when handling their expiration, use local indexes instead (#2929)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - `neofs-lens fstree cleanup-tmp` command (#2967)
 - `neofs-cli control object revive` command (#2968)
 - `--disable-auto-gen-tag` flag for gendoc command (#2983)
+- Docs files for cli commands to the `docs/cli-commands` folder (#2983)
 
 ### Fixed
 - Do not search for tombstones when handling their expiration, use local indexes instead (#2929)

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ test:
 lint: .golangci.yml
 	@golangci-lint --timeout=5m run
 
+cli-gendoc: $(BIN)/neofs-cli
+	@echo "⇒ Generating CLI commands documentation"
+	@$< gendoc ./docs/cli-commands -d
+
 # Run linters in Docker
 docker/lint:
 	docker run --rm -t \

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ have additional documents describing them:
  * [Extended headers](docs/cli-xheaders.md)
  * [Exit codes](docs/cli-exit-codes.md)
 
+See [docs/cli-commands](docs/cli-commands) for information about all cli commands.
+
 `neofs-adm` is a network setup and management utility usually used by the
 network administrators. Refer to [docs/cli-adm.md](docs/cli-adm.md) for mode
 information about it.

--- a/cmd/neofs-cli/modules/control/shards_set_mode.go
+++ b/cmd/neofs-cli/modules/control/shards_set_mode.go
@@ -3,6 +3,7 @@ package control
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/mr-tron/base58"
@@ -91,6 +92,7 @@ func initControlSetShardModeCmd() {
 	iterateSafeShardModes(func(strMode string) {
 		modes = append(modes, "'"+strMode+"'")
 	})
+	sort.Strings(modes)
 
 	flags.String(shardModeFlag, "",
 		fmt.Sprintf("New shard mode (%s)", strings.Join(modes, ", ")),

--- a/docs/cli-commands/neofs-cli.md
+++ b/docs/cli-commands/neofs-cli.md
@@ -1,0 +1,42 @@
+## neofs-cli
+
+Command Line Tool to work with NeoFS
+
+### Synopsis
+
+NeoFS CLI provides all basic interactions with NeoFS and it's services.
+
+It contains commands for interaction with NeoFS nodes using different versions
+of neofs-api and some useful utilities for compiling ACL rules from JSON
+notation, managing container access through protocol gates, querying network map
+and much more!
+
+```
+neofs-cli [flags]
+```
+
+### Options
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -h, --help            help for neofs-cli
+  -v, --verbose         Verbose output
+      --version         Application version and NeoFS API compatibility
+```
+
+### SEE ALSO
+
+* [neofs-cli accounting](neofs-cli_accounting.md)	 - Operations with accounts and balances
+* [neofs-cli acl](neofs-cli_acl.md)	 - Operations with Access Control Lists
+* [neofs-cli bearer](neofs-cli_bearer.md)	 - Operations with bearer token
+* [neofs-cli completion](neofs-cli_completion.md)	 - Generate completion script
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+* [neofs-cli gendoc](neofs-cli_gendoc.md)	 - Generate documentation for this command
+* [neofs-cli netmap](neofs-cli_netmap.md)	 - Operations with Network Map
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+* [neofs-cli session](neofs-cli_session.md)	 - Operations with session token
+* [neofs-cli storagegroup](neofs-cli_storagegroup.md)	 - Operations with Storage Groups
+* [neofs-cli tree](neofs-cli_tree.md)	 - Operations with the Tree service
+* [neofs-cli util](neofs-cli_util.md)	 - Utility operations
+

--- a/docs/cli-commands/neofs-cli_accounting.md
+++ b/docs/cli-commands/neofs-cli_accounting.md
@@ -1,0 +1,26 @@
+## neofs-cli accounting
+
+Operations with accounts and balances
+
+### Synopsis
+
+Operations with accounts and balances
+
+### Options
+
+```
+  -h, --help   help for accounting
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli accounting balance](neofs-cli_accounting_balance.md)	 - Get internal balance of NeoFS account
+

--- a/docs/cli-commands/neofs-cli_accounting_balance.md
+++ b/docs/cli-commands/neofs-cli_accounting_balance.md
@@ -1,0 +1,33 @@
+## neofs-cli accounting balance
+
+Get internal balance of NeoFS account
+
+### Synopsis
+
+Get internal balance of NeoFS account
+
+```
+neofs-cli accounting balance [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -h, --help                  help for balance
+      --owner string          owner of balance account (omit to use owner from private key)
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli accounting](neofs-cli_accounting.md)	 - Operations with accounts and balances
+

--- a/docs/cli-commands/neofs-cli_acl.md
+++ b/docs/cli-commands/neofs-cli_acl.md
@@ -1,0 +1,23 @@
+## neofs-cli acl
+
+Operations with Access Control Lists
+
+### Options
+
+```
+  -h, --help   help for acl
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli acl basic](neofs-cli_acl_basic.md)	 - Operations with Basic Access Control Lists
+* [neofs-cli acl extended](neofs-cli_acl_extended.md)	 - Operations with Extended Access Control Lists
+

--- a/docs/cli-commands/neofs-cli_acl_basic.md
+++ b/docs/cli-commands/neofs-cli_acl_basic.md
@@ -1,0 +1,22 @@
+## neofs-cli acl basic
+
+Operations with Basic Access Control Lists
+
+### Options
+
+```
+  -h, --help   help for basic
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli acl](neofs-cli_acl.md)	 - Operations with Access Control Lists
+* [neofs-cli acl basic print](neofs-cli_acl_basic_print.md)	 - Pretty print basic ACL from the HEX representation
+

--- a/docs/cli-commands/neofs-cli_acl_basic_print.md
+++ b/docs/cli-commands/neofs-cli_acl_basic_print.md
@@ -1,0 +1,40 @@
+## neofs-cli acl basic print
+
+Pretty print basic ACL from the HEX representation
+
+### Synopsis
+
+Pretty print basic ACL from the HEX representation or keyword.
+Few roles have exclusive default access to set of operation, even if particular bit deny it.
+Container have access to the operations of the data replication mechanism:
+    Get, Head, Put, Search, Hash.
+InnerRing members are allowed to data audit ops only:
+    Get, Head, Hash, Search.
+
+```
+neofs-cli acl basic print [flags]
+```
+
+### Examples
+
+```
+neofs-cli acl basic print 0x1C8C8CCC
+```
+
+### Options
+
+```
+  -h, --help   help for print
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli acl basic](neofs-cli_acl_basic.md)	 - Operations with Basic Access Control Lists
+

--- a/docs/cli-commands/neofs-cli_acl_extended.md
+++ b/docs/cli-commands/neofs-cli_acl_extended.md
@@ -1,0 +1,23 @@
+## neofs-cli acl extended
+
+Operations with Extended Access Control Lists
+
+### Options
+
+```
+  -h, --help   help for extended
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli acl](neofs-cli_acl.md)	 - Operations with Access Control Lists
+* [neofs-cli acl extended create](neofs-cli_acl_extended_create.md)	 - Create extended ACL from the text representation
+* [neofs-cli acl extended print](neofs-cli_acl_extended_print.md)	 - Pretty print extended ACL from the file(in text or json format) or for given container.
+

--- a/docs/cli-commands/neofs-cli_acl_extended_create.md
+++ b/docs/cli-commands/neofs-cli_acl_extended_create.md
@@ -1,0 +1,68 @@
+## neofs-cli acl extended create
+
+Create extended ACL from the text representation
+
+### Synopsis
+
+Create extended ACL from the text representation.
+
+Rule consist of these blocks: <action> <operation> [<filter1> ...] [<target1> ...]
+
+Action is 'allow' or 'deny'.
+
+Operation is an object service verb: 'get', 'head', 'put', 'search', 'delete', 'getrange', or 'getrangehash'.
+
+Filter consists of <typ>:<key><match><value>
+  Typ is 'obj' for object applied filter or 'req' for request applied filter. 
+  Key is a valid unicode string corresponding to object or request header key. 
+    Well-known system object headers start with '$Object:' prefix.
+    User defined headers start without prefix.
+    Read more about filter keys at github.com/nspcc-dev/neofs-api/blob/master/proto-docs/acl.md#message-eaclrecordfilter
+  Match is:
+    '=' for string equality or, if no value, attribute absence;
+    '!=' for string inequality;
+    '>' | '>=' | '<' | '<=' for integer comparison.
+  Value is a valid unicode string corresponding to object or request header value. Numeric filters must have base-10 integer values.
+
+Target is 
+  'user' for container owner, 
+  'system' for Storage nodes in container and Inner Ring nodes,
+  'others' for all other request senders, 
+  'pubkey:<key1>,<key2>,...' for exact request sender, where <key> is a hex-encoded 33-byte public key, DEPRECATED,
+  'address:<adr1>,<adr2>,...' for exact request sender, where <adr> is a base58 25-byte address. Example: NSiVJYZej4XsxG5CUpdwn7VRQk8iiiDMPM.
+
+When both '--rule' and '--file' arguments are used, '--rule' records will be placed higher in resulting extended ACL table.
+
+
+```
+neofs-cli acl extended create [flags]
+```
+
+### Examples
+
+```
+neofs-cli acl extended create --cid EutHBsdT1YCzHxjCfQHnLPL1vFrkSyLSio4vkphfnEk -f rules.txt --out table.json
+neofs-cli acl extended create --cid EutHBsdT1YCzHxjCfQHnLPL1vFrkSyLSio4vkphfnEk -r 'allow get obj:Key=Value others' -r 'deny put others' -r 'deny put obj:$Object:payloadLength<4096 others' -r 'deny get obj:Quality>=100 others'
+```
+
+### Options
+
+```
+      --cid string         Container ID.
+  -f, --file string        Read list of extended ACL table records from text file
+  -h, --help               help for create
+  -o, --out string         Save JSON formatted extended ACL table in file
+  -r, --rule stringArray   Extended ACL table record to apply
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli acl extended](neofs-cli_acl_extended.md)	 - Operations with Extended Access Control Lists
+

--- a/docs/cli-commands/neofs-cli_acl_extended_print.md
+++ b/docs/cli-commands/neofs-cli_acl_extended_print.md
@@ -1,0 +1,26 @@
+## neofs-cli acl extended print
+
+Pretty print extended ACL from the file(in text or json format) or for given container.
+
+```
+neofs-cli acl extended print [flags]
+```
+
+### Options
+
+```
+  -f, --file string   Read list of extended ACL table records from text or json file
+  -h, --help          help for print
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli acl extended](neofs-cli_acl_extended.md)	 - Operations with Extended Access Control Lists
+

--- a/docs/cli-commands/neofs-cli_bearer.md
+++ b/docs/cli-commands/neofs-cli_bearer.md
@@ -1,0 +1,23 @@
+## neofs-cli bearer
+
+Operations with bearer token
+
+### Options
+
+```
+  -h, --help   help for bearer
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli bearer create](neofs-cli_bearer_create.md)	 - Create bearer token
+* [neofs-cli bearer print](neofs-cli_bearer_print.md)	 - Print binary-marshalled bearer tokens from file or STDIN in JSON format
+

--- a/docs/cli-commands/neofs-cli_bearer_create.md
+++ b/docs/cli-commands/neofs-cli_bearer_create.md
@@ -1,0 +1,43 @@
+## neofs-cli bearer create
+
+Create bearer token
+
+### Synopsis
+
+Create bearer token.
+
+All epoch flags can be specified relative to the current epoch with the +n syntax.
+In this case --rpc-endpoint flag should be specified and the epoch in bearer token
+is set to current epoch + n.
+
+
+```
+neofs-cli bearer create [flags]
+```
+
+### Options
+
+```
+  -e, --eacl string               Path to the extended ACL table
+  -x, --expire-at string          The last active epoch for the token
+  -h, --help                      help for create
+  -i, --issued-at string          Epoch to issue token at
+      --json                      Output token in JSON
+  -l, --lifetime uint             Number of epochs for token to stay valid
+  -n, --not-valid-before string   Not valid before epoch
+      --out string                File to write token to
+  -o, --owner string              Token owner
+  -r, --rpc-endpoint string       Remote node address (as 'multiaddr' or '<host>:<port>')
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli bearer](neofs-cli_bearer.md)	 - Operations with bearer token
+

--- a/docs/cli-commands/neofs-cli_bearer_print.md
+++ b/docs/cli-commands/neofs-cli_bearer_print.md
@@ -1,0 +1,30 @@
+## neofs-cli bearer print
+
+Print binary-marshalled bearer tokens from file or STDIN in JSON format
+
+### Synopsis
+
+neofs-cli bearer print [FILE]
+With no FILE, or when FILE is -, read standard input.
+
+```
+neofs-cli bearer print [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for print
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli bearer](neofs-cli_bearer.md)	 - Operations with bearer token
+

--- a/docs/cli-commands/neofs-cli_completion.md
+++ b/docs/cli-commands/neofs-cli_completion.md
@@ -1,0 +1,55 @@
+## neofs-cli completion
+
+Generate completion script
+
+### Synopsis
+
+To load completions:
+
+Bash:
+  $ source <(neofs-cli completion bash)
+
+  To load completions for each session, execute once:
+  Linux:
+  $ neofs-cli completion bash > /etc/bash_completion.d/neofs-cli
+  MacOS:
+  $ neofs-cli completion bash > /usr/local/etc/bash_completion.d/neofs-cli
+
+Zsh:
+  If shell completion is not already enabled in your environment you will need
+  to enable it.  You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+  
+  To load completions for each session, execute once:
+  $ neofs-cli completion zsh > "${fpath[1]}/_neofs-cli"
+  
+  You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ neofs-cli completion fish | source
+  
+  To load completions for each session, execute once:
+  $ neofs-cli completion fish > ~/.config/fish/completions/neofs-cli.fish
+
+
+```
+neofs-cli completion [bash|zsh|fish|powershell]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+

--- a/docs/cli-commands/neofs-cli_container.md
+++ b/docs/cli-commands/neofs-cli_container.md
@@ -1,0 +1,33 @@
+## neofs-cli container
+
+Operations with containers
+
+### Synopsis
+
+Operations with containers
+
+### Options
+
+```
+  -h, --help   help for container
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli container create](neofs-cli_container_create.md)	 - Create new container
+* [neofs-cli container delete](neofs-cli_container_delete.md)	 - Delete existing container
+* [neofs-cli container get](neofs-cli_container_get.md)	 - Get container field info
+* [neofs-cli container get-eacl](neofs-cli_container_get-eacl.md)	 - Get extended ACL table of container
+* [neofs-cli container list](neofs-cli_container_list.md)	 - List all created containers
+* [neofs-cli container list-objects](neofs-cli_container_list-objects.md)	 - List existing objects in container
+* [neofs-cli container nodes](neofs-cli_container_nodes.md)	 - Show nodes for container
+* [neofs-cli container set-eacl](neofs-cli_container_set-eacl.md)	 - Set new extended ACL table for container
+

--- a/docs/cli-commands/neofs-cli_container_create.md
+++ b/docs/cli-commands/neofs-cli_container_create.md
@@ -1,0 +1,45 @@
+## neofs-cli container create
+
+Create new container
+
+### Synopsis
+
+Create new container and register it in the NeoFS. 
+It will be stored in sidechain when inner ring will accepts it.
+
+```
+neofs-cli container create [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -a, --attributes strings    Comma separated pairs of container attributes in form of Key1=Value1,Key2=Value2
+      --await                 Block execution until container is persisted. Increases default execution timeout to 60s
+      --basic-acl string      HEX-encoded basic ACL value or one of the keywords ['public-read-write', 'private', 'eacl-public-read','eacl-private', 'public-read', 'eacl-public-read-write', 'public-append', 'eacl-public-append']. To see the basic ACL details, run: 'neofs-cli acl basic print' (default "private")
+      --disable-timestamp     Disable timestamp container attribute
+  -f, --force                 Skip placement validity check
+      --global-name           Name becomes a domain name, that is registered with the default zone in NNS contract. Requires name attribute.
+  -h, --help                  help for create
+      --name string           Container name attribute
+  -p, --policy string         QL-encoded or JSON-encoded placement policy or path to file with it
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the container PUT session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_delete.md
+++ b/docs/cli-commands/neofs-cli_container_delete.md
@@ -1,0 +1,39 @@
+## neofs-cli container delete
+
+Delete existing container
+
+### Synopsis
+
+Delete existing container. 
+Only owner of the container has a permission to remove container.
+
+```
+neofs-cli container delete [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --await                 Block execution until container is removed. Increases default execution timeout to 60s
+      --cid string            Container ID.
+  -f, --force                 Skip validation checks (ownership, presence of LOCK objects)
+  -h, --help                  help for delete
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the container DELETE session
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_get-eacl.md
+++ b/docs/cli-commands/neofs-cli_container_get-eacl.md
@@ -1,0 +1,39 @@
+## neofs-cli container get-eacl
+
+Get extended ACL table of container
+
+### Synopsis
+
+Get extended ACL table of container
+
+```
+neofs-cli container get-eacl [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for get-eacl
+      --json                  Encode EACL table in json format
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --to string             Path to dump encoded container (default: binary encoded)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_get.md
+++ b/docs/cli-commands/neofs-cli_container_get.md
@@ -1,0 +1,40 @@
+## neofs-cli container get
+
+Get container field info
+
+### Synopsis
+
+Get container field info
+
+```
+neofs-cli container get [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+      --from string           Path to file with encoded container
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for get
+      --json                  Print or dump container in JSON format
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --to string             Path to dump encoded container
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_list-objects.md
+++ b/docs/cli-commands/neofs-cli_container_list-objects.md
@@ -1,0 +1,39 @@
+## neofs-cli container list-objects
+
+List existing objects in container
+
+### Synopsis
+
+List existing objects in container
+
+```
+neofs-cli container list-objects [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for list-objects
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+      --with-attr             Request and print user attributes of each object
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_list.md
+++ b/docs/cli-commands/neofs-cli_container_list.md
@@ -1,0 +1,38 @@
+## neofs-cli container list
+
+List all created containers
+
+### Synopsis
+
+List all created containers
+
+```
+neofs-cli container list [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for list
+      --owner string          Owner of containers (omit to use owner from private key)
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+      --with-attr             Request and print attributes of each container
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_nodes.md
+++ b/docs/cli-commands/neofs-cli_container_nodes.md
@@ -1,0 +1,39 @@
+## neofs-cli container nodes
+
+Show nodes for container
+
+### Synopsis
+
+Show nodes taking part in a container at the current epoch.
+
+```
+neofs-cli container nodes [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+      --from string           Path to file with encoded container
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for nodes
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --short                 Shortens output of node info
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_container_set-eacl.md
+++ b/docs/cli-commands/neofs-cli_container_set-eacl.md
@@ -1,0 +1,42 @@
+## neofs-cli container set-eacl
+
+Set new extended ACL table for container
+
+### Synopsis
+
+Set new extended ACL table for container.
+Container ID in EACL table will be substituted with ID from the CLI.
+
+```
+neofs-cli container set-eacl [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --await                 block execution until EACL is persisted. Increases default execution timeout to 60s
+      --cid string            Container ID.
+  -f, --force                 skip validation checks (ownership, extensibility of the container ACL)
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for set-eacl
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the container SETEACL session
+      --table string          path to file with JSON or binary encoded EACL table
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli container](neofs-cli_container.md)	 - Operations with containers
+

--- a/docs/cli-commands/neofs-cli_control.md
+++ b/docs/cli-commands/neofs-cli_control.md
@@ -1,0 +1,31 @@
+## neofs-cli control
+
+Operations with storage node
+
+### Synopsis
+
+Operations with storage node
+
+### Options
+
+```
+  -h, --help   help for control
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli control drop-objects](neofs-cli_control_drop-objects.md)	 - Drop objects from the node's local storage
+* [neofs-cli control healthcheck](neofs-cli_control_healthcheck.md)	 - Health check of the NeoFS node
+* [neofs-cli control object](neofs-cli_control_object.md)	 - Direct object operations with storage engine
+* [neofs-cli control set-status](neofs-cli_control_set-status.md)	 - Set status of the storage node in NeoFS network map
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+* [neofs-cli control synchronize-tree](neofs-cli_control_synchronize-tree.md)	 - Synchronize log for the tree
+

--- a/docs/cli-commands/neofs-cli_control_drop-objects.md
+++ b/docs/cli-commands/neofs-cli_control_drop-objects.md
@@ -1,0 +1,34 @@
+## neofs-cli control drop-objects
+
+Drop objects from the node's local storage
+
+### Synopsis
+
+Drop objects from the node's local storage
+
+```
+neofs-cli control drop-objects [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for drop-objects
+  -o, --objects strings    List of object addresses to be removed in string format
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+

--- a/docs/cli-commands/neofs-cli_control_healthcheck.md
+++ b/docs/cli-commands/neofs-cli_control_healthcheck.md
@@ -1,0 +1,34 @@
+## neofs-cli control healthcheck
+
+Health check of the NeoFS node
+
+### Synopsis
+
+Health check of the NeoFS node. Checks storage node by default, use --ir flag to work with Inner Ring.
+
+```
+neofs-cli control healthcheck [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for healthcheck
+      --ir                 Communicate with IR node
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+

--- a/docs/cli-commands/neofs-cli_control_object.md
+++ b/docs/cli-commands/neofs-cli_control_object.md
@@ -1,0 +1,24 @@
+## neofs-cli control object
+
+Direct object operations with storage engine
+
+### Options
+
+```
+  -h, --help   help for object
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+* [neofs-cli control object list](neofs-cli_control_object_list.md)	 - Get list of all objects in the storage node
+* [neofs-cli control object revive](neofs-cli_control_object_revive.md)	 - Forcefully revive object
+* [neofs-cli control object status](neofs-cli_control_object_status.md)	 - Check current object status
+

--- a/docs/cli-commands/neofs-cli_control_object_list.md
+++ b/docs/cli-commands/neofs-cli_control_object_list.md
@@ -1,0 +1,33 @@
+## neofs-cli control object list
+
+Get list of all objects in the storage node
+
+### Synopsis
+
+Get list of all objects in the storage node
+
+```
+neofs-cli control object list [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for list
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control object](neofs-cli_control_object.md)	 - Direct object operations with storage engine
+

--- a/docs/cli-commands/neofs-cli_control_object_revive.md
+++ b/docs/cli-commands/neofs-cli_control_object_revive.md
@@ -1,0 +1,34 @@
+## neofs-cli control object revive
+
+Forcefully revive object
+
+### Synopsis
+
+Purge removal marks from metabases
+
+```
+neofs-cli control object revive [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for revive
+      --object string      Object address
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control object](neofs-cli_control_object.md)	 - Direct object operations with storage engine
+

--- a/docs/cli-commands/neofs-cli_control_object_status.md
+++ b/docs/cli-commands/neofs-cli_control_object_status.md
@@ -1,0 +1,30 @@
+## neofs-cli control object status
+
+Check current object status
+
+```
+neofs-cli control object status [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for status
+      --object string      Object address
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control object](neofs-cli_control_object.md)	 - Direct object operations with storage engine
+

--- a/docs/cli-commands/neofs-cli_control_set-status.md
+++ b/docs/cli-commands/neofs-cli_control_set-status.md
@@ -1,0 +1,35 @@
+## neofs-cli control set-status
+
+Set status of the storage node in NeoFS network map
+
+### Synopsis
+
+Set status of the storage node in NeoFS network map
+
+```
+neofs-cli control set-status [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -f, --force              Force turning to local maintenance
+  -h, --help               help for set-status
+      --status string      New netmap status keyword ('online', 'offline', 'maintenance')
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+

--- a/docs/cli-commands/neofs-cli_control_shards.md
+++ b/docs/cli-commands/neofs-cli_control_shards.md
@@ -1,0 +1,31 @@
+## neofs-cli control shards
+
+Operations with storage node's shards
+
+### Synopsis
+
+Operations with storage node's shards
+
+### Options
+
+```
+  -h, --help   help for shards
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+* [neofs-cli control shards dump](neofs-cli_control_shards_dump.md)	 - Dump objects from shard
+* [neofs-cli control shards evacuate](neofs-cli_control_shards_evacuate.md)	 - Evacuate objects from shard
+* [neofs-cli control shards flush-cache](neofs-cli_control_shards_flush-cache.md)	 - Flush objects from the write-cache to the main storage
+* [neofs-cli control shards list](neofs-cli_control_shards_list.md)	 - List shards of the storage node
+* [neofs-cli control shards restore](neofs-cli_control_shards_restore.md)	 - Restore objects from shard
+* [neofs-cli control shards set-mode](neofs-cli_control_shards_set-mode.md)	 - Set work mode of the shard
+

--- a/docs/cli-commands/neofs-cli_control_shards_dump.md
+++ b/docs/cli-commands/neofs-cli_control_shards_dump.md
@@ -1,0 +1,36 @@
+## neofs-cli control shards dump
+
+Dump objects from shard
+
+### Synopsis
+
+Dump objects from shard to a file
+
+```
+neofs-cli control shards dump [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for dump
+      --id string          Shard ID in base58 encoding
+      --no-errors          Skip invalid/unreadable objects
+      --path string        File to write objects to
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_shards_evacuate.md
+++ b/docs/cli-commands/neofs-cli_control_shards_evacuate.md
@@ -1,0 +1,36 @@
+## neofs-cli control shards evacuate
+
+Evacuate objects from shard
+
+### Synopsis
+
+Evacuate objects from shard to other shards
+
+```
+neofs-cli control shards evacuate [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --all                Process all shards
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for evacuate
+      --id strings         List of shard IDs in base58 encoding
+      --no-errors          Skip invalid/unreadable objects
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_shards_flush-cache.md
+++ b/docs/cli-commands/neofs-cli_control_shards_flush-cache.md
@@ -1,0 +1,35 @@
+## neofs-cli control shards flush-cache
+
+Flush objects from the write-cache to the main storage
+
+### Synopsis
+
+Flush objects from the write-cache to the main storage
+
+```
+neofs-cli control shards flush-cache [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --all                Process all shards
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for flush-cache
+      --id strings         List of shard IDs in base58 encoding
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_shards_list.md
+++ b/docs/cli-commands/neofs-cli_control_shards_list.md
@@ -1,0 +1,34 @@
+## neofs-cli control shards list
+
+List shards of the storage node
+
+### Synopsis
+
+List shards of the storage node
+
+```
+neofs-cli control shards list [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for list
+      --json               Print shard info as a JSON array
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_shards_restore.md
+++ b/docs/cli-commands/neofs-cli_control_shards_restore.md
@@ -1,0 +1,36 @@
+## neofs-cli control shards restore
+
+Restore objects from shard
+
+### Synopsis
+
+Restore objects from shard to a file
+
+```
+neofs-cli control shards restore [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for restore
+      --id string          Shard ID in base58 encoding
+      --no-errors          Skip invalid/unreadable objects
+      --path string        File to read objects from
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_shards_set-mode.md
+++ b/docs/cli-commands/neofs-cli_control_shards_set-mode.md
@@ -1,0 +1,37 @@
+## neofs-cli control shards set-mode
+
+Set work mode of the shard
+
+### Synopsis
+
+Set work mode of the shard
+
+```
+neofs-cli control shards set-mode [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --all                Process all shards
+      --clear-errors       Set shard error count to 0
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+  -h, --help               help for set-mode
+      --id strings         List of shard IDs in base58 encoding
+      --mode string        New shard mode ('degraded-read-only', 'read-only', 'read-write')
+  -t, --timeout duration   Timeout for the operation (default 15s)
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control shards](neofs-cli_control_shards.md)	 - Operations with storage node's shards
+

--- a/docs/cli-commands/neofs-cli_control_synchronize-tree.md
+++ b/docs/cli-commands/neofs-cli_control_synchronize-tree.md
@@ -1,0 +1,36 @@
+## neofs-cli control synchronize-tree
+
+Synchronize log for the tree
+
+### Synopsis
+
+Synchronize log for the tree in an object tree service.
+
+```
+neofs-cli control synchronize-tree [flags]
+```
+
+### Options
+
+```
+      --address string     Address of wallet account
+      --cid string         Container ID.
+      --endpoint string    Remote node control address (as 'multiaddr' or '<host>:<port>')
+      --height uint        Starting height
+  -h, --help               help for synchronize-tree
+  -t, --timeout duration   Timeout for the operation (default 15s)
+      --tree-id string     Tree ID
+  -w, --wallet string      Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli control](neofs-cli_control.md)	 - Operations with storage node
+

--- a/docs/cli-commands/neofs-cli_gendoc.md
+++ b/docs/cli-commands/neofs-cli_gendoc.md
@@ -1,0 +1,44 @@
+## neofs-cli gendoc
+
+Generate documentation for this command
+
+### Synopsis
+
+Generate documentation for this command. If the template is not provided,
+builtin cobra generator is used and each subcommand is placed in
+a separate file in the same directory.
+
+The last optional argument specifies the template to use with text/template.
+In this case there is a number of helper functions which can be used:
+  replace STR FROM TO -- same as strings.ReplaceAll
+  join ARRAY SEPARATOR -- same as strings.Join
+  split STR SEPARATOR -- same as strings.Split
+  fullUse CMD -- slice of all command names starting from the parent
+  listFlags CMD -- list of command flags
+
+
+```
+neofs-cli gendoc <dir> [flags]
+```
+
+### Options
+
+```
+      --depth int              If template is specified, unify all commands starting from depth in a single file. Default: 1. (default 1)
+  -d, --disable-auto-gen-tag   Defines if gen tag of cobra will be printed.
+  -e, --extension string       If the template is specified, string to append to the output file names
+  -h, --help                   help for gendoc
+  -t, --type string            Type for the documentation ('md' or 'man') (default "md")
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+

--- a/docs/cli-commands/neofs-cli_netmap.md
+++ b/docs/cli-commands/neofs-cli_netmap.md
@@ -1,0 +1,29 @@
+## neofs-cli netmap
+
+Operations with Network Map
+
+### Synopsis
+
+Operations with Network Map
+
+### Options
+
+```
+  -h, --help   help for netmap
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli netmap epoch](neofs-cli_netmap_epoch.md)	 - Get current epoch number
+* [neofs-cli netmap netinfo](neofs-cli_netmap_netinfo.md)	 - Get information about NeoFS network
+* [neofs-cli netmap nodeinfo](neofs-cli_netmap_nodeinfo.md)	 - Get target node info
+* [neofs-cli netmap snapshot](neofs-cli_netmap_snapshot.md)	 - Request current local snapshot of the network map
+

--- a/docs/cli-commands/neofs-cli_netmap_epoch.md
+++ b/docs/cli-commands/neofs-cli_netmap_epoch.md
@@ -1,0 +1,36 @@
+## neofs-cli netmap epoch
+
+Get current epoch number
+
+### Synopsis
+
+Get current epoch number
+
+```
+neofs-cli netmap epoch [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for epoch
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli netmap](neofs-cli_netmap.md)	 - Operations with Network Map
+

--- a/docs/cli-commands/neofs-cli_netmap_netinfo.md
+++ b/docs/cli-commands/neofs-cli_netmap_netinfo.md
@@ -1,0 +1,37 @@
+## neofs-cli netmap netinfo
+
+Get information about NeoFS network
+
+### Synopsis
+
+Get information about NeoFS network.
+		Unknown configuration settings are displayed in hexadecimal format.
+
+```
+neofs-cli netmap netinfo [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for netinfo
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli netmap](neofs-cli_netmap.md)	 - Operations with Network Map
+

--- a/docs/cli-commands/neofs-cli_netmap_nodeinfo.md
+++ b/docs/cli-commands/neofs-cli_netmap_nodeinfo.md
@@ -1,0 +1,37 @@
+## neofs-cli netmap nodeinfo
+
+Get target node info
+
+### Synopsis
+
+Get target node info
+
+```
+neofs-cli netmap nodeinfo [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for nodeinfo
+      --json                  Print node info in JSON format
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli netmap](neofs-cli_netmap.md)	 - Operations with Network Map
+

--- a/docs/cli-commands/neofs-cli_netmap_snapshot.md
+++ b/docs/cli-commands/neofs-cli_netmap_snapshot.md
@@ -1,0 +1,36 @@
+## neofs-cli netmap snapshot
+
+Request current local snapshot of the network map
+
+### Synopsis
+
+Request current local snapshot of the network map
+
+```
+neofs-cli netmap snapshot [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for snapshot
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli netmap](neofs-cli_netmap.md)	 - Operations with Network Map
+

--- a/docs/cli-commands/neofs-cli_object.md
+++ b/docs/cli-commands/neofs-cli_object.md
@@ -1,0 +1,34 @@
+## neofs-cli object
+
+Operations with Objects
+
+### Synopsis
+
+Operations with Objects
+
+### Options
+
+```
+  -h, --help   help for object
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli object delete](neofs-cli_object_delete.md)	 - Delete object from NeoFS
+* [neofs-cli object get](neofs-cli_object_get.md)	 - Get object from NeoFS
+* [neofs-cli object hash](neofs-cli_object_hash.md)	 - Get object hash
+* [neofs-cli object head](neofs-cli_object_head.md)	 - Get object header
+* [neofs-cli object lock](neofs-cli_object_lock.md)	 - Lock object in container
+* [neofs-cli object nodes](neofs-cli_object_nodes.md)	 - Show nodes for an object
+* [neofs-cli object put](neofs-cli_object_put.md)	 - Put object to NeoFS
+* [neofs-cli object range](neofs-cli_object_range.md)	 - Get payload range data of an object
+* [neofs-cli object search](neofs-cli_object_search.md)	 - Search object
+

--- a/docs/cli-commands/neofs-cli_object_delete.md
+++ b/docs/cli-commands/neofs-cli_object_delete.md
@@ -1,0 +1,42 @@
+## neofs-cli object delete
+
+Delete object from NeoFS
+
+### Synopsis
+
+Delete object from NeoFS
+
+```
+neofs-cli object delete [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --binary                Deserialize object structure from given file.
+      --cid string            Container ID.
+      --file string           File with object payload
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for delete
+      --oid strings           Object ID.
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object DELETE session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_get.md
+++ b/docs/cli-commands/neofs-cli_object_get.md
@@ -1,0 +1,44 @@
+## neofs-cli object get
+
+Get object from NeoFS
+
+### Synopsis
+
+Get object from NeoFS
+
+```
+neofs-cli object get [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --binary                Serialize whole object structure into given file(id + signature + header + payload).
+      --cid string            Container ID.
+      --file string           File to write object payload to(with -b together with signature and header). Default: stdout.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for get
+      --no-progress           Do not show progress bar
+      --oid string            Object ID.
+      --raw                   Set raw request option
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object GET session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_hash.md
+++ b/docs/cli-commands/neofs-cli_object_hash.md
@@ -1,0 +1,43 @@
+## neofs-cli object hash
+
+Get object hash
+
+### Synopsis
+
+Get object hash
+
+```
+neofs-cli object hash [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for hash
+      --oid string            Object ID.
+      --range string          Range to take hash from in the form offset1:length1,... Full object payload length if not specified
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --salt string           Salt in hex format
+      --session string        Filepath to a JSON- or binary-encoded token of the object RANGEHASH session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+      --type string           Hash type. Either 'sha256' or 'tz' (default "sha256")
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_head.md
+++ b/docs/cli-commands/neofs-cli_object_head.md
@@ -1,0 +1,45 @@
+## neofs-cli object head
+
+Get object header
+
+### Synopsis
+
+Get object header
+
+```
+neofs-cli object head [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+      --file string           File to write header to. Default: stdout.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for head
+      --json                  Marshal output in JSON
+      --main-only             Return only main fields
+      --oid string            Object ID.
+      --proto                 Marshal output in Protobuf
+      --raw                   Set raw request option
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object HEAD session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_lock.md
+++ b/docs/cli-commands/neofs-cli_object_lock.md
@@ -1,0 +1,42 @@
+## neofs-cli object lock
+
+Lock object in container
+
+### Synopsis
+
+Lock object in container
+
+```
+neofs-cli object lock [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -e, --expire-at uint        The last active epoch for the lock
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for lock
+      --lifetime uint         Lock lifetime
+      --oid strings           Object ID.
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object PUT session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_nodes.md
+++ b/docs/cli-commands/neofs-cli_object_nodes.md
@@ -1,0 +1,34 @@
+## neofs-cli object nodes
+
+Show nodes for an object
+
+### Synopsis
+
+Show nodes taking part in an object placement at the current epoch.
+
+```
+neofs-cli object nodes [flags]
+```
+
+### Options
+
+```
+      --cid string            Container ID.
+  -h, --help                  help for nodes
+      --oid string            Object ID.
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --short                 Short node output info
+  -t, --timeout duration      Timeout for the operation (default 15s)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_put.md
+++ b/docs/cli-commands/neofs-cli_object_put.md
@@ -1,0 +1,47 @@
+## neofs-cli object put
+
+Put object to NeoFS
+
+### Synopsis
+
+Put object to NeoFS
+
+```
+neofs-cli object put [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --attributes strings    User attributes in form of Key1=Value1,Key2=Value2
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --binary                Deserialize object structure from given file.
+      --cid string            Container ID.
+      --disable-filename      Do not set well-known filename attribute
+      --disable-timestamp     Do not set well-known timestamp attribute
+  -e, --expire-at uint        The last active epoch in the life of the object
+      --file string           File with object payload
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for put
+  -l, --lifetime uint         Number of epochs for object to stay valid
+      --no-progress           Do not show progress bar
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object PUT session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_range.md
+++ b/docs/cli-commands/neofs-cli_object_range.md
@@ -1,0 +1,43 @@
+## neofs-cli object range
+
+Get payload range data of an object
+
+### Synopsis
+
+Get payload range data of an object
+
+```
+neofs-cli object range [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+      --file string           File to write object payload to. Default: stdout.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for range
+      --oid string            Object ID.
+      --range string          Range to take data from in the form offset:length
+      --raw                   Set raw request option
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object RANGE session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_object_search.md
+++ b/docs/cli-commands/neofs-cli_object_search.md
@@ -1,0 +1,43 @@
+## neofs-cli object search
+
+Search object
+
+### Synopsis
+
+Search object
+
+```
+neofs-cli object search [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -f, --filters strings       Repeated filter expressions or files with protobuf JSON
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for search
+      --oid string            Search object by identifier
+      --phy                   Search physically stored objects
+      --root                  Search for user objects
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --session string        Filepath to a JSON- or binary-encoded token of the object SEARCH session
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli object](neofs-cli_object.md)	 - Operations with Objects
+

--- a/docs/cli-commands/neofs-cli_session.md
+++ b/docs/cli-commands/neofs-cli_session.md
@@ -1,0 +1,22 @@
+## neofs-cli session
+
+Operations with session token
+
+### Options
+
+```
+  -h, --help   help for session
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli session create](neofs-cli_session_create.md)	 - Create session token
+

--- a/docs/cli-commands/neofs-cli_session_create.md
+++ b/docs/cli-commands/neofs-cli_session_create.md
@@ -1,0 +1,40 @@
+## neofs-cli session create
+
+Create session token
+
+### Synopsis
+
+Create session token.
+
+Default lifetime of session token is 10 epochs 
+if none of --expire-at or --lifetime flags is specified. 
+
+
+```
+neofs-cli session create [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+  -e, --expire-at uint        The last active epoch for token to stay valid
+  -h, --help                  help for create
+      --json                  Output token in JSON
+  -l, --lifetime uint         Number of epochs for token to stay valid (default 10)
+      --out string            File to write session token to
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli session](neofs-cli_session.md)	 - Operations with session token
+

--- a/docs/cli-commands/neofs-cli_storagegroup.md
+++ b/docs/cli-commands/neofs-cli_storagegroup.md
@@ -1,0 +1,29 @@
+## neofs-cli storagegroup
+
+Operations with Storage Groups
+
+### Synopsis
+
+Operations with Storage Groups
+
+### Options
+
+```
+  -h, --help   help for storagegroup
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli storagegroup delete](neofs-cli_storagegroup_delete.md)	 - Delete storage group from NeoFS
+* [neofs-cli storagegroup get](neofs-cli_storagegroup_get.md)	 - Get storage group from NeoFS
+* [neofs-cli storagegroup list](neofs-cli_storagegroup_list.md)	 - List storage groups in NeoFS container
+* [neofs-cli storagegroup put](neofs-cli_storagegroup_put.md)	 - Put storage group to NeoFS
+

--- a/docs/cli-commands/neofs-cli_storagegroup_delete.md
+++ b/docs/cli-commands/neofs-cli_storagegroup_delete.md
@@ -1,0 +1,39 @@
+## neofs-cli storagegroup delete
+
+Delete storage group from NeoFS
+
+### Synopsis
+
+Delete storage group from NeoFS
+
+```
+neofs-cli storagegroup delete [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for delete
+      --id string             Storage group identifier
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli storagegroup](neofs-cli_storagegroup.md)	 - Operations with Storage Groups
+

--- a/docs/cli-commands/neofs-cli_storagegroup_get.md
+++ b/docs/cli-commands/neofs-cli_storagegroup_get.md
@@ -1,0 +1,40 @@
+## neofs-cli storagegroup get
+
+Get storage group from NeoFS
+
+### Synopsis
+
+Get storage group from NeoFS
+
+```
+neofs-cli storagegroup get [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for get
+      --id string             Storage group identifier
+      --raw                   Set raw request option
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli storagegroup](neofs-cli_storagegroup.md)	 - Operations with Storage Groups
+

--- a/docs/cli-commands/neofs-cli_storagegroup_list.md
+++ b/docs/cli-commands/neofs-cli_storagegroup_list.md
@@ -1,0 +1,38 @@
+## neofs-cli storagegroup list
+
+List storage groups in NeoFS container
+
+### Synopsis
+
+List storage groups in NeoFS container
+
+```
+neofs-cli storagegroup list [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for list
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli storagegroup](neofs-cli_storagegroup.md)	 - Operations with Storage Groups
+

--- a/docs/cli-commands/neofs-cli_storagegroup_put.md
+++ b/docs/cli-commands/neofs-cli_storagegroup_put.md
@@ -1,0 +1,41 @@
+## neofs-cli storagegroup put
+
+Put storage group to NeoFS
+
+### Synopsis
+
+Put storage group to NeoFS
+
+```
+neofs-cli storagegroup put [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --bearer string         File with signed JSON or binary encoded bearer token
+      --cid string            Container ID.
+  -e, --expire-at uint        The last active epoch of the storage group
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for put
+      --lifetime uint         Storage group lifetime in epochs
+  -m, --members strings       ID list of storage group members
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+      --ttl uint32            TTL value in request meta header (default 2)
+  -w, --wallet string         Path to the wallet
+  -x, --xhdr strings          Request X-Headers in form of Key=Value
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli storagegroup](neofs-cli_storagegroup.md)	 - Operations with Storage Groups
+

--- a/docs/cli-commands/neofs-cli_tree.md
+++ b/docs/cli-commands/neofs-cli_tree.md
@@ -1,0 +1,25 @@
+## neofs-cli tree
+
+Operations with the Tree service
+
+### Options
+
+```
+  -h, --help   help for tree
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli tree add](neofs-cli_tree_add.md)	 - Add a node to the tree service
+* [neofs-cli tree add-by-path](neofs-cli_tree_add-by-path.md)	 - Add a node by the path
+* [neofs-cli tree get-by-path](neofs-cli_tree_get-by-path.md)	 - Get a node by its path
+* [neofs-cli tree list](neofs-cli_tree_list.md)	 - Get tree IDs
+

--- a/docs/cli-commands/neofs-cli_tree_add-by-path.md
+++ b/docs/cli-commands/neofs-cli_tree_add-by-path.md
@@ -1,0 +1,34 @@
+## neofs-cli tree add-by-path
+
+Add a node by the path
+
+```
+neofs-cli tree add-by-path [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for add-by-path
+      --meta strings          Meta pairs in the form of Key1=[0x]Value1,Key2=[0x]Value2
+      --path string           Path to a node
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --tid string            Tree ID
+  -t, --timeout duration      Timeout for the operation (default 15s)
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli tree](neofs-cli_tree.md)	 - Operations with the Tree service
+

--- a/docs/cli-commands/neofs-cli_tree_add.md
+++ b/docs/cli-commands/neofs-cli_tree_add.md
@@ -1,0 +1,34 @@
+## neofs-cli tree add
+
+Add a node to the tree service
+
+```
+neofs-cli tree add [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for add
+      --meta strings          Meta pairs in the form of Key1=[0x]Value1,Key2=[0x]Value2
+      --pid uint              Parent node ID
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --tid string            Tree ID
+  -t, --timeout duration      Timeout for the operation (default 15s)
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli tree](neofs-cli_tree.md)	 - Operations with the Tree service
+

--- a/docs/cli-commands/neofs-cli_tree_get-by-path.md
+++ b/docs/cli-commands/neofs-cli_tree_get-by-path.md
@@ -1,0 +1,34 @@
+## neofs-cli tree get-by-path
+
+Get a node by its path
+
+```
+neofs-cli tree get-by-path [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for get-by-path
+      --latest                Look only for the latest version of a node
+      --path string           Path to a node
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+      --tid string            Tree ID
+  -t, --timeout duration      Timeout for the operation (default 15s)
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli tree](neofs-cli_tree.md)	 - Operations with the Tree service
+

--- a/docs/cli-commands/neofs-cli_tree_list.md
+++ b/docs/cli-commands/neofs-cli_tree_list.md
@@ -1,0 +1,31 @@
+## neofs-cli tree list
+
+Get tree IDs
+
+```
+neofs-cli tree list [flags]
+```
+
+### Options
+
+```
+      --address string        Address of wallet account
+      --cid string            Container ID.
+  -g, --generate-key          Generate new private key
+  -h, --help                  help for list
+  -r, --rpc-endpoint string   Remote node address (as 'multiaddr' or '<host>:<port>')
+  -t, --timeout duration      Timeout for the operation (default 15s)
+  -w, --wallet string         Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli tree](neofs-cli_tree.md)	 - Operations with the Tree service
+

--- a/docs/cli-commands/neofs-cli_util.md
+++ b/docs/cli-commands/neofs-cli_util.md
@@ -1,0 +1,24 @@
+## neofs-cli util
+
+Utility operations
+
+### Options
+
+```
+  -h, --help   help for util
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli](neofs-cli.md)	 - Command Line Tool to work with NeoFS
+* [neofs-cli util convert](neofs-cli_util_convert.md)	 - Convert representation of NeoFS structures
+* [neofs-cli util keyer](neofs-cli_util_keyer.md)	 - Generate or print information about keys
+* [neofs-cli util sign](neofs-cli_util_sign.md)	 - Sign NeoFS structure
+

--- a/docs/cli-commands/neofs-cli_util_convert.md
+++ b/docs/cli-commands/neofs-cli_util_convert.md
@@ -1,0 +1,22 @@
+## neofs-cli util convert
+
+Convert representation of NeoFS structures
+
+### Options
+
+```
+  -h, --help   help for convert
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util](neofs-cli_util.md)	 - Utility operations
+* [neofs-cli util convert eacl](neofs-cli_util_convert_eacl.md)	 - Convert representation of extended ACL table
+

--- a/docs/cli-commands/neofs-cli_util_convert_eacl.md
+++ b/docs/cli-commands/neofs-cli_util_convert_eacl.md
@@ -1,0 +1,28 @@
+## neofs-cli util convert eacl
+
+Convert representation of extended ACL table
+
+```
+neofs-cli util convert eacl [flags]
+```
+
+### Options
+
+```
+      --from string   File with JSON or binary encoded extended ACL table
+  -h, --help          help for eacl
+      --json          Dump extended ACL table in JSON encoding
+      --to string     File to dump extended ACL table (default: binary encoded)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util convert](neofs-cli_util_convert.md)	 - Convert representation of NeoFS structures
+

--- a/docs/cli-commands/neofs-cli_util_keyer.md
+++ b/docs/cli-commands/neofs-cli_util_keyer.md
@@ -1,0 +1,29 @@
+## neofs-cli util keyer
+
+Generate or print information about keys
+
+```
+neofs-cli util keyer [flags]
+```
+
+### Options
+
+```
+  -g, --generate       Generate new private key
+  -h, --help           help for keyer
+      --hex            Print all values in hex encoding
+  -m, --multisig       Calculate multisig address from public keys
+  -u, --uncompressed   Use uncompressed public key format
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util](neofs-cli_util.md)	 - Utility operations
+

--- a/docs/cli-commands/neofs-cli_util_sign.md
+++ b/docs/cli-commands/neofs-cli_util_sign.md
@@ -1,0 +1,23 @@
+## neofs-cli util sign
+
+Sign NeoFS structure
+
+### Options
+
+```
+  -h, --help   help for sign
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util](neofs-cli_util.md)	 - Utility operations
+* [neofs-cli util sign bearer-token](neofs-cli_util_sign_bearer-token.md)	 - Sign bearer token to use it in requests
+* [neofs-cli util sign session-token](neofs-cli_util_sign_session-token.md)	 - Sign session token to use it in requests
+

--- a/docs/cli-commands/neofs-cli_util_sign_bearer-token.md
+++ b/docs/cli-commands/neofs-cli_util_sign_bearer-token.md
@@ -1,0 +1,31 @@
+## neofs-cli util sign bearer-token
+
+Sign bearer token to use it in requests
+
+```
+neofs-cli util sign bearer-token [flags]
+```
+
+### Options
+
+```
+      --address string   Address of wallet account
+      --from string      File with JSON or binary encoded bearer token to sign
+  -g, --generate-key     Generate new private key
+  -h, --help             help for bearer-token
+      --json             Dump bearer token in JSON encoding
+      --to string        File to dump signed bearer token (default: binary encoded)
+  -w, --wallet string    Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util sign](neofs-cli_util_sign.md)	 - Sign NeoFS structure
+

--- a/docs/cli-commands/neofs-cli_util_sign_session-token.md
+++ b/docs/cli-commands/neofs-cli_util_sign_session-token.md
@@ -1,0 +1,31 @@
+## neofs-cli util sign session-token
+
+Sign session token to use it in requests
+
+```
+neofs-cli util sign session-token [flags]
+```
+
+### Options
+
+```
+      --address string   Address of wallet account
+      --force-issuer     Set configured account as the session issuer even if it is already specified
+      --from string      File with JSON encoded session token to sign
+  -g, --generate-key     Generate new private key
+  -h, --help             help for session-token
+      --to string        File to save signed session token (optional)
+  -w, --wallet string    Path to the wallet
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string   Config file (default is $HOME/.config/neofs-cli/config.yaml)
+  -v, --verbose         Verbose output
+```
+
+### SEE ALSO
+
+* [neofs-cli util sign](neofs-cli_util_sign.md)	 - Sign NeoFS structure
+

--- a/pkg/util/gendoc/gendoc.go
+++ b/pkg/util/gendoc/gendoc.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	gendocTypeFlag = "type"
+	gendocDisableAutoGenTagFlag = "disable-auto-gen-tag"
+	gendocTypeFlag              = "type"
 
 	gendocMarkdown = "md"
 	gendocMan      = "man"
@@ -61,6 +62,7 @@ In this case there is a number of helper functions which can be used:
 			}
 
 			typ, _ := cmd.Flags().GetString(gendocTypeFlag)
+			rootCmd.DisableAutoGenTag, _ = cmd.Flags().GetBool(gendocDisableAutoGenTagFlag)
 			switch typ {
 			case gendocMarkdown:
 				return doc.GenMarkdownTree(rootCmd, args[0])
@@ -78,6 +80,7 @@ In this case there is a number of helper functions which can be used:
 
 	ff := gendocCmd.Flags()
 	ff.StringP(gendocTypeFlag, "t", gendocMarkdown, "Type for the documentation ('md' or 'man')")
+	ff.BoolP(gendocDisableAutoGenTagFlag, "d", false, "Defines if gen tag of cobra will be printed.")
 	ff.Int(depthFlag, 1, "If template is specified, unify all commands starting from depth in a single file. Default: 1.")
 	ff.StringP(extensionFlag, "e", "", "If the template is specified, string to append to the output file names")
 	return gendocCmd


### PR DESCRIPTION
Generate docs with `neofs-cli gendoc ./docs/cli-commands`.

Closes #1413.

So, if we add a new command, should we generate docs now? Should we also add some checks so that we don't forget to do this?