### PR TITLE
metabase: drop almost all of Prm/Res structures

### DIFF
--- a/cmd/neofs-lens/internal/meta/list-garbage.go
+++ b/cmd/neofs-lens/internal/meta/list-garbage.go
@@ -27,14 +27,10 @@ func listGarbageFunc(cmd *cobra.Command, _ []string) error {
 	}
 	defer db.Close()
 
-	var garbPrm meta.GarbageIterationPrm
-	garbPrm.SetHandler(
-		func(garbageObject meta.GarbageObject) error {
-			cmd.Println(garbageObject.Address().EncodeToString())
-			return nil
-		})
-
-	err = db.IterateOverGarbage(garbPrm)
+	err = db.IterateOverGarbage(func(garbageObject meta.GarbageObject) error {
+		cmd.Println(garbageObject.Address().EncodeToString())
+		return nil
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("could not iterate over garbage bucket: %w", err)
 	}

--- a/cmd/neofs-lens/internal/meta/list-graveyard.go
+++ b/cmd/neofs-lens/internal/meta/list-graveyard.go
@@ -27,20 +27,16 @@ func listGraveyardFunc(cmd *cobra.Command, _ []string) error {
 	}
 	defer db.Close()
 
-	var gravePrm meta.GraveyardIterationPrm
-	gravePrm.SetHandler(
-		func(tsObj meta.TombstonedObject) error {
-			cmd.Printf(
-				"Object: %s\nTS: %s (TS expiration: %d)\n",
-				tsObj.Address().EncodeToString(),
-				tsObj.Tombstone().EncodeToString(),
-				tsObj.TombstoneExpiration(),
-			)
+	err = db.IterateOverGraveyard(func(tsObj meta.TombstonedObject) error {
+		cmd.Printf(
+			"Object: %s\nTS: %s (TS expiration: %d)\n",
+			tsObj.Address().EncodeToString(),
+			tsObj.Tombstone().EncodeToString(),
+			tsObj.TombstoneExpiration(),
+		)
 
-			return nil
-		})
-
-	err = db.IterateOverGraveyard(gravePrm)
+		return nil
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("could not iterate over graveyard bucket: %w", err)
 	}

--- a/cmd/neofs-lens/internal/meta/list.go
+++ b/cmd/neofs-lens/internal/meta/list.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/spf13/cobra"
 )
 
@@ -40,15 +39,12 @@ func listFunc(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("%s flag must be positive", limitFlagName)
 	}
 
-	var prm meta.ListPrm
-	prm.SetCount(vLimit)
-
-	res, err := db.ListWithCursor(prm)
+	addrs, _, err := db.ListWithCursor(int(vLimit), nil)
 	if err != nil {
 		return fmt.Errorf("metabase's `ListWithCursor`: %w", err)
 	}
 
-	for _, addressWithType := range res.AddressList() {
+	for _, addressWithType := range addrs {
 		cmd.Printf("%s, Type: %s\n", addressWithType.Address, addressWithType.Type)
 	}
 

--- a/cmd/neofs-lens/internal/meta/put.go
+++ b/cmd/neofs-lens/internal/meta/put.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/spf13/cobra"
 )
@@ -56,10 +55,7 @@ func writeObject(cmd *cobra.Command, _ []string) error {
 		return errors.New("missing container ID in object")
 	}
 
-	var pPrm meta.PutPrm
-	pPrm.SetObject(obj)
-
-	_, err = db.Put(pPrm)
+	err = db.Put(obj, nil, nil)
 	if err != nil {
 		return fmt.Errorf("can't put object: %w", err)
 	}

--- a/pkg/local_object_storage/metabase/control_test.go
+++ b/pkg/local_object_storage/metabase/control_test.go
@@ -51,12 +51,5 @@ func TestReset(t *testing.T) {
 }
 
 func metaExists(db *meta.DB, addr oid.Address) (bool, error) {
-	var existsPrm meta.ExistsPrm
-	existsPrm.SetAddress(addr)
-
-	res, err := db.Exists(existsPrm)
-	if err != nil {
-		return false, err
-	}
-	return res.Exists(), nil
+	return db.Exists(addr, false)
 }

--- a/pkg/local_object_storage/metabase/delete_test.go
+++ b/pkg/local_object_storage/metabase/delete_test.go
@@ -132,9 +132,6 @@ func TestExpiredObject(t *testing.T) {
 }
 
 func metaDelete(db *meta.DB, addrs ...oid.Address) error {
-	var deletePrm meta.DeletePrm
-	deletePrm.SetAddresses(addrs...)
-
-	_, err := db.Delete(deletePrm)
+	_, err := db.Delete(addrs)
 	return err
 }

--- a/pkg/local_object_storage/metabase/get_test.go
+++ b/pkg/local_object_storage/metabase/get_test.go
@@ -204,11 +204,9 @@ func benchmarkGet(b *testing.B, numOfObj int) {
 			var counter int
 
 			for pb.Next() {
-				var getPrm meta.GetPrm
-				getPrm.SetAddress(addrs[counter%len(addrs)])
 				counter++
 
-				_, err := db.Get(getPrm)
+				_, err := db.Get(addrs[counter%len(addrs)], false)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -224,10 +222,7 @@ func benchmarkGet(b *testing.B, numOfObj int) {
 	b.Run("serial", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := range b.N {
-			var getPrm meta.GetPrm
-			getPrm.SetAddress(addrs[i%len(addrs)])
-
-			_, err := db.Get(getPrm)
+			_, err := db.Get(addrs[i%len(addrs)], false)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -283,13 +278,5 @@ func TestDB_GetContainer(t *testing.T) {
 }
 
 func metaGet(db *meta.DB, addr oid.Address, raw bool) (*objectSDK.Object, error) {
-	var prm meta.GetPrm
-	prm.SetAddress(addr)
-	prm.SetRaw(raw)
-
-	res, err := db.Get(prm)
-	if err != nil {
-		return nil, err
-	}
-	return res.Header(), nil
+	return db.Get(addr, raw)
 }

--- a/pkg/local_object_storage/metabase/inhume_test.go
+++ b/pkg/local_object_storage/metabase/inhume_test.go
@@ -45,7 +45,6 @@ func TestInhumeTombOnTomb(t *testing.T) {
 		addr2     = oidtest.Address()
 		addr3     = oidtest.Address()
 		inhumePrm meta.InhumePrm
-		existsPrm meta.ExistsPrm
 	)
 
 	inhumePrm.SetAddresses(addr1)
@@ -55,10 +54,8 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	_, err = db.Inhume(inhumePrm)
 	require.NoError(t, err)
 
-	existsPrm.SetAddress(addr1)
-
 	// addr1 should become inhumed {addr1:addr2}
-	_, err = db.Exists(existsPrm)
+	_, err = db.Exists(addr1, false)
 	require.ErrorAs(t, err, new(apistatus.ObjectAlreadyRemoved))
 
 	inhumePrm.SetAddresses(addr3)
@@ -72,13 +69,11 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	// as a tomb-on-tomb; metabase should return ObjectNotFound
 	// NOT ObjectAlreadyRemoved since that record has been removed
 	// from graveyard but addr1 is still marked with GC
-	_, err = db.Exists(existsPrm)
+	_, err = db.Exists(addr1, false)
 	require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
 
-	existsPrm.SetAddress(addr3)
-
 	// addr3 should be inhumed {addr3: addr1}
-	_, err = db.Exists(existsPrm)
+	_, err = db.Exists(addr3, false)
 	require.ErrorAs(t, err, new(apistatus.ObjectAlreadyRemoved))
 
 	inhumePrm.SetAddresses(addr1)
@@ -88,12 +83,10 @@ func TestInhumeTombOnTomb(t *testing.T) {
 	_, err = db.Inhume(inhumePrm)
 	require.NoError(t, err)
 
-	existsPrm.SetAddress(addr1)
-
 	// record with addr1 key should not appear in graveyard
 	// (tomb can not be inhumed) but should be kept as object
 	// with GC mark
-	_, err = db.Exists(existsPrm)
+	_, err = db.Exists(addr1, false)
 	require.ErrorAs(t, err, new(apistatus.ObjectNotFound))
 }
 

--- a/pkg/local_object_storage/metabase/lock_test.go
+++ b/pkg/local_object_storage/metabase/lock_test.go
@@ -177,42 +177,32 @@ func TestDB_IsLocked(t *testing.T) {
 	// existing and locked objs
 
 	objs, _ := putAndLockObj(t, db, 5)
-	var prm meta.IsLockedPrm
 
 	for _, obj := range objs {
-		prm.SetAddress(objectcore.AddressOf(obj))
-
-		res, err := db.IsLocked(prm)
+		locked, err := db.IsLocked(objectcore.AddressOf(obj))
 		require.NoError(t, err)
 
-		require.True(t, res.Locked())
+		require.True(t, locked)
 	}
 
 	// some rand obj
 
-	prm.SetAddress(oidtest.Address())
-
-	res, err := db.IsLocked(prm)
+	locked, err := db.IsLocked(oidtest.Address())
 	require.NoError(t, err)
 
-	require.False(t, res.Locked())
+	require.False(t, locked)
 
 	// existing but not locked obj
 
 	obj := objecttest.Object()
 
-	var putPrm meta.PutPrm
-	putPrm.SetObject(&obj)
-
-	_, err = db.Put(putPrm)
+	err = db.Put(&obj, nil, nil)
 	require.NoError(t, err)
 
-	prm.SetAddress(objectcore.AddressOf(&obj))
-
-	res, err = db.IsLocked(prm)
+	locked, err = db.IsLocked(objectcore.AddressOf(&obj))
 	require.NoError(t, err)
 
-	require.False(t, res.Locked())
+	require.False(t, locked)
 }
 
 func TestDB_Lock_Expired(t *testing.T) {

--- a/pkg/local_object_storage/metabase/movable_test.go
+++ b/pkg/local_object_storage/metabase/movable_test.go
@@ -57,26 +57,13 @@ func TestDB_Movable(t *testing.T) {
 }
 
 func metaToMoveIt(db *meta.DB, addr oid.Address) error {
-	var toMovePrm meta.ToMoveItPrm
-	toMovePrm.SetAddress(addr)
-
-	_, err := db.ToMoveIt(toMovePrm)
-	return err
+	return db.ToMoveIt(addr)
 }
 
 func metaMovable(db *meta.DB) ([]oid.Address, error) {
-	r, err := db.Movable(meta.MovablePrm{})
-	if err != nil {
-		return nil, err
-	}
-
-	return r.AddressList(), nil
+	return db.Movable()
 }
 
 func metaDoNotMove(db *meta.DB, addr oid.Address) error {
-	var doNotMovePrm meta.DoNotMovePrm
-	doNotMovePrm.SetAddress(addr)
-
-	_, err := db.DoNotMove(doNotMovePrm)
-	return err
+	return db.DoNotMove(addr)
 }

--- a/pkg/local_object_storage/metabase/put_test.go
+++ b/pkg/local_object_storage/metabase/put_test.go
@@ -115,13 +115,7 @@ func TestDB_PutBlobovnicaUpdate(t *testing.T) {
 }
 
 func metaPut(db *meta.DB, obj *objectSDK.Object, id []byte) error {
-	var putPrm meta.PutPrm
-	putPrm.SetObject(obj)
-	putPrm.SetStorageID(id)
-
-	_, err := db.Put(putPrm)
-
-	return err
+	return db.Put(obj, id, nil)
 }
 
 func TestDB_PutBinary(t *testing.T) {
@@ -146,10 +140,7 @@ func TestDB_PutBinary(t *testing.T) {
 
 	db := newDB(t)
 
-	var putPrm meta.PutPrm
-	putPrm.SetObject(hdr)
-	putPrm.SetHeaderBinary(hdrBin)
-	_, err := db.Put(putPrm)
+	err := db.Put(hdr, nil, hdrBin)
 	require.NoError(t, err)
 
 	res, err := metaGet(db, addr, false)
@@ -159,9 +150,7 @@ func TestDB_PutBinary(t *testing.T) {
 	// now place some garbage
 	addr.SetObject(oidtest.ID())
 	hdr.SetID(addr.Object()) // to avoid 'already exists' outcome
-	putPrm.SetObject(hdr)
-	putPrm.SetHeaderBinary([]byte("definitely not an object"))
-	_, err = db.Put(putPrm)
+	err = db.Put(hdr, nil, []byte("definitely not an object"))
 	require.NoError(t, err)
 
 	_, err = metaGet(db, addr, false)

--- a/pkg/local_object_storage/metabase/select_test.go
+++ b/pkg/local_object_storage/metabase/select_test.go
@@ -874,31 +874,19 @@ func TestRemovedObjects(t *testing.T) {
 }
 
 func benchmarkSelect(b *testing.B, db *meta.DB, cid cidSDK.ID, fs objectSDK.SearchFilters, expected int) {
-	var prm meta.SelectPrm
-	prm.SetContainerID(cid)
-	prm.SetFilters(fs)
-
 	for range b.N {
-		res, err := db.Select(prm)
+		addrs, err := db.Select(cid, fs)
 		if err != nil {
 			b.Fatal(err)
 		}
-		if len(res.AddressList()) != expected {
-			b.Fatalf("expected %d items, got %d", expected, len(res.AddressList()))
+		if len(addrs) != expected {
+			b.Fatalf("expected %d items, got %d", expected, len(addrs))
 		}
 	}
 }
 
 func metaSelect(db *meta.DB, cnr cidSDK.ID, fs objectSDK.SearchFilters) ([]oid.Address, error) {
-	var prm meta.SelectPrm
-	prm.SetFilters(fs)
-	prm.SetContainerID(cnr)
-
-	res, err := db.Select(prm)
-	if err != nil {
-		return nil, err
-	}
-	return res.AddressList(), nil
+	return db.Select(cnr, fs)
 }
 
 func numQuery(key string, op objectSDK.SearchMatchType, val string) (res objectSDK.SearchFilters) {

--- a/pkg/local_object_storage/metabase/status.go
+++ b/pkg/local_object_storage/metabase/status.go
@@ -36,16 +36,14 @@ func (db *DB) ObjectStatus(address oid.Address) (ObjectStatus, error) {
 		return res, nil
 	}
 
-	storageID := StorageIDPrm{}
-	storageID.SetAddress(address)
-	resStorageID, err := db.StorageID(storageID)
+	resStorageID, err := db.StorageID(address)
 	if err != nil {
 		res.Error = fmt.Errorf("reading storage ID: %w", err)
 		return res, res.Error
 	}
 
-	if id := resStorageID.StorageID(); id != nil {
-		res.StorageID = string(id)
+	if resStorageID != nil {
+		res.StorageID = string(resStorageID)
 	}
 
 	err = db.boltDB.View(func(tx *bbolt.Tx) error {

--- a/pkg/local_object_storage/metabase/storage_id_test.go
+++ b/pkg/local_object_storage/metabase/storage_id_test.go
@@ -50,21 +50,9 @@ func TestDB_StorageID(t *testing.T) {
 }
 
 func metaUpdateStorageID(db *meta.DB, addr oid.Address, id []byte) error {
-	var sidPrm meta.UpdateStorageIDPrm
-	sidPrm.SetAddress(addr)
-	sidPrm.SetStorageID(id)
-
-	_, err := db.UpdateStorageID(sidPrm)
-	return err
+	return db.UpdateStorageID(addr, id)
 }
 
 func metaStorageID(db *meta.DB, addr oid.Address) ([]byte, error) {
-	var sidPrm meta.StorageIDPrm
-	sidPrm.SetAddress(addr)
-
-	r, err := db.StorageID(sidPrm)
-	if err != nil {
-		return nil, err
-	}
-	return r.StorageID(), nil
+	return db.StorageID(addr)
 }

--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -241,11 +241,7 @@ func (s *Shard) resyncObjectHandler(addr oid.Address, data []byte, descriptor []
 		}
 	}
 
-	var mPrm meta.PutPrm
-	mPrm.SetObject(obj)
-	mPrm.SetStorageID(descriptor)
-
-	_, err := s.metaBase.Put(mPrm)
+	err := s.metaBase.Put(obj, descriptor, nil)
 	if err != nil && !meta.IsErrRemoved(err) && !errors.Is(err, meta.ErrObjectIsExpired) {
 		return err
 	}

--- a/pkg/local_object_storage/shard/exists.go
+++ b/pkg/local_object_storage/shard/exists.go
@@ -2,7 +2,6 @@ package shard
 
 import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/common"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
@@ -57,18 +56,10 @@ func (s *Shard) Exists(prm ExistsPrm) (ExistsRes, error) {
 		}
 		exists = res.Exists
 	} else {
-		var existsPrm meta.ExistsPrm
-		existsPrm.SetAddress(prm.addr)
-		if prm.ignoreExpiration {
-			existsPrm.IgnoreExpiration()
-		}
-
-		var res meta.ExistsRes
-		res, err = s.metaBase.Exists(existsPrm)
+		exists, err = s.metaBase.Exists(prm.addr, prm.ignoreExpiration)
 		if err != nil {
 			return ExistsRes{}, err
 		}
-		exists = res.Exists()
 	}
 
 	return ExistsRes{

--- a/pkg/local_object_storage/shard/head.go
+++ b/pkg/local_object_storage/shard/head.go
@@ -1,7 +1,6 @@
 package shard
 
 import (
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
@@ -58,16 +57,10 @@ func (s *Shard) Head(prm HeadPrm) (HeadRes, error) {
 		}
 		obj = res.Object()
 	} else {
-		var headParams meta.GetPrm
-		headParams.SetAddress(prm.addr)
-		headParams.SetRaw(prm.raw)
-
-		var res meta.GetRes
-		res, err = s.metaBase.Get(headParams)
+		obj, err = s.metaBase.Get(prm.addr, prm.raw)
 		if err != nil {
 			return HeadRes{}, err
 		}
-		obj = res.Header()
 	}
 
 	return HeadRes{

--- a/pkg/local_object_storage/shard/lock.go
+++ b/pkg/local_object_storage/shard/lock.go
@@ -3,7 +3,6 @@ package shard
 import (
 	"fmt"
 
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
@@ -41,13 +40,5 @@ func (s *Shard) IsLocked(addr oid.Address) (bool, error) {
 		return false, ErrDegradedMode
 	}
 
-	var prm meta.IsLockedPrm
-	prm.SetAddress(addr)
-
-	res, err := s.metaBase.IsLocked(prm)
-	if err != nil {
-		return false, err
-	}
-
-	return res.Locked(), nil
+	return s.metaBase.IsLocked(addr)
 }

--- a/pkg/local_object_storage/shard/move.go
+++ b/pkg/local_object_storage/shard/move.go
@@ -1,7 +1,6 @@
 package shard
 
 import (
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"go.uber.org/zap"
 )
@@ -33,10 +32,7 @@ func (s *Shard) ToMoveIt(prm ToMoveItPrm) (ToMoveItRes, error) {
 		return ToMoveItRes{}, ErrDegradedMode
 	}
 
-	var toMovePrm meta.ToMoveItPrm
-	toMovePrm.SetAddress(prm.addr)
-
-	_, err := s.metaBase.ToMoveIt(toMovePrm)
+	err := s.metaBase.ToMoveIt(prm.addr)
 	if err != nil {
 		s.log.Debug("could not mark object for shard relocation in metabase",
 			zap.String("error", err.Error()),

--- a/pkg/local_object_storage/shard/put.go
+++ b/pkg/local_object_storage/shard/put.go
@@ -5,7 +5,6 @@ import (
 
 	objectCore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/common"
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"go.uber.org/zap"
 )
@@ -89,13 +88,11 @@ func (s *Shard) Put(prm PutPrm) (PutRes, error) {
 	}
 
 	if !m.NoMetabase() {
-		var pPrm meta.PutPrm
-		pPrm.SetObject(prm.obj)
+		var binHeader []byte
 		if prm.binSet {
-			pPrm.SetHeaderBinary(data[:prm.hdrLen])
+			binHeader = data[:prm.hdrLen]
 		}
-		pPrm.SetStorageID(res.StorageID)
-		if _, err := s.metaBase.Put(pPrm); err != nil {
+		if err := s.metaBase.Put(prm.obj, res.StorageID, binHeader); err != nil {
 			// may we need to handle this case in a special way
 			// since the object has been successfully written to BlobStor
 			return PutRes{}, fmt.Errorf("could not put object to metabase: %w", err)

--- a/pkg/local_object_storage/shard/select.go
+++ b/pkg/local_object_storage/shard/select.go
@@ -3,7 +3,6 @@ package shard
 import (
 	"fmt"
 
-	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
@@ -49,16 +48,12 @@ func (s *Shard) Select(prm SelectPrm) (SelectRes, error) {
 		return SelectRes{}, ErrDegradedMode
 	}
 
-	var selectPrm meta.SelectPrm
-	selectPrm.SetFilters(prm.filters)
-	selectPrm.SetContainerID(prm.cnr)
-
-	mRes, err := s.metaBase.Select(selectPrm)
+	addrs, err := s.metaBase.Select(prm.cnr, prm.filters)
 	if err != nil {
 		return SelectRes{}, fmt.Errorf("could not select objects from metabase: %w", err)
 	}
 
 	return SelectRes{
-		addrList: mRes.AddressList(),
+		addrList: addrs,
 	}, nil
 }

--- a/pkg/local_object_storage/writecache/flush_test.go
+++ b/pkg/local_object_storage/writecache/flush_test.go
@@ -55,15 +55,12 @@ func TestFlush(t *testing.T) {
 
 	check := func(t *testing.T, mb *meta.DB, bs *blobstor.BlobStor, objects []objectPair) {
 		for i := range objects {
-			var mPrm meta.StorageIDPrm
-			mPrm.SetAddress(objects[i].addr)
-
-			mRes, err := mb.StorageID(mPrm)
+			id, err := mb.StorageID(objects[i].addr)
 			require.NoError(t, err)
 
 			var prm common.GetPrm
 			prm.Address = objects[i].addr
-			prm.StorageID = mRes.StorageID()
+			prm.StorageID = id
 
 			res, err := bs.Get(prm)
 			require.NoError(t, err)
@@ -85,9 +82,7 @@ func TestFlush(t *testing.T) {
 		require.NoError(t, wc.Flush(false))
 
 		for i := range 2 {
-			var mPrm meta.GetPrm
-			mPrm.SetAddress(objects[i].addr)
-			_, err := mb.Get(mPrm)
+			_, err := mb.Get(objects[i].addr, false)
 			require.Error(t, err)
 
 			_, err = bs.Get(common.GetPrm{Address: objects[i].addr})
@@ -116,9 +111,7 @@ func TestFlush(t *testing.T) {
 		require.NoError(t, wc.SetMode(mode.Degraded))
 
 		for i := range 2 {
-			var mPrm meta.GetPrm
-			mPrm.SetAddress(objects[i].addr)
-			_, err := mb.Get(mPrm)
+			_, err := mb.Get(objects[i].addr, false)
 			require.Error(t, err)
 
 			_, err = bs.Get(common.GetPrm{Address: objects[i].addr})
@@ -216,9 +209,7 @@ func TestFlush(t *testing.T) {
 		require.NoError(t, mb.SetMode(mode.ReadWrite))
 
 		for i := range objects {
-			var prm meta.PutPrm
-			prm.SetObject(objects[i].obj)
-			_, err := mb.Put(prm)
+			err := mb.Put(objects[i].obj, nil, nil)
 			require.NoError(t, err)
 		}
 
@@ -228,9 +219,7 @@ func TestFlush(t *testing.T) {
 		_, err := mb.Inhume(inhumePrm)
 		require.NoError(t, err)
 
-		var deletePrm meta.DeletePrm
-		deletePrm.SetAddresses(objects[2].addr, objects[3].addr)
-		_, err = mb.Delete(deletePrm)
+		_, err = mb.Delete([]oid.Address{objects[2].addr, objects[3].addr})
 		require.NoError(t, err)
 
 		require.NoError(t, bs.SetMode(mode.ReadOnly))

--- a/pkg/local_object_storage/writecache/init.go
+++ b/pkg/local_object_storage/writecache/init.go
@@ -105,19 +105,13 @@ func (c *cache) initFlushMarks() {
 // First return value is true iff object exists.
 // Second return value is true iff object can be safely removed.
 func (c *cache) flushStatus(addr oid.Address) (bool, bool) {
-	var existsPrm meta.ExistsPrm
-	existsPrm.SetAddress(addr)
-
-	_, err := c.metabase.Exists(existsPrm)
+	_, err := c.metabase.Exists(addr, false)
 	if err != nil {
 		needRemove := errors.Is(err, meta.ErrObjectIsExpired) || errors.As(err, new(apistatus.ObjectAlreadyRemoved))
 		return needRemove, needRemove
 	}
 
-	var prm meta.StorageIDPrm
-	prm.SetAddress(addr)
-
-	mRes, _ := c.metabase.StorageID(prm)
-	res, err := c.blobstor.Exists(common.ExistsPrm{Address: addr, StorageID: mRes.StorageID()})
+	sid, _ := c.metabase.StorageID(addr)
+	res, err := c.blobstor.Exists(common.ExistsPrm{Address: addr, StorageID: sid})
 	return err == nil && res.Exists, false
 }


### PR DESCRIPTION
They:
 * are present in some methods and not in others
 * add substantial cognitive overhead for anyone looking
 * require more code to handle trivial things
 * can allocate more and more of microobjects creating GC pressure

Test wrappers in the same package perfectly suggest what everyone wanted to have in the first place. So this patch is a pure refactoring and doesn't change any behavior, but it drops almost all structures. "Almost" because there are cases where we pass a number of things (mostly as a result) and having some enclosing structure makes some sense there.