### PR TITLE
metabase: GC objects using new searchV2 index

### DIFF
--- a/pkg/local_object_storage/metabase/metadata.go
+++ b/pkg/local_object_storage/metabase/metadata.go
@@ -146,7 +146,7 @@ func deleteMetadata(tx *bbolt.Tx, cnr cid.ID, id oid.ID) error {
 	c := metaBkt.Cursor()
 	for kIDAttr, _ := c.Seek(pref); bytes.HasPrefix(kIDAttr, pref); kIDAttr, _ = c.Next() {
 		sepInd := bytes.LastIndex(kIDAttr, objectcore.MetaAttributeDelimiter)
-		if sepInd < 0 {
+		if sepInd < 1+oid.Size {
 			return fmt.Errorf("invalid key with prefix 0x%X in meta bucket: missing delimiter", kIDAttr[0])
 		}
 		kAttrID := make([]byte, len(kIDAttr)+attributeDelimiterLen)


### PR DESCRIPTION
1. Cleanup new index based only on current new index's state
2. Keep actual stored objects' size based only on new index's state
3. Delete old indexes based on their old state, but do not involve them in new routines

Tests for counters and parent objects are based on PUT + DELETE operations, so they are actual for the new code too. Closes #3245.