### PR TITLE
metabase: fix meta data cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 - Bearer token signed not by its issuer is no longer passed (#3216)
 - In-object session token signed not by its issuer is no longer passed by SN and CLI (#3216)
 - Object signed not by its owner is no longer passed by SN (#3264)
+- Metabase indexes cleanup (#3290)
 
 ### Changed
 - IR calls `ObjectService.SearchV2` to select SG objects now (#3144)


### PR DESCRIPTION
`bytes.LastIndex` can be buggy in this case since filter's value _may_ have a zero byte in an object ID, checksum, etc. (any system header fields in other words). In particular, it closes #3277.