### PR TITLE
ir: improve error messages during configuration validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - `neofs-cli object delete` command output (#3056)
+- Make the error message more clearer when validating IR configuration (#3072)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/cmd/neofs-ir/defaults.go
+++ b/cmd/neofs-ir/defaults.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -37,7 +38,7 @@ func newConfig(path string) (*viper.Viper, error) {
 
 	err = validate.ValidateStruct(v)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed config validation: %w", err)
 	}
 
 	return v, nil


### PR DESCRIPTION
Now it is clear that the error is related to reading the config.