### PR TITLE
node: add check for unmarshalling config to validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Fail gracefully on error from config validation (#3037)
 
 ### Changed
 

--- a/cmd/neofs-node/config/config.go
+++ b/cmd/neofs-node/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/internal"
@@ -58,7 +59,7 @@ func New(_ Prm, opts ...Option) *Config {
 	if o.validate {
 		err := validate.ValidateStruct(v)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed config validation: %v", err)
 		}
 	}
 


### PR DESCRIPTION
This is a check in case there is a ",remain" tag in the configuration field, and if there is an incorrect data format, then the value of the field was ignored, since then there will be a check to see if this field is correct or not. This makes some errors clearer after unmarshalling.

Closes #3034.

Actually, I don't like this fix. I want the attribute field to be a list.