### PR TITLE
netmap: always approve v2 node bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - Not initialized FSTree in the write-cache (#3220)
 - Potential approval of network map candidate with duplicated attribute by IR (#3224)
 - Unscheduled attempt to tick the epoch when new epoch event has already arrived in IR (#3226)
+- Missing v2 SN approval from IR for netmap node v1 networks (#3238)
 
 ### Changed
 - Retry flush from write-cache after 10s delay if an error is received (#3221)

--- a/pkg/innerring/processors/netmap/process_peers.go
+++ b/pkg/innerring/processors/netmap/process_peers.go
@@ -37,10 +37,10 @@ func (np *Processor) processAddPeer(ev netmapEvent.AddPeer) {
 		return
 	}
 
-	np.validateCandidate(tx, nodeInfo)
+	np.validateCandidate(tx, nodeInfo, false)
 }
 
-func (np *Processor) validateCandidate(tx *transaction.Transaction, nodeInfo netmap.NodeInfo) {
+func (np *Processor) validateCandidate(tx *transaction.Transaction, nodeInfo netmap.NodeInfo, v2 bool) {
 	// validate node info
 	var err = np.nodeValidator.Verify(nodeInfo)
 	if err != nil {
@@ -62,7 +62,7 @@ func (np *Processor) validateCandidate(tx *transaction.Transaction, nodeInfo net
 
 	updated := np.netmapSnapshot.touch(keyString, np.epochState.EpochCounter(), nodeInfoBinary)
 
-	if updated {
+	if v2 || updated {
 		np.log.Info("approving network map candidate",
 			zap.String("key", keyString))
 
@@ -99,7 +99,7 @@ func (np *Processor) processAddNode(ev netmapEvent.AddNode) {
 		np.log.Warn("can't parse network map candidate")
 		return
 	}
-	np.validateCandidate(tx, nodeInfo)
+	np.validateCandidate(tx, nodeInfo, true)
 }
 
 // Process update peer notification by sending approval tx to the smart contract.


### PR DESCRIPTION
SNs on old networks with v1 node netmap send two bootstrap requests one after another, v1 and v2. But IR approves only one because of "updated" check:

    neofs-ir[1458]: info        netmap/handlers.go:45        notification        {"type": "add peer"}
    neofs-ir[1458]: info        netmap/handlers.go:64        notification        {"type": "add node"}
    neofs-ir[1458]: info        netmap/process_peers.go:66        approving network map candidate        {"key": "03aeff8a19f0202090afb0916b1c00b432321be7e8623a06c9b9b5db8ee5c053a4"}

Even though the system works with the old map fine we can't switch to v2 because that map is either empty or has 1-2 node (sometimes v2 is approved before v1 due to concurrency).

This is a minimal fix to always approve correct v2 nodes, then after the switch we'll simplify all of this code.