### PR TITLE
Change `WC` size estimations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)
+- Write-cache size estimations (#3106)
 
 ### Removed
 - Drop creating new eacl tables with public keys (#3096)

--- a/pkg/local_object_storage/writecache/delete.go
+++ b/pkg/local_object_storage/writecache/delete.go
@@ -24,7 +24,7 @@ func (c *cache) Delete(addr oid.Address) error {
 			storagelog.StorageTypeField(wcStorageType),
 			storagelog.OpField("DELETE"),
 		)
-		c.objCounters.DecFS()
+		c.objCounters.Delete(addr)
 	}
 
 	return err

--- a/pkg/local_object_storage/writecache/migrate_test.go
+++ b/pkg/local_object_storage/writecache/migrate_test.go
@@ -1,0 +1,87 @@
+package writecache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func TestMigrateFromBolt(t *testing.T) {
+	c, b, _ := newCache(t)
+
+	wc := c.(*cache)
+	path := filepath.Join(wc.path, dbName)
+
+	require.NoError(t, wc.Close())
+
+	t.Run("ok, no database", func(t *testing.T) {
+		require.NoError(t, wc.migrate())
+	})
+
+	db, err := bbolt.Open(path, os.ModePerm, &bbolt.Options{
+		NoFreelistSync: true,
+		ReadOnly:       false,
+		Timeout:        time.Second,
+	})
+	require.NoError(t, err)
+
+	t.Run("couldn't open database", func(t *testing.T) {
+		err := wc.migrate()
+		require.Error(t, err)
+		fmt.Println(err)
+	})
+
+	require.NoError(t, db.Close())
+	t.Run("no default bucket", func(t *testing.T) {
+		err := wc.migrate()
+		require.Error(t, err)
+		fmt.Println(err)
+	})
+
+	db, err = bbolt.Open(path, os.ModePerm, &bbolt.Options{
+		NoFreelistSync: true,
+		ReadOnly:       false,
+		Timeout:        time.Second,
+	})
+	require.NoError(t, err)
+
+	obj := objecttest.Object()
+
+	var addr oid.Address
+	addr.SetObject(obj.GetID())
+	addr.SetContainer(obj.GetContainerID())
+
+	require.NoError(t, db.Batch(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(defaultBucket)
+		require.NoError(t, err)
+
+		require.NoError(t, b.Put([]byte(addr.String()), obj.Marshal()))
+
+		return nil
+	}))
+
+	t.Run("migrate object", func(t *testing.T) {
+		require.NoError(t, db.Close())
+		require.NoError(t, wc.migrate())
+
+		_, err := wc.Get(addr)
+		require.Error(t, err, apistatus.ObjectNotFound{})
+
+		bObject, err := b.Get(addr, []byte{})
+		require.NoError(t, err)
+		require.Equal(t, obj.GetID(), bObject.GetID())
+		require.Equal(t, obj.GetContainerID(), bObject.GetContainerID())
+		require.Equal(t, obj.Marshal(), bObject.Marshal())
+
+		_, err = os.Stat(path)
+		require.Error(t, err, os.ErrNotExist)
+	})
+}

--- a/pkg/local_object_storage/writecache/options.go
+++ b/pkg/local_object_storage/writecache/options.go
@@ -38,7 +38,7 @@ type options struct {
 	// maxCacheSize is the maximum total size of all objects saved in cache.
 	// 1 GiB by default.
 	maxCacheSize uint64
-	// objCounters contains atomic counters for the number of objects stored in cache.
+	// objCounters contains object list along with sizes and overall size of cache.
 	objCounters counters
 	// noSync is true iff FSTree allows unsynchronized writes.
 	noSync bool

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -97,7 +97,7 @@ func (c *cache) deleteFromDisk(keys []string) []string {
 				storagelog.StorageTypeField(wcStorageType),
 				storagelog.OpField("DELETE"),
 			)
-			c.objCounters.DecFS()
+			c.objCounters.Delete(addr)
 		}
 	}
 

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -101,6 +101,9 @@ func New(opts ...Option) Cache {
 			log:           zap.NewNop(),
 			maxObjectSize: defaultMaxObjectSize,
 			maxCacheSize:  defaultMaxCacheSize,
+			objCounters: counters{
+				objMap: make(map[oid.Address]uint64),
+			},
 		},
 	}
 


### PR DESCRIPTION
Closes #3101.

> Keep object list in memory along with sizes (map address to size)

Why are we doing this? We don't use it anywhere, do we?

Also, I forgot to include tests for migration from #3091, so I did it here.