### PR TITLE
ir: increase fschain pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 ### Changed
+- Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)
 
 ### Removed
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -1067,7 +1067,7 @@ func createListener(cli *client.Client, p chainParams) (event.Listener, error) {
 	// the client cannot make RPC requests if
 	// the notification channel is not being
 	// read by another goroutine.
-	const listenerPoolCap = 10
+	const listenerPoolCap = 300
 
 	listener, err := event.NewListener(event.ListenerParams{
 		Logger:             p.log.With(zap.String("chain", p.name)),


### PR DESCRIPTION
Similar to 19c72bfe0b5d322e4de8019df5c1431af35ca5f6, but for IR.

We've got

    neofs-ir[1394797]: warn        event/listener.go:248        listener worker pool drained        {"chain": "fschain", "capacity": 10}

in testnet.