### PR TITLE
writecache: make migration on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Zero range denial by `neofs-cli object range|hash` commands (#3182)
+- Not all the components needed for write-cache migration were initialized (#3186)
 
 ### Changed
 


### PR DESCRIPTION
Closes #3185.

I checked and in this case `encoder` is not nil.