### PR TITLE
Fix broken metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for NeoFS Node
 - The first object of the split object is not deleted (#3089)
 - The parent of the split object is not removed from the metabase (#3089)
 - A split expired object is not deleted after the lock is removed or expired (#3089)
+- `neofs_node_engine_list_containers_time_bucket` and `neofs_node_engine_exists_time_bucket` metrics (#3014)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/pkg/local_object_storage/engine/exists.go
+++ b/pkg/local_object_storage/engine/exists.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (e *StorageEngine) exists(addr oid.Address) (bool, error) {
+	if e.metrics != nil {
+		defer elapsed(e.metrics.AddExistsDuration)()
+	}
+
 	for _, sh := range e.sortedShards(addr) {
 		exists, err := sh.Exists(addr, false)
 		if err != nil {

--- a/pkg/metrics/engine.go
+++ b/pkg/metrics/engine.go
@@ -167,7 +167,7 @@ func (m engineMetrics) register() {
 }
 
 func (m engineMetrics) AddListContainersDuration(d time.Duration) {
-	m.listObjectsDuration.Observe(d.Seconds())
+	m.listContainersDuration.Observe(d.Seconds())
 }
 
 func (m engineMetrics) AddEstimateContainerSizeDuration(d time.Duration) {


### PR DESCRIPTION
Fix `neofs_node_engine_list_containers_time_bucket` and `neofs_node_engine_exists_time_bucket` metrics.

Closes #3102.