### PR TITLE
node: fix race between heartbeat and state updater

### DIFF
--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -180,17 +180,6 @@ func initNetmapService(c *cfg) {
 	})
 
 	addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {
-		if !c.needBootstrap() || c.cfgNetmap.reBoostrapTurnedOff.Load() { // fixes #470
-			return
-		}
-
-		err := c.heartbeat()
-		if err != nil {
-			c.log.Warn("can't send heartbeat tx", zap.Error(err))
-		}
-	})
-
-	addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {
 		e := ev.(netmapEvent.NewEpoch).EpochNumber()
 
 		ni, err := c.netmapLocalNodeState(e)
@@ -204,6 +193,15 @@ func initNetmapService(c *cfg) {
 		}
 
 		c.handleLocalNodeInfoFromNetwork(ni)
+
+		if !c.needBootstrap() || c.cfgNetmap.reBoostrapTurnedOff.Load() { // fixes #470
+			return
+		}
+
+		err = c.heartbeat()
+		if err != nil {
+			c.log.Warn("can't send heartbeat tx", zap.Error(err))
+		}
 	})
 
 	addNewEpochAsyncNotificationHandler(c, func(ev event.Event) {


### PR DESCRIPTION
The first heartbeat attempt after the node bootstrap can end up this way:

    warn    neofs-node/netmap.go:189        can't send heartbeat tx {"error": "incorrect current network map status OFFLINE, restart recommended"

Which is not critical since the next one will succeed, but the root of the problem is _two_ asynchronous handlers started for a new epoch, one of them updating local node data and the other sending heartbeats. This problem existed even before nodeV2, but with the old heartbeat mechanism it wasn't visible.

I doubt we need two routines here, everything can be performed with a single one sequentially and correctly.