### PR TITLE
meta: fix broken tests

### DIFF
--- a/pkg/services/meta/containers_test.go
+++ b/pkg/services/meta/containers_test.go
@@ -54,7 +54,7 @@ func TestObjectExpiration(t *testing.T) {
 		})
 
 		net := testNetwork{}
-		net.setContainers(map[cid.ID]struct{}{cID: {}})
+		net.setContainers([]cid.ID{cID})
 		net.setObjects(objsToAddrMap(oo))
 		ee := make([]objEvent, 0, objNum)
 		for _, o := range oo {
@@ -114,7 +114,7 @@ func TestObjectExpiration(t *testing.T) {
 		})
 
 		net := testNetwork{}
-		net.setContainers(map[cid.ID]struct{}{cID: {}})
+		net.setContainers([]cid.ID{cID})
 		net.setObjects(objsToAddrMap([]object.Object{o, lock}))
 
 		eObj := objEvent{


### PR DESCRIPTION
ebf8f8b3f56347c4c1adb99e130f2749af6a6270 from #3241 had no lines conflicting with 7b730e476688a5e9f095417d3489a74f56adb574 from #3242, but in fact merging it broke tests.