### PR TITLE
morph/client: sync subs restoration with main notify cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for NeoFS Node
 - Exit code of CLI commands for already removed object (#3300)
 - CLI timeout can expire before RPC (#3302)
 - `accounting balance` request without timeout (#3302)
+- Possible NEO chain client's infinite reconnection loop (#3292)
 
 ### Changed
 - IR calls `ObjectService.SearchV2` to select SG objects now (#3144)


### PR DESCRIPTION
If connection was lost quite fast after the previous reconnection, a separate restoration routine may decline `for`'s next reconnection iteration and lead to reconnection deadlock. Do not reuse restoration channel b/w iterations. Closes #3292.