### PR TITLE
morph: fix nil pointer dereferencing to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 ### Fixed
 - `neofs-cli object delete` command output (#3056)
 - Make the error message more clearer when validating IR configuration (#3072)
+- Panic during shutdown if N3 client connection is lost (#3073)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/pkg/morph/client/multi.go
+++ b/pkg/morph/client/multi.go
@@ -64,5 +64,7 @@ func (c *Client) closeWaiter() {
 	case <-c.closeChan:
 	}
 	var conn = c.conn.Swap(nil)
-	conn.Close()
+	if conn != nil {
+		conn.Close()
+	}
 }

--- a/pkg/morph/client/notifications.go
+++ b/pkg/morph/client/notifications.go
@@ -229,6 +229,9 @@ routeloop:
 		if conn == nil {
 			c.logger.Info("RPC connection lost, attempting reconnect")
 			conn = c.switchRPC()
+			if conn == nil {
+				break routeloop
+			}
 			go c.restoreSubscriptions(conn, restoreCh)
 		}
 		var connLost bool


### PR DESCRIPTION
When the RPC connection is lost and a recovery attempt occurs, the variable `conn` responsible for the connection may be nil and therefore additional verification is needed.

I couldn't come up with a better solution, so I'm open to smart thoughts.

Closes #3061.