### PR TITLE
node/pilorama: supress flipping tree test

### DIFF
--- a/pkg/local_object_storage/pilorama/forest_test.go
+++ b/pkg/local_object_storage/pilorama/forest_test.go
@@ -651,6 +651,7 @@ func TestApplyTricky2(t *testing.T) {
 }
 
 func TestForest_ApplyRandom(t *testing.T) {
+	t.Skip("tree service code is about to be dropped, no one gonna spend time fixing it")
 	for i := range providers {
 		t.Run(providers[i].name, func(t *testing.T) {
 			testForestTreeApplyRandom(t, providers[i].construct)


### PR DESCRIPTION
It disrupts, and it is decided not to fix it. No changes are expected to be done in the pilorama.