### PR TITLE
node: Fix false negative connection to FS chain in multi-endpoint setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Do not search for tombstones when handling their expiration, use local indexes instead (#2929)
 - Unathorized container ops accepted by the IR (#2947)
 - Structure table in the SN-configuration document (#2974)
+- False negative connection to NeoFS chain in multi-endpoint setup with at least one live node (#2986)
 
 ### Changed
 - `ObjectService`'s `Put` RPC handler caches up to 10K lists of per-object sorted container nodes (#2901)

--- a/pkg/morph/client/constructor.go
+++ b/pkg/morph/client/constructor.go
@@ -166,6 +166,7 @@ func New(key *keys.PrivateKey, opts ...Option) (*Client, error) {
 				cli.logger.Warn("Neo RPC connection failure", zap.String("endpoint", e), zap.Error(err))
 				continue
 			}
+			break
 		}
 
 		if err != nil {


### PR DESCRIPTION
Defect of 0d08b51afe772444a5bf280b2c6750bb1d001d48. Previously, node unconditionally visited all configured FS chain endpoints, and the result of the connection to the last address was final. In the case where the previous nodes (at least one) were available but the last one was not, a general init error occurred.

Now node breaks on first successful dial.

Fixes #2986.