### PR TITLE
meta: do not try processing non-meta-enabled containers

### DIFF
--- a/pkg/services/meta/meta.go
+++ b/pkg/services/meta/meta.go
@@ -31,6 +31,9 @@ type ContainerLister interface {
 	// List returns node's containers that support chain-based meta data and
 	// any error that does not allow listing.
 	List() (map[cid.ID]struct{}, error)
+	// IsMineWithMeta checks if the given CID has meta enabled and current
+	// node belongs to it.
+	IsMineWithMeta(cid.ID) (bool, error)
 }
 
 // wsClient is for test purposes only.

--- a/pkg/services/meta/notifications.go
+++ b/pkg/services/meta/notifications.go
@@ -119,6 +119,15 @@ func (m *Meta) listenNotifications(ctx context.Context) error {
 				continue
 			}
 
+			ok, err = m.cLister.IsMineWithMeta(ev.cID)
+			if err != nil {
+				l.Error("can't get container data", zap.Error(err))
+				continue
+			}
+			if !ok {
+				continue
+			}
+
 			m.m.Lock()
 
 			st, err := storageForContainer(m.rootPath, ev.cID)

--- a/pkg/services/meta/notifications_test.go
+++ b/pkg/services/meta/notifications_test.go
@@ -39,6 +39,10 @@ type testContainerLister struct {
 	resErr error
 }
 
+func (t *testContainerLister) IsMineWithMeta(id cid.ID) (bool, error) {
+	return true, nil
+}
+
 func (t *testContainerLister) List() (map[cid.ID]struct{}, error) {
 	return t.res, t.resErr
 }


### PR DESCRIPTION
7b502637fbbe7fffc7b6ccaf3309c20a4ebde565 was incomplete, upon receiving a new container event the service still tries to handle it.