### PR TITLE
cli/eacl: drop using public key targets in eACL tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,15 @@ Changelog for NeoFS Node
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)
 
 ### Removed
+- Drop creating new eacl tables with public keys (#3096)
 
 ### Updated
 
 ### Updating from v0.44.2
+Using public keys as a rule target in eACL tables was deprecated, and 
+since this realese it is not supported to create new eACL table with keys, 
+use addresses instead. 
+For more information call `neofs-cli acl extended create -h`.
 
 ## [0.44.2] - 2024-12-20
 

--- a/cmd/neofs-cli/modules/acl/extended/create_test.go
+++ b/cmd/neofs-cli/modules/acl/extended/create_test.go
@@ -25,9 +25,8 @@ func TestParseTable(t *testing.T) {
 			jsonRecord: `{"operation":"PUT","action":"ALLOW","filters":[],"targets":[{"role":"USER","keys":[]}]}`,
 		},
 		{
-			name:       "valid rule with public key",
-			rule:       "deny getrange pubkey:036410abb260bbbda89f61c0cad65a4fa15ac5cb83b3c3abf8aee403856fcf65ed",
-			jsonRecord: `{"operation":"GETRANGE","action":"DENY","filters":[],"targets":[{"role":"ROLE_UNSPECIFIED","keys":["A2QQq7Jgu72on2HAytZaT6FaxcuDs8Or+K7kA4Vvz2Xt"]}]}`,
+			name: "invalid rule with public key",
+			rule: "deny getrange pubkey:036410abb260bbbda89f61c0cad65a4fa15ac5cb83b3c3abf8aee403856fcf65ed",
 		},
 		{
 			name:       "valid rule with account",

--- a/docs/cli-commands/neofs-cli_acl_extended_create.md
+++ b/docs/cli-commands/neofs-cli_acl_extended_create.md
@@ -28,7 +28,6 @@ Target is
   'user' for container owner, 
   'system' for Storage nodes in container and Inner Ring nodes,
   'others' for all other request senders, 
-  'pubkey:<key1>,<key2>,...' for exact request sender, where <key> is a hex-encoded 33-byte public key, DEPRECATED,
   'address:<adr1>,<adr2>,...' for exact request sender, where <adr> is a base58 25-byte address. Example: NSiVJYZej4XsxG5CUpdwn7VRQk8iiiDMPM.
 
 When both '--rule' and '--file' arguments are used, '--rule' records will be placed higher in resulting extended ACL table.


### PR DESCRIPTION
Closes #2922.