### PR TITLE
Makefile: use `buildx` component to build images with BuildKit

### DIFF
--- a/.docker/Dockerfile.adm
+++ b/.docker/Dockerfile.adm
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.ir
+++ b/.docker/Dockerfile.ir
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.storage
+++ b/.docker/Dockerfile.storage
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/.docker/Dockerfile.storage-testnet
+++ b/.docker/Dockerfile.storage-testnet
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 ARG BUILD=now
 ARG VERSION=dev
 ARG REPO=repository

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ protoc:
 # Build NeoFS component's docker image
 image-%:
 	@echo "⇒ Build NeoFS $* docker image "
-	@docker build \
+	@docker buildx build \
 		--build-arg REPO=$(REPO) \
 		--build-arg VERSION=$(VERSION) \
 		--rm \


### PR DESCRIPTION
The GH workflow uses the [build-push-action](https://github.com/docker/build-push-action), where images are built with `buildx`. So I made it like this in our `Makefile`.
Also, fix warnings in Dockerfiles.

Closes #3006.