### PR TITLE
node: use version attribute setter from SDK

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -890,7 +890,7 @@ func (c *cfg) configWatcher(ctx context.Context) {
 func writeSystemAttributes(c *cfg) error {
 	// `Version` attribute
 
-	c.cfgNodeInfo.localInfo.SetAttribute("Version", misc.Version)
+	c.cfgNodeInfo.localInfo.SetVersion(misc.Version)
 
 	// `Capacity` attribute
 


### PR DESCRIPTION
It was unavailable at feature release time.