### PR TITLE
ir/node: disable log sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Metabase is refilled if an object exists in write-cache but is missing in metabase (#2977)
 - Pprof and metrics services stop at the end of SN's application lifecycle (#2976)
 - Reject configuration with unknown fields (#2981)
+- Log sampling is disabled by default now (#3011)
 
 ### Removed
 - Support for node.key configuration (#2959)

--- a/cmd/neofs-ir/main.go
+++ b/cmd/neofs-ir/main.go
@@ -66,6 +66,7 @@ func main() {
 	c := zap.NewProductionConfig()
 	c.Level = logLevel
 	c.Encoding = cfg.GetString("logger.encoding")
+	c.Sampling = nil
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		c.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	} else {

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -570,6 +570,7 @@ func initCfg(appCfg *config.Config) *cfg {
 	logCfg := zap.NewProductionConfig()
 	logCfg.Level = c.internals.logLevel
 	logCfg.Encoding = c.logger.encoding
+	logCfg.Sampling = nil
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	} else {


### PR DESCRIPTION
The default Zap config is:

> Sampling is enabled at 100:100 by default, meaning that after the first 100 log entries with the same level and message in the same second, it will log every 100th entry with the same level and message in the same second. You may disable this behavior by setting Sampling to nil.

It leads to message loss too easily and we care a lot about each and every object. Notice that it was disabled in NeoGo as well in a52e016c22de2269fcc7362f33317cebfa7e8e4c (https://github.com/nspcc-dev/neo-go/pull/598).