### PR TITLE
ir: drop session key check

### DIFF
--- a/pkg/innerring/processors/container/common.go
+++ b/pkg/innerring/processors/container/common.go
@@ -79,10 +79,6 @@ func (cp *Processor) verifySignature(v signatureVerificationData) error {
 			return errors.New("session token is not signed by the container owner")
 		}
 
-		if !tok.AssertAuthKey(&key) {
-			return errors.New("signed with a non-session key")
-		}
-
 		if !tok.AssertVerb(v.verb) {
 			return errWrongSessionVerb
 		}


### PR DESCRIPTION
We've got test_static_session_token_container_delete failing after 4b7eee5c02938b9c2e84fe1e78a61f40581af4a4. This happens because deletion event has no real key and we're substituting it by the key used when container was created. It's an issuer key effectively, not a session key. And IMO this check is not very useful, we're checking signature against session-bound key anyway adn we trust this key because the token is issued by correct owner. The key from event is not very useful from the security perspective then.

The code extracting the key is moved as well because we can avoid decoding for the tokenized case.