### PR TITLE
peapod-to-fstree: do not migrate objects without container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog for NeoFS Node
 - neofs-adm uses alphabet0/1/2 names for wallet files by default now (#3268)
 - Distribute load in writecache during flushing (#3261)
 - Faster migration in peapod-to-fstree (#3280)
+- `peapod-to-fstree` migrates only objects with existing containers (#3283)
 
 ### Removed
 - SN `apiclient.allow_external` config (#3235)


### PR DESCRIPTION
Read actual containers from FS chain on start and skip objects whose containers are not in the actual list. In practice, it's going to save us a lot of time.