### PR TITLE
object/put: fix concurrent PUT data corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Panic in event listener related to inability to switch RPC node (#2970)
 - Non-container nodes never check placement policy on PUT, SEARCH requests (#3014)
 - If shards are overloaded with PUT requests, operation is not skipped but waits for 30 seconds (#2871)
+- Data corruption if PUT is done too concurrently (#2978)
 
 ### Changed
 - `ObjectService`'s `Put` RPC handler caches up to 10K lists of per-object sorted container nodes (#2901)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ attribute, which is used for container domain name in NNS contracts (#2954)
 - Log sampling is disabled by default now (#3011)
 - EACL is no longer considered for system role (#2972)
 - Deprecate peapod substorage (#3013)
+- Node does not stop trying to PUT an object if there are more PUT tasks than configured (#3027)
 
 ### Removed
 - Support for node.key configuration (#2959)

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -326,13 +326,8 @@ func (x placementIterator) iterateNodesForObject(obj oid.ID, f func(nodeDesc) er
 					}
 				}); err != nil {
 					wg.Done()
-					svcutil.LogWorkerPoolError(x.log, "PUT", err)
 					err = fmt.Errorf("submit next job to save an object to the worker pool: %w", err)
-					if e, _ := lastRespErr.Load().(error); e != nil {
-						err = fmt.Errorf("%w (last node error: %w)", err, e)
-					}
-					wg.Wait()
-					return errIncompletePut{singleErr: err}
+					svcutil.LogWorkerPoolError(x.log, "PUT", err)
 				}
 			}
 			wg.Wait()

--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -331,6 +331,7 @@ func (x placementIterator) iterateNodesForObject(obj oid.ID, f func(nodeDesc) er
 					if e, _ := lastRespErr.Load().(error); e != nil {
 						err = fmt.Errorf("%w (last node error: %w)", err, e)
 					}
+					wg.Wait()
 					return errIncompletePut{singleErr: err}
 				}
 			}


### PR DESCRIPTION
If ants pool is busy and cannot take task, early `return` without `wg.Wait()`
leads to `iterateNodesForObject`'s `return` and all the buffers for binary
replication from now may be reused while are still in use by the other routines
inside the pool. Wait for WG before any `return` is called. Closes https://github.com/nspcc-dev/neofs-node/issues/2978, https://github.com/nspcc-dev/neofs-node/issues/2988,
https://github.com/nspcc-dev/neofs-node/issues/2975, https://github.com/nspcc-dev/neofs-node/issues/2971.