### PR TITLE
peapod-to-fstree: ignore corrupt objects without container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Changelog for NeoFS Node
 - neofs-adm uses alphabet0/1/2 names for wallet files by default now (#3268)
 - Distribute load in writecache during flushing (#3261)
 - Faster migration in peapod-to-fstree (#3280)
-- `peapod-to-fstree` migrates only objects with existing containers (#3283)
+- `peapod-to-fstree` migrates only objects with existing containers (#3283, #3306)
 - Storage Node now prohibits parents with their own parents (object split of already split object) (#2451) 
 
 ### Removed

--- a/cmd/peapod-to-fstree/main.go
+++ b/cmd/peapod-to-fstree/main.go
@@ -46,7 +46,14 @@ func (s *onlyObjectsWithContainersStorage) Iterate(objHandler func(oid.Address, 
 		}
 
 		return objHandler(addr, data, id)
-	}, nil)
+	}, func(addr oid.Address, err error) error {
+		_, found := s.containers[addr.Container()]
+		if !found {
+			log.Printf("skipping corrupted object without container '%s': %v\n", addr, err)
+			return nil
+		}
+		return err
+	})
 }
 
 func main() {


### PR DESCRIPTION
I don't know how to check it, but in theory it should work.