### PR TITLE
Fix bugs with removing split objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - `neofs-cli object delete` command output (#3056)
 - Make the error message more clearer when validating IR configuration (#3072)
 - Panic during shutdown if N3 client connection is lost (#3073)
+- The first object of the split object is not deleted (#3089)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - Make the error message more clearer when validating IR configuration (#3072)
 - Panic during shutdown if N3 client connection is lost (#3073)
 - The first object of the split object is not deleted (#3089)
+- The parent of the split object is not removed from the metabase (#3089)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Panic during shutdown if N3 client connection is lost (#3073)
 - The first object of the split object is not deleted (#3089)
 - The parent of the split object is not removed from the metabase (#3089)
+- A split expired object is not deleted after the lock is removed or expired (#3089)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -162,7 +162,7 @@ func (db *DB) delete(tx *bbolt.Tx, addr oid.Address, currEpoch uint64) (bool, bo
 
 	// if object is an only link to a parent, then remove parent
 	if parent := obj.Parent(); parent != nil && !parent.GetID().IsZero() {
-		err = db.deleteObject(tx, obj, true)
+		err = db.deleteObject(tx, parent, true)
 		if err != nil {
 			return false, false, 0, fmt.Errorf("could not remove parent object: %w", err)
 		}

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -161,12 +161,7 @@ func (db *DB) delete(tx *bbolt.Tx, addr oid.Address, currEpoch uint64) (bool, bo
 	}
 
 	// if object is an only link to a parent, then remove parent
-	if parent := obj.Parent(); parent != nil {
-		if id := parent.GetID(); id.IsZero() {
-			// unfinished header from the first part
-			return false, false, 0, nil
-		}
-
+	if parent := obj.Parent(); parent != nil && !parent.GetID().IsZero() {
 		err = db.deleteObject(tx, obj, true)
 		if err != nil {
 			return false, false, 0, fmt.Errorf("could not remove parent object: %w", err)

--- a/pkg/local_object_storage/shard/gc_test.go
+++ b/pkg/local_object_storage/shard/gc_test.go
@@ -59,10 +59,14 @@ func TestGC_ExpiredObjectWithExpiredLock(t *testing.T) {
 			meta.WithEpochState(epoch),
 		),
 		shard.WithDeletedLockCallback(func(aa []oid.Address) {
-			sh.HandleDeletedLocks(aa)
+			unlocked := sh.HandleDeletedLocks(aa)
+			expired := sh.FilterExpired(unlocked)
+			require.NoError(t, sh.MarkGarbage(false, expired...))
 		}),
 		shard.WithExpiredLocksCallback(func(aa []oid.Address) {
-			sh.HandleExpiredLocks(aa)
+			unlocked := sh.HandleExpiredLocks(aa)
+			expired := sh.FilterExpired(unlocked)
+			require.NoError(t, sh.MarkGarbage(false, expired...))
 		}),
 		shard.WithGCWorkerPoolInitializer(func(sz int) util.WorkerPool {
 			pool, err := ants.NewPool(sz)


### PR DESCRIPTION
Fix #3026.

For bug about expired objects that aren't deleted after locks expire, there's also a simpler solution - [here](https://github.com/nspcc-dev/neofs-node/blob/8b65833d3651185fd9078e36b5acac73b1eaf762/pkg/local_object_storage/shard/gc.go#L121) make it consistently: handle expired locks and then handle expired objects. But really I don't like this, because the parallelism in the calculations is lost, and the logic for deleting the locks may still be wrong.