### PR TITLE
node: Do not verify signature of eACLs from the Container contract

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -704,7 +704,7 @@ func initBasics(c *cfg, key *keys.PrivateKey, stateStorage *state.PersistentStor
 
 	b.netMapSource = b.nCli
 	b.cnrSrc = cntClient.AsContainerSource(b.cCli)
-	b.eaclSrc = &morphEACLFetcher{w: b.cCli}
+	b.eaclSrc = b.cCli
 	b.cnrLst = b.cCli
 	if ttl >= 0 {
 		b.netmapCache = newCachedNetmapStorage(nState, b.netMapSource)

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -17,7 +17,6 @@ import (
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine"
 	morphClient "github.com/nspcc-dev/neofs-node/pkg/morph/client"
-	cntClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
 	"github.com/nspcc-dev/neofs-node/pkg/services/meta"
 	objectService "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/acl"
@@ -313,24 +312,6 @@ func initObjectService(c *cfg) {
 	for _, srv := range c.cfgGRPC.servers {
 		protoobject.RegisterObjectServiceServer(srv, server)
 	}
-}
-
-type morphEACLFetcher struct {
-	w *cntClient.Client
-}
-
-func (s *morphEACLFetcher) GetEACL(cnr cid.ID) (*containercore.EACL, error) {
-	eaclInfo, err := s.w.GetEACL(cnr)
-	if err != nil {
-		return nil, err
-	}
-
-	if !eaclInfo.Signature.Verify(eaclInfo.Value.Marshal()) {
-		// TODO(@cthulhu-rider): #1387 use "const" error
-		return nil, errors.New("invalid signature of the eACL table")
-	}
-
-	return eaclInfo, nil
 }
 
 type reputationClientConstructor struct {


### PR DESCRIPTION
for #3194, smth definite should be done for this. I decided to trust the contract and drop verification. If we'll decide to keep the check, it should be globalized/deduplicated and refactored same as #3265