### PR TITLE
node: fix panic in error cases, fix #2970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Overriding the default container and object attributes only with the appropriate flags (#2985)
 - RPC client reconnection failures leading to complete SN failure (#2797)
 - `meta.DB.Open(readOnly)` moves metabase in RO mode (#3000)
+- Panic in event listener related to inability to switch RPC node (#2970)
 
 ### Changed
 - `ObjectService`'s `Put` RPC handler caches up to 10K lists of per-object sorted container nodes (#2901)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog for NeoFS Node
 - Expose health status of inner ring via Prometheus (#2934)
 - `neofs-cli control object list` command (#2853)
 - `node` config option `storage.ignore_uninited_shards` (#2953)
-- For `neofs-cli container create`, add `--global-name` flag, that sets name attribute as the value of `__NEOFS__NAME` 
+- For `neofs-cli container create`, add `--global-name` flag, that sets name attribute as the value of `__NEOFS__NAME`
 attribute, which is used for container domain name in NNS contracts (#2954)
 - Save last epoch when metabase was resynchronized (#2966)
 - `neofs-lens meta last-resync-epoch` command (#2966)
@@ -36,7 +36,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Use org-wide linter (#2943)
 - Timestamps are no longer produced in logs if not running with TTY (#2964)
 - In inner ring config, default ports for TCP addresses are used if they are missing (#2969)
-- Metabase is refilled if an object exists in write-cache but is missing in metabase (#2977) 
+- Metabase is refilled if an object exists in write-cache but is missing in metabase (#2977)
 - Pprof and metrics services stop at the end of SN's application lifecycle (#2976)
 - Reject configuration with unknown fields (#2981)
 

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -173,7 +173,6 @@ func wait(c *cfg) {
 	select {
 	case <-c.ctx.Done(): // graceful shutdown
 	case err := <-c.internalErr: // internal application error
-		close(c.internalErr)
 		c.ctxCancel()
 
 		c.log.Warn("internal application error",


### PR DESCRIPTION
internalErr has some buffer to accept multiple errors, but it only processes one of them, so if we have some cascading failures with multiple components reporting an error some of them will end up panicking because of closed channed. It's not very critical since the node is to die anyway, but it's nothing good either.

This particular case shouldn't really happen after #2996, but leaving this channel open is better than panic in case some other events lead to multiple sends to it.