### PR TITLE
workflows: upgrade tj-actions/changed-files to v46

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get changed CHANGELOG
         id: changelog-diff
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           files: CHANGELOG.md
 

--- a/.github/workflows/config-update.yml
+++ b/.github/workflows/config-update.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get changed config-related files
         id: config-diff
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           files: |
             config/**
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed doc files
         id: docs-diff
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v46
         with:
           files: docs/**
 


### PR DESCRIPTION
It was recently compromised and even though changes to tags were reverted it's still worth upgrading (GH also warns about <=45.0.7).

I've checked this repository, we've not leaked anything since March 14 (the day of the attack).

See https://github.com/tj-actions/changed-files/issues/2463 also.