### PR TITLE
ir: drop annoying "new transaction callback finished with error" log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - NPE in metabase V3->4 migration routine (#3212)
+- "new transaction callback finished with error" logs for "already exists in mempool" error (#3218)
 
 ### Changed
 

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -503,7 +503,7 @@ func New(cfg Config) (res *Blockchain, err error) {
 
 	notaryService, err := notary.NewNotary(cfgNotary, netServer.Net, netServer.GetNotaryPool(), func(tx *transaction.Transaction) error {
 		err := netServer.RelayTxn(tx)
-		if err != nil && !errors.Is(err, core.ErrAlreadyExists) {
+		if err != nil && !errors.Is(err, core.ErrAlreadyExists) && !errors.Is(err, core.ErrAlreadyInPool) {
 			return fmt.Errorf("relay completed notary transaction %s: %w", tx.Hash().StringLE(), err)
 		}
 


### PR DESCRIPTION
Follow NeoGo commit 3abddc78c0581c832a2754f21acf8215ee6e0f59 (https://github.com/nspcc-dev/neo-go/pull/3063) where ErrAlreadyExists was split into ErrAlreadyExists and ErrAlreadyInPool. Both are perfectly fine for this callback (transaction assembled and added into pool, nothing more to do).