### PR TITLE
cli: fix --owner flag of accounting balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog for NeoFS Node
 - Possible NEO chain client's infinite reconnection loop (#3292)
 - Multiple flush same big objects (#3317)
 - Split object middle children treated as root objects in SearchV2 (#3316)
+- Broken "owner" parameter of "accounting balance" CLI command (#3325)
 
 ### Changed
 - IR calls `ObjectService.SearchV2` to select SG objects now (#3144)

--- a/cmd/neofs-cli/modules/accounting/balance.go
+++ b/cmd/neofs-cli/modules/accounting/balance.go
@@ -36,7 +36,10 @@ var accountingBalanceCmd = &cobra.Command{
 		if balanceOwner == "" {
 			idUser = user.NewFromECDSAPublicKey(pk.PublicKey)
 		} else {
-			return fmt.Errorf("can't decode owner ID wallet address: %w", idUser.DecodeString(balanceOwner))
+			err = idUser.DecodeString(balanceOwner)
+			if err != nil {
+				return fmt.Errorf("can't decode owner ID wallet address: %w", err)
+			}
 		}
 
 		ctx, cancel := commonflags.GetCommandContext(cmd)


### PR DESCRIPTION
Regression of 9ac84e30c21:
    can't decode owner ID wallet address: %!w(<nil>)