### PR TITLE
metabase: fix NPE in metadata search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog for NeoFS Node
 - Broken "owner" parameter of "accounting balance" CLI command (#3325)
 - Unclosed network connections in CLI (#3326)
 - SN no longer fails tombstone verification on `ALREADY_REMOVED` member's status (#3327)
+- Panic in search (#3333)
 
 ### Changed
 - IR calls `ObjectService.SearchV2` to select SG objects now (#3144)

--- a/pkg/local_object_storage/metabase/metadata.go
+++ b/pkg/local_object_storage/metabase/metadata.go
@@ -302,7 +302,7 @@ func (db *DB) searchUnfiltered(cnr cid.ID, cursor *objectcore.SearchCursor, coun
 		if cursor != nil && bytes.Equal(k, cursor.PrimarySeekKey) { // cursor is the last response element, so go next
 			k, _ = mbc.Next()
 		}
-		for ; k[0] == metaPrefixID; k, _ = mbc.Next() {
+		for ; len(k) > 0 && k[0] == metaPrefixID; k, _ = mbc.Next() {
 			if n == count { // there are still elements
 				newCursor = res[n-1].ID[:]
 				return nil


### PR DESCRIPTION
Next() can always return nil. Fixes

goroutine 8378 [running]:
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase.(*DB).searchUnfiltered.func1(0xc009167420)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/metadata.go:305 +0x4e8
go.etcd.io/bbolt.(*DB).View(0xc0001d5a00?, 0xc009222f38)
	go.etcd.io/bbolt@v1.4.0/db.go:939 +0x6c
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase.(*DB).searchUnfiltered(0xc00148e030, {0xc0, 0xe6, 0xf5, 0xe7, 0x60, 0x1e, 0x7e, 0x28, 0xe0, ...}, ...)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/metadata.go:294 +0x156
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase.(*DB).Search(0x46fafd?, {0xc0, 0xe6, 0xf5, 0xe7, 0x60, 0x1e, 0x7e, 0x28, 0xe0, ...}, ...)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/metadata.go:231 +0x48
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase.(*DB).Select(0xc00148e030, {0xc0, 0xe6, 0xf5, 0xe7, 0x60, 0x1e, 0x7e, 0x28, 0xe0, ...}, ...)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase/select.go:52 +0x4aa
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard.(*Shard).Select(0x529b598f63e8fd8d?, {0xc0, 0xe6, 0xf5, 0xe7, 0x60, 0x1e, 0x7e, 0x28, 0xe0, ...}, ...)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/select.go:27 +0x108
github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine.(*StorageEngine).Select(0xc0001ec2a0, {0xc0, 0xe6, 0xf5, 0xe7, 0x60, 0x1e, 0x7e, 0x28, 0xe0, ...}, ...)
	github.com/nspcc-dev/neofs-node/pkg/local_object_storage/engine/select.go:35 +0x393
github.com/nspcc-dev/neofs-node/pkg/services/object/search.(*storageEngineWrapper).search(0xff?, 0xc1fc4f8184419982?)
	github.com/nspcc-dev/neofs-node/pkg/services/object/search/util.go:112 +0x56
github.com/nspcc-dev/neofs-node/pkg/services/object/search.(*execCtx).executeLocal(0xc009171b80)
	github.com/nspcc-dev/neofs-node/pkg/services/object/search/local.go:8 +0x3c
github.com/nspcc-dev/neofs-node/pkg/services/object/search.(*execCtx).execute(0xc009171b80, {0x13e5d10, 0xc009404030})
	github.com/nspcc-dev/neofs-node/pkg/services/object/search/search.go:44 +0x46
github.com/nspcc-dev/neofs-node/pkg/services/object/search.(*Service).Search(0xc000392180, {0x13e5d10, 0xc009404030}, {{0x13d96c0, 0xc00948e280}, 0xc009498080, {0xc0, 0xe6, 0xf5, 0xe7, ...}, ...})
	github.com/nspcc-dev/neofs-node/pkg/services/object/search/search.go:35 +0x1ce
main.(*objectSvc).Search(0x13e5d10?, {0x13e5d10?, 0xc009404030?}, {{0x13d96c0, 0xc00948e280}, 0xc009498080, {0xc0, 0xe6, 0xf5, 0xe7, ...}, ...})
	github.com/nspcc-dev/neofs-node/cmd/neofs-node/object.go:78 +0x58
github.com/nspcc-dev/neofs-node/pkg/services/object.(*server).Search(0xc00020c210, 0xc0091e5380, {0x13ecdb0, 0xc00908fb20})
	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:1518 +0x584
github.com/nspcc-dev/neofs-sdk-go/proto/object._ObjectService_Search_Handler({0x1167aa0, 0xc00020c210}, {0x13eaac8, 0xc0090f9ea0})
	github.com/nspcc-dev/neofs-sdk-go@v1.0.0-rc.13.0.20250417140404-8d69cb0e9a25/proto/object/service_grpc.pb.go:817 +0x107
google.golang.org/grpc.(*Server).processStreamingRPC(0xc0014b0200, {0x13e5d10, 0xc00936bef0}, 0xc0091eacc0, 0xc00148f470, 0x1d71e80, 0x0)
	google.golang.org/grpc@v1.70.0/server.go:1690 +0x126b
google.golang.org/grpc.(*Server).handleStream(0xc0014b0200, {0x13e6ae0, 0xc000431520}, 0xc0091eacc0)
	google.golang.org/grpc@v1.70.0/server.go:1814 +0xb69
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.70.0/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 568
	google.golang.org/grpc@v1.70.0/server.go:1041 +0x125