### PR TITLE
Delete objects from wc after flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog for NeoFS Node
 - nil pointer error for `storage sanity` command (#3151)
 - Process designation event of the mainnet RoleManagement contract (#3134)
 - Storage nodes running out of GAS because `putContainerSize` was not paid for by proxy (#3167)
+- Write-cache flushing loop to drop objects (#3169)
 
 ### Changed
 - Number of cuncurrenly handled notifications from the chain was increased from 10 to 300 for IR (#3068)

--- a/pkg/local_object_storage/writecache/doc.go
+++ b/pkg/local_object_storage/writecache/doc.go
@@ -3,7 +3,4 @@
 // Write-cache uses file system tree for storing objects.
 //
 // Flushing from the writecache to the main storage is done in the background.
-// To make it possible to serve Read requests after the object was flushed,
-// we maintain an LRU cache containing addresses of all the objects that
-// could be safely deleted. The actual deletion is done during eviction from this cache.
 package writecache

--- a/pkg/local_object_storage/writecache/get.go
+++ b/pkg/local_object_storage/writecache/get.go
@@ -11,14 +11,11 @@ import (
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in write-cache.
 func (c *cache) Get(addr oid.Address) (*objectSDK.Object, error) {
-	saddr := addr.EncodeToString()
-
 	obj, err := c.fsTree.Get(addr)
 	if err != nil {
 		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
 	}
 
-	c.flushed.Get(saddr)
 	return obj, nil
 }
 
@@ -35,13 +32,10 @@ func (c *cache) Head(addr oid.Address) (*objectSDK.Object, error) {
 }
 
 func (c *cache) GetBytes(addr oid.Address) ([]byte, error) {
-	saddr := addr.EncodeToString()
-
 	b, err := c.fsTree.GetBytes(addr)
 	if err != nil {
 		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
 	}
 
-	c.flushed.Get(saddr)
 	return b, nil
 }

--- a/pkg/local_object_storage/writecache/init.go
+++ b/pkg/local_object_storage/writecache/init.go
@@ -13,18 +13,14 @@ func (c *cache) initFlushMarks() {
 	c.log.Info("filling flush marks for objects in FSTree")
 
 	var addrHandler = func(addr oid.Address) error {
-		flushed, needRemove := c.flushStatus(addr)
-		if flushed {
-			c.store.flushed.Add(addr.EncodeToString(), true)
-			if needRemove {
-				err := c.fsTree.Delete(addr)
-				if err == nil {
-					storagelog.Write(c.log,
-						storagelog.AddressField(addr),
-						storagelog.StorageTypeField(wcStorageType),
-						storagelog.OpField("DELETE"),
-					)
-				}
+		if c.flushStatus(addr) {
+			err := c.fsTree.Delete(addr)
+			if err == nil {
+				storagelog.Write(c.log,
+					storagelog.AddressField(addr),
+					storagelog.StorageTypeField(wcStorageType),
+					storagelog.OpField("DELETE"),
+				)
 			}
 		}
 		return nil
@@ -35,16 +31,15 @@ func (c *cache) initFlushMarks() {
 }
 
 // flushStatus returns info about the object state in the main storage.
-// First return value is true iff object exists.
-// Second return value is true iff object can be safely removed.
-func (c *cache) flushStatus(addr oid.Address) (bool, bool) {
+// Return value is true iff object exists and can be safely removed.
+func (c *cache) flushStatus(addr oid.Address) bool {
 	_, err := c.metabase.Exists(addr, false)
 	if err != nil {
 		needRemove := errors.Is(err, meta.ErrObjectIsExpired) || errors.As(err, new(apistatus.ObjectAlreadyRemoved))
-		return needRemove, needRemove
+		return needRemove
 	}
 
 	sid, _ := c.metabase.StorageID(addr)
 	exists, err := c.blobstor.Exists(addr, sid)
-	return err == nil && exists, false
+	return err == nil && exists
 }

--- a/pkg/local_object_storage/writecache/iterate.go
+++ b/pkg/local_object_storage/writecache/iterate.go
@@ -18,9 +18,6 @@ func (c *cache) Iterate(handler func(oid.Address, []byte) error, ignoreErrors bo
 	}
 
 	var addrHandler = func(addr oid.Address) error {
-		if _, ok := c.flushed.Peek(addr.EncodeToString()); ok {
-			return nil
-		}
 		data, err := c.fsTree.GetBytes(addr)
 		if err != nil {
 			if ignoreErrors || errors.As(err, new(apistatus.ObjectNotFound)) {

--- a/pkg/local_object_storage/writecache/storage.go
+++ b/pkg/local_object_storage/writecache/storage.go
@@ -1,35 +1,12 @@
 package writecache
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
-	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
-	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
-	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.uber.org/zap"
 )
-
-// store represents persistent storage with in-memory LRU cache
-// for flushed items on top of it.
-type store struct {
-	maxFlushedMarksCount int
-	maxRemoveBatchSize   int
-
-	// flushed contains addresses of objects that were already flushed to the main storage.
-	// We use LRU cache instead of map here to facilitate removing of unused object in favour of
-	// frequently read ones.
-	// MUST NOT be used inside bolt db transaction because it's eviction handler
-	// removes untracked items from the database.
-	flushed simplelru.LRUCache[string, bool]
-
-	fsKeysToRemove []string
-}
 
 const dbName = "small.bolt"
 
@@ -49,57 +26,5 @@ func (c *cache) openStore(readOnly bool) error {
 		return fmt.Errorf("could not open FSTree: %w", err)
 	}
 
-	// Write-cache can be opened multiple times during `SetMode`.
-	// flushed map must not be re-created in this case.
-	if c.flushed == nil {
-		c.flushed, _ = lru.NewWithEvict[string, bool](c.maxFlushedMarksCount, c.removeFlushed)
-	}
 	return nil
-}
-
-// removeFlushed removes an object from the writecache.
-// To minimize interference with the client operations, the actual removal
-// is done in batches.
-// It is not thread-safe and is used only as an evict callback to LRU cache.
-func (c *cache) removeFlushed(addr string, _ bool) {
-	c.fsKeysToRemove = append(c.fsKeysToRemove, addr)
-
-	if len(c.fsKeysToRemove) >= c.maxRemoveBatchSize {
-		c.fsKeysToRemove = c.deleteFromDisk(c.fsKeysToRemove)
-	}
-}
-
-func (c *cache) deleteFromDisk(keys []string) []string {
-	if len(keys) == 0 {
-		return keys
-	}
-
-	var copyIndex int
-	var addr oid.Address
-
-	for i := range keys {
-		if err := addr.DecodeString(keys[i]); err != nil {
-			c.log.Error("can't parse address", zap.String("address", keys[i]))
-			continue
-		}
-
-		err := c.fsTree.Delete(addr)
-		if err != nil && !errors.As(err, new(apistatus.ObjectNotFound)) {
-			c.log.Error("can't remove object from write-cache", zap.Error(err))
-
-			// Save the key for the next iteration.
-			keys[copyIndex] = keys[i]
-			copyIndex++
-			continue
-		} else if err == nil {
-			storagelog.Write(c.log,
-				storagelog.AddressField(keys[i]),
-				storagelog.StorageTypeField(wcStorageType),
-				storagelog.OpField("DELETE"),
-			)
-			c.objCounters.Delete(addr)
-		}
-	}
-
-	return keys[:copyIndex]
 }

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -67,8 +67,6 @@ type cache struct {
 	closeCh chan struct{}
 	// wg is a wait group for flush workers.
 	wg sync.WaitGroup
-	// store contains underlying database.
-	store
 	// fsTree contains big files stored directly on file-system.
 	fsTree *fstree.FSTree
 }
@@ -110,11 +108,6 @@ func New(opts ...Option) Cache {
 	for i := range opts {
 		opts[i](&c.options)
 	}
-
-	// Make the LRU cache contain which take approximately 3/4 of the maximum space.
-	c.maxFlushedMarksCount = int(c.maxCacheSize/c.maxObjectSize) / 2 * 3 / 4
-	// Trigger the removal when the cache is 7/8 full, so that new items can still arrive.
-	c.maxRemoveBatchSize = c.maxFlushedMarksCount / 8
 
 	return c
 }


### PR DESCRIPTION
Closes #3077.

IIUC, the LRU cache was needed since the boltDB was processed in parallel and it was not safe to delete objects directly from there, but now only fstree and therefore it is no longer needed?