### PR TITLE
container: make `putContainerSize` method as notary request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog for NeoFS Node
 - The correct role parameter to invocation (#3127)
 - nil pointer error for `storage sanity` command (#3151)
 - Process designation event of the mainnet RoleManagement contract (#3134)
+- Storage nodes running out of GAS because `putContainerSize` was not paid for by proxy (#3167)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/pkg/innerring/processors/container/handlers.go
+++ b/pkg/innerring/processors/container/handlers.go
@@ -61,3 +61,22 @@ func (cp *Processor) handleSetEACL(ev event.Event) {
 			zap.Int("capacity", cp.pool.Cap()))
 	}
 }
+
+func (cp *Processor) handleAnnounceLoad(ev event.Event) {
+	e := ev.(containerEvent.AnnounceLoad)
+
+	cp.log.Info("notification",
+		zap.String("type", "announce load"),
+	)
+
+	// send an event to the worker pool
+
+	err := cp.pool.Submit(func() {
+		cp.processAnnounceLoad(e)
+	})
+	if err != nil {
+		// there system can be moved into controlled degradation stage
+		cp.log.Warn("container processor worker pool drained",
+			zap.Int("capacity", cp.pool.Cap()))
+	}
+}

--- a/pkg/innerring/processors/container/process_announce_load.go
+++ b/pkg/innerring/processors/container/process_announce_load.go
@@ -1,0 +1,77 @@
+package container
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event/container"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	netmapSDK "github.com/nspcc-dev/neofs-sdk-go/netmap"
+	"go.uber.org/zap"
+)
+
+func (cp *Processor) processAnnounceLoad(e container.AnnounceLoad) {
+	if !cp.alphabetState.IsAlphabet() {
+		cp.log.Info("non alphabet mode, ignore announce load")
+		return
+	}
+
+	err := cp.checkAnnounceLoad(e)
+	if err != nil {
+		cp.log.Error("announce load check failed",
+			zap.Error(err),
+		)
+
+		return
+	}
+
+	nr := e.NotaryRequest()
+	err = cp.cnrClient.Morph().NotarySignAndInvokeTX(nr.MainTransaction, false)
+	if err != nil {
+		cp.log.Error("could not approve announce load",
+			zap.Error(err),
+		)
+	}
+}
+
+func (cp *Processor) checkAnnounceLoad(e container.AnnounceLoad) error {
+	binCnr := e.ContainerID()
+
+	var idCnr cid.ID
+	err := idCnr.Decode(binCnr)
+	if err != nil || idCnr.IsZero() {
+		return fmt.Errorf("invalid container ID: %w", err)
+	}
+
+	cnr, err := cp.cnrClient.Get(binCnr)
+	if err != nil {
+		return fmt.Errorf("could not receive the container: %w", err)
+	}
+
+	nm, err := cp.netState.NetMap()
+	if err != nil {
+		return fmt.Errorf("could not get netmap: %w", err)
+	}
+
+	ni, err := nm.ContainerNodes(cnr.Value.PlacementPolicy(), idCnr)
+	if err != nil {
+		return fmt.Errorf("could not get container nodes: %w", err)
+	}
+
+	if !checkNodes(ni, e.Key()) {
+		return fmt.Errorf("%s does not belong to container %s", e.Key(), idCnr.String())
+	}
+
+	return nil
+}
+
+func checkNodes(ni [][]netmapSDK.NodeInfo, key []byte) bool {
+	for _, replicas := range ni {
+		for _, node := range replicas {
+			if bytes.Equal(node.PublicKey(), key) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/innerring/processors/container/processor.go
+++ b/pkg/innerring/processors/container/processor.go
@@ -136,6 +136,11 @@ func (cp *Processor) ListenerNotaryParsers() []event.NotaryParserInfo {
 	p.SetParser(containerEvent.ParseSetEACLNotary)
 	pp = append(pp, p)
 
+	// announce load
+	p.SetRequestType(containerEvent.AnnounceLoadNotaryEvent)
+	p.SetParser(containerEvent.ParseAnnounceLoadNotary)
+	pp = append(pp, p)
+
 	return pp
 }
 
@@ -166,6 +171,11 @@ func (cp *Processor) ListenerNotaryHandlers() []event.NotaryHandlerInfo {
 	// set eACL
 	h.SetRequestType(containerEvent.SetEACLNotaryEvent)
 	h.SetHandler(cp.handleSetEACL)
+	hh = append(hh, h)
+
+	// announce load
+	h.SetRequestType(containerEvent.AnnounceLoadNotaryEvent)
+	h.SetHandler(cp.handleAnnounceLoad)
 	hh = append(hh, h)
 
 	return hh

--- a/pkg/morph/client/container/load.go
+++ b/pkg/morph/client/container/load.go
@@ -40,6 +40,11 @@ func (c *Client) AnnounceLoad(p AnnounceLoadPrm) error {
 	prm.SetArgs(p.a.Epoch(), cnr[:], p.a.Value(), p.key)
 	prm.InvokePrmOptional = p.InvokePrmOptional
 
+	// no magic bugs with notary requests anymore, this operation should
+	// _always_ be notary signed so make it one more time even if it is
+	// a repeated flag setting
+	prm.RequireAlphabetSignature()
+
 	err := c.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", putSizeMethod, err)

--- a/pkg/morph/event/container/announce_load.go
+++ b/pkg/morph/event/container/announce_load.go
@@ -1,0 +1,36 @@
+package container
+
+import "github.com/nspcc-dev/neo-go/pkg/network/payload"
+
+// AnnounceLoad structure of container.AnnounceLoad notification from morph chain.
+type AnnounceLoad struct {
+	epoch uint64
+	cnrID []byte
+	val   uint64
+	key   []byte
+
+	// For notary notifications only.
+	// Contains raw transactions of notary request.
+	notaryRequest *payload.P2PNotaryRequest
+}
+
+// MorphEvent implements Neo:Morph Event interface.
+func (AnnounceLoad) MorphEvent() {}
+
+// Epoch returns epoch when estimation of the container data size was calculated.
+func (al AnnounceLoad) Epoch() uint64 { return al.epoch }
+
+// ContainerID returns container ID for which the amount of data is estimated.
+func (al AnnounceLoad) ContainerID() []byte { return al.cnrID }
+
+// Value returns estimated amount of data (in bytes) in the specified container.
+func (al AnnounceLoad) Value() uint64 { return al.val }
+
+// Key returns a public key of the reporter.
+func (al AnnounceLoad) Key() []byte { return al.key }
+
+// NotaryRequest returns raw notary request if notification
+// was received via notary service. Otherwise, returns nil.
+func (al AnnounceLoad) NotaryRequest() *payload.P2PNotaryRequest {
+	return al.notaryRequest
+}

--- a/pkg/morph/event/container/announce_load_notary.go
+++ b/pkg/morph/event/container/announce_load_notary.go
@@ -1,0 +1,60 @@
+package container
+
+import (
+	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
+)
+
+const (
+	// AnnounceLoadNotaryEvent is method name for announce load estimation operation
+	// in `Container` contract. Is used as identificator for notary
+	// announce load estimation requests.
+	AnnounceLoadNotaryEvent = "putContainerSize"
+)
+
+// ParseAnnounceLoadNotary from NotaryEvent into container event structure.
+func ParseAnnounceLoadNotary(ne event.NotaryEvent) (event.Event, error) {
+	const expectedItemNumAnnounceLoad = 4
+	var ev AnnounceLoad
+
+	fieldNum := 0
+
+	for _, op := range ne.Params() {
+		switch fieldNum {
+		case 3:
+			n, err := event.IntFromOpcode(op)
+			if err != nil {
+				return nil, err
+			}
+
+			ev.epoch = uint64(n)
+		case 2:
+			data, err := event.BytesFromOpcode(op)
+			if err != nil {
+				return nil, err
+			}
+
+			ev.cnrID = data
+		case 1:
+			n, err := event.IntFromOpcode(op)
+			if err != nil {
+				return nil, err
+			}
+
+			ev.val = uint64(n)
+		case 0:
+			data, err := event.BytesFromOpcode(op)
+			if err != nil {
+				return nil, err
+			}
+
+			ev.key = data
+		case expectedItemNumAnnounceLoad:
+			return nil, event.UnexpectedArgNumErr(AnnounceLoadNotaryEvent)
+		}
+		fieldNum++
+	}
+
+	ev.notaryRequest = ne.Raw()
+
+	return ev, nil
+}


### PR DESCRIPTION
Closes #3129.

```
$ neo-go query tx --rpc-endpoint http://ir01.neofs.devenv:30333 -v fa93c36cad8ffdcce764c0446f2751d7203df1f1fea6e46973775afbe6b5f5ff
Hash:			fa93c36cad8ffdcce764c0446f2751d7203df1f1fea6e46973775afbe6b5f5ff
OnChain:		true
BlockHash:		f47c609369e5f5a49e9f1ea23422a14bea595e93856e403de3c0f6b2df5163bb
Success:		true
Signer:			Nb7aVeU98VySALvRo4mBfyVh59hHr5pZy8 (None)
Signer:			NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP (WitnessScope(65))
Signer:			NPTmih9X14Y7xLvmD6RVtDHdH1Y9qJwoTe (WitnessScope(65))
Signer:			NRNp25VPHahL3umVxBcMLuEENGZR9cHxtc (None)
SystemFee:		0.4007524 GAS
NetworkFee:		0.3792789 GAS
Script:			DCECrJIM198LYbKJBy5rlG4tpOGjG5qxxiG7R14w+kqxAsMCsSIVAAwgw96yKzw10YleF8Z9YTY/SDE42F8J4pWnsTKq4Wm79lAUFMAfDBBwdXRDb250YWluZXJTaXplDBT9G8bLGk90cBmczNNgGoQo1gKSXUFifVtS
INDEX    OPCODE       PARAMETER
0        PUSHDATA1    02ac920cd7df0b61b289072e6b946e2da4e1a31b9ab1c621bb475e30fa4ab102c3    <<
35       PUSHINT32    1385137 (b1221500)
40       PUSHDATA1    c3deb22b3c35d1895e17c67d61363f483138d85f09e295a7b132aae169bbf650
74       PUSH4        
75       PUSH4        
76       PACK         
77       PUSH15       
78       PUSHDATA1    707574436f6e7461696e657253697a65 ("putContainerSize")
96       PUSHDATA1    fd1bc6cb1a4f7470199cccd3601a8428d602925d ("NizHREgKiGs6qf5Eag8xYiNzMhsRJqZH1L", "0x5d9202d628841a60d3cc9c1970744f1acbc61bfd")
118      SYSCALL      System.Contract.Call (627d5b52)
```
I don't know why the epoch is not shown, but it is passed. 

```
info	runtime/engine.go:152	runtime log	{"tx": "ea08b5d7f1cf452cc059c021c79a50881edb1d566396473aa9a0dc8cb10a1024", "script": "5d9202d628841a60d3cc9c1970744f1acbc61bfd", "msg": "saved container size estimation"}
...
info	runtime/engine.go:152	runtime log	{"tx": "fa93c36cad8ffdcce764c0446f2751d7203df1f1fea6e46973775afbe6b5f5ff", "script": "5d9202d628841a60d3cc9c1970744f1acbc61bfd", "msg": "saved container size estimation"}
```
I also noticed that this output is repeated, but the first time it does not find such a transaction, and the second time everything is fine.

I have a question about the work: I put an object with a size of 2433713 and it split into small pieces on other nodes, but in the end the function showed a smaller size, and in other nodes this output:
```
debug	route/calls.go:160	could not close remote server writer	{"component": "container_estimations", "key": "02ac920cd7df0b61b289072e6b946e2da4e1a31b9ab1c621bb475e30fa4ab102c3", "error": "status: code = 1024 message = node outside the container"}
```
Shouldn't it be either?

Also suggest what other validation can be performed during processing.