### PR TITLE
Fix error from `CalculateNonceAndVUB`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ Changelog for NeoFS Node
 - `neofs_node_engine_list_objects_time_bucket` metric (#3120)
 - The correct role parameter to invocation (#3127)
 - nil pointer error for `storage sanity` command (#3151)
+- Process designation event of the mainnet RoleManagement contract (#3134)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)
 - Write-cache size estimations (#3106)
 - New network map support solving the limit of ~320 nodes per network
+- Calculation of VUB for zero hash (#3134)
 
 ### Removed
 - Drop creating new eacl tables with public keys (#3096)

--- a/pkg/innerring/state.go
+++ b/pkg/innerring/state.go
@@ -123,15 +123,18 @@ func (s *Server) voteForFSChainValidator(validators keys.PublicKeys, trigger *ut
 		nonce uint32 = 1
 		vub   uint32
 		vubP  *uint32
+		hash  util.Uint256
 	)
 
 	if trigger != nil {
-		nonce, vub, err = s.morphClient.CalculateNonceAndVUB(*trigger)
-		if err != nil {
-			return fmt.Errorf("could not calculate nonce and `validUntilBlock` values: %w", err)
-		}
-		vubP = &vub
+		hash = *trigger
 	}
+
+	nonce, vub, err = s.morphClient.CalculateNonceAndVUB(hash)
+	if err != nil {
+		return fmt.Errorf("could not calculate nonce and `validUntilBlock` values: %w", err)
+	}
+	vubP = &vub
 
 	s.contracts.alphabet.iterate(func(ind int, contract util.Uint160) {
 		_, err := s.morphClient.NotaryInvoke(contract, 0, nonce, vubP, voteMethod, epoch, validators)

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -767,6 +767,13 @@ func (c *Client) CalculateNonceAndVUB(hash util.Uint256) (nonce uint32, vub uint
 
 	nonce = binary.LittleEndian.Uint32(hash.BytesLE())
 
+	if hash.Equals(util.Uint256{}) {
+		vub, err = c.notaryTxValidationLimit(conn)
+		if err != nil {
+			return 0, 0, fmt.Errorf("could not get vub validation limit: %w", err)
+		}
+		return nonce, vub, nil
+	}
 	height, err := c.getTransactionHeight(conn, hash)
 	if err != nil {
 		return 0, 0, fmt.Errorf("could not get transaction height: %w", err)

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -268,7 +268,7 @@ func (c *Client) UpdateNotaryList(notaries keys.PublicKeys, txHash util.Uint256)
 
 	nonce, vub, err := c.CalculateNonceAndVUB(txHash)
 	if err != nil {
-		return fmt.Errorf("could not calculate nonce and `valicUntilBlock` values: %w", err)
+		return fmt.Errorf("could not calculate nonce and `validUntilBlock` values: %w", err)
 	}
 
 	return c.notaryInvokeAsCommittee(
@@ -292,7 +292,7 @@ func (c *Client) UpdateNeoFSAlphabetList(alphas keys.PublicKeys, txHash util.Uin
 
 	nonce, vub, err := c.CalculateNonceAndVUB(txHash)
 	if err != nil {
-		return fmt.Errorf("could not calculate nonce and `valicUntilBlock` values: %w", err)
+		return fmt.Errorf("could not calculate nonce and `validUntilBlock` values: %w", err)
 	}
 
 	return c.notaryInvokeAsCommittee(

--- a/pkg/morph/event/rolemanagement/designate.go
+++ b/pkg/morph/event/rolemanagement/designate.go
@@ -40,6 +40,6 @@ func ParseDesignate(e *state.ContainedNotificationEvent) (event.Event, error) {
 
 	return Designate{
 		Role:   noderoles.Role(bi.Int64()),
-		TxHash: e.Container,
+		TxHash: util.Uint256{},
 	}, nil
 }


### PR DESCRIPTION
The alphabetic key change event comes from the main chain with its hash, and when calculating vub, an error is returned because there is no hash in the fs chain. Ignore the error and calculate the value in another way.