### PR TITLE
meta: handle container events via blocks

### DIFF
--- a/pkg/services/meta/notifications_test.go
+++ b/pkg/services/meta/notifications_test.go
@@ -202,7 +202,6 @@ func createAndRunTestMeta(t *testing.T, ws wsClient, network NeoFSNetwork) (*Met
 		rootPath:    t.TempDir(),
 		magicNumber: 102938475,
 		bCh:         make(chan *block.Header),
-		cnrDelEv:    make(chan *state.ContainedNotificationEvent),
 		cnrPutEv:    make(chan *state.ContainedNotificationEvent),
 		epochEv:     make(chan *state.ContainedNotificationEvent),
 		blockBuff:   make(chan *block.Header, blockBuffSize),


### PR DESCRIPTION
Do not subscribe for containers additionally, use blocks as a single source of notifications. Now meta service is always in one of the two mutually exclusive state:
1. IDLE: subscribed to new containers event and not subscribed to blocks
2. ACTIVE: subscribed to blocks and not subscribed to new containers

Refs #3175, closes #3259.