### PR TITLE
go.mod: upgrade to NeoGo 0.109.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Changelog for NeoFS Node
 ### Updated
 - `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250417140404-8d69cb0e9a25` (#3255)
 - `github.com/nspcc-dev/neofs-contract` dependency to `v0.22.0` (#3282, #3305, #3323)
-- `github.com/nspcc-dev/neo-go` dependency to `v0.108.2-0.20250414115617-823a05fcc10b` (#3298)
+- `github.com/nspcc-dev/neo-go` dependency to `v0.109.0` (#3298, #3335)
 
 ### Updating from v0.45.2
 `apiclient.allow_external` field must be dropped from any SN configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 - SN now supports `ObjectService` requests, objects and session/bearer tokens signed using N3 account scheme (#3303, #3305)
 - SN attempts to read containers/eACLs calling new Container contract's `getContainerData`/`getEACLData` methods (#3323)
 - `request create-container` command to NeoFS CLI (#3319)
+- `max_valid_until_block_increment` setting to IR consensus configuration (#3335)
 
 ### Fixed
 - Bearer token signed not by its issuer is no longer passed (#3216)

--- a/cmd/neofs-ir/validate_test.go
+++ b/cmd/neofs-ir/validate_test.go
@@ -198,9 +198,10 @@ func TestCheckForUnknownFieldsExample(t *testing.T) {
 					Type: "boltdb",
 					Path: "./db/morph.bolt",
 				},
-				TimePerBlock:       time.Second,
-				MaxTraceableBlocks: 11520,
-				SeedNodes:          []string{"node2", "node3:20333"},
+				TimePerBlock:                time.Second,
+				MaxTraceableBlocks:          11520,
+				MaxValidUntilBlockIncrement: 3600,
+				SeedNodes:                   []string{"node2", "node3:20333"},
 				Hardforks: config.Hardforks{
 					Name: map[string]uint32{
 						"name": 1730000,

--- a/config/example/ir.yaml
+++ b/config/example/ir.yaml
@@ -41,6 +41,8 @@ fschain:
       # Must not be negative
     max_traceable_blocks: 11520 # Optional length of the chain accessible to smart contracts. Defaults to 17280.
       # Must not be greater than 4294967295
+    max_valid_until_block_increment: 3600 # Optional transaction validity period relative to the current height. Defaults to 8640.
+      # Must not be greater than 4294967295
     seed_nodes: # Optional list of existing nodes to communicate with over Neo P2P protocol. By default, node runs as standalone
       # Same format as 'p2p.listen'
       - node2

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/nspcc-dev/hrw/v2 v2.0.3
 	github.com/nspcc-dev/locode-db v0.6.0
-	github.com/nspcc-dev/neo-go v0.108.2-0.20250414115617-823a05fcc10b
+	github.com/nspcc-dev/neo-go v0.109.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.22.0
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250417140404-8d69cb0e9a25
@@ -51,6 +51,7 @@ require (
 	github.com/consensys/gnark-crypto v0.17.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.2 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -73,7 +74,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nspcc-dev/dbft v0.3.3-0.20250321140139-7462b47e4d2d // indirect
 	github.com/nspcc-dev/go-ordered-json v0.0.0-20250226190835-fb3f82b1f468 // indirect
-	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250410112417-d414d8a86b83 // indirect
+	github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115 // indirect
 	github.com/nspcc-dev/rfc6979 v0.2.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
+github.com/decred/dcrd/crypto/ripemd160 v1.0.2 h1:TvGTmUBHDU75OHro9ojPLK+Yv7gDl2hnUvRocRCjsys=
+github.com/decred/dcrd/crypto/ripemd160 v1.0.2/go.mod h1:uGfjDyePSpa75cSQLzNdVmWlbQMBuiJkvXw/MNKRY4M=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -189,10 +191,10 @@ github.com/nspcc-dev/hrw/v2 v2.0.3 h1:GUIitIiDpAaQat9SZccp7XVAuwtqaM40+uZ9D8Q4A8
 github.com/nspcc-dev/hrw/v2 v2.0.3/go.mod h1:VWlFSGGPcHG1abuIDJb5u83tIF2EqOatC8Z7svZmgWQ=
 github.com/nspcc-dev/locode-db v0.6.0 h1:EdRUug+sL0EMLZgucLETD6bnegKjyEZh+D5x4r5VMvY=
 github.com/nspcc-dev/locode-db v0.6.0/go.mod h1:mJLXdzlcRucr3AFUvf5fJH+rFv1bJuU85e1jtDHDTz8=
-github.com/nspcc-dev/neo-go v0.108.2-0.20250414115617-823a05fcc10b h1:9tz24azDSs/rPa4XyMTmTaC8cpDEuWlRdzIRrkqWifU=
-github.com/nspcc-dev/neo-go v0.108.2-0.20250414115617-823a05fcc10b/go.mod h1:kG04QGJIyW3lm61YYsSG3gWIHJh3m6rilwdoKxfxdAI=
-github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250410112417-d414d8a86b83 h1:/KgsA/svNkniRm6sZr3jdCBd45WILNzaOrjC1b+wn8g=
-github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250410112417-d414d8a86b83/go.mod h1:3byneDNT60tiD8MSyGSyjpI1uVp9v+coySegJoQPF8c=
+github.com/nspcc-dev/neo-go v0.109.0 h1:1oqIjDOB3mOlsdufvWNv8AYX3I8Kk3f0lhZyPzbuzGw=
+github.com/nspcc-dev/neo-go v0.109.0/go.mod h1:Sv/mc0zbRUauA2HhA0TMy6L/lYMIe7pnI2QQers9elM=
+github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115 h1:VWIceT+fh7sB5H+J5hhOIN+pWCy9/PHcvpvjSXteIQg=
+github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115/go.mod h1:3byneDNT60tiD8MSyGSyjpI1uVp9v+coySegJoQPF8c=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK0EMGLvunXcFyq7fBURS/CsN4MH+4nlYiqn6pTwWAU=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.22.0 h1:dxSm/NYyc7ZtWlhskH4e4yzXxf5pBCEOR3lLLmV98i8=

--- a/pkg/innerring/config/fschain.go
+++ b/pkg/innerring/config/fschain.go
@@ -43,6 +43,11 @@ type Consensus struct {
 	// Optional: defaults to 17280.
 	MaxTraceableBlocks uint32 `mapstructure:"max_traceable_blocks"`
 
+	// Transaction validity limit relative to the current height.
+	//
+	// Optional: defaults to 8640.
+	MaxValidUntilBlockIncrement uint32 `mapstructure:"max_valid_until_block_increment"`
+
 	// List of nodes' addresses to communicate with over Neo P2P protocol in
 	// 'host:port' format.
 	//

--- a/pkg/innerring/config_test.go
+++ b/pkg/innerring/config_test.go
@@ -357,6 +357,8 @@ fschain:
 				{kvF("time_per_block", "not a duration")},
 				{kvF("max_traceable_blocks", -1)},
 				{kvF("max_traceable_blocks", math.MaxUint32+1)},
+				{kvF("max_valid_until_block_increment", -1)},
+				{kvF("max_valid_until_block_increment", math.MaxUint32+1)},
 				{kvF("hardforks", "not a dictionary")},
 				{kvF("hardforks", map[string]any{"name": "not a number"})},
 				{kvF("hardforks", map[string]any{"name": -1})},

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -152,11 +152,13 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 	cfgBaseProto.StandbyCommittee = standByCommittee
 
 	cfgBaseProto.TimePerBlock = cfg.TimePerBlock
+	cfgBaseProto.Genesis.TimePerBlock = cfg.TimePerBlock
 	cfgBaseProto.SeedList = cfg.SeedNodes
 	cfgBaseProto.VerifyTransactions = true
 	cfgBaseProto.P2PSigExtensions = true
 	cfgBaseProto.P2PNotaryRequestPayloadPoolSize = int(cfg.P2PNotaryRequestPayloadPoolSize)
 	cfgBaseProto.MaxTraceableBlocks = cfg.MaxTraceableBlocks
+	cfgBaseProto.Genesis.MaxTraceableBlocks = cfg.MaxTraceableBlocks
 	cfgBaseProto.Hardforks = cfg.Hardforks.Name
 	if cfg.ValidatorsHistory.Height != nil {
 		cfgBaseProto.ValidatorsHistory = make(map[uint32]uint32, len(cfg.ValidatorsHistory.Height))
@@ -286,7 +288,6 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 	cfgConsensus.ProtocolConfiguration = bc.GetConfig().ProtocolConfiguration
 	cfgConsensus.RequestTx = netServer.RequestTx
 	cfgConsensus.StopTxFlow = netServer.StopTxFlow
-	cfgConsensus.TimePerBlock = cfg.TimePerBlock
 	cfgConsensus.Wallet = neowallet
 
 	consensusService, err := consensus.NewService(cfgConsensus)

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -121,6 +121,9 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 	if cfg.MaxTraceableBlocks == 0 {
 		cfg.MaxTraceableBlocks = 17280
 	}
+	if cfg.MaxValidUntilBlockIncrement == 0 {
+		cfg.MaxValidUntilBlockIncrement = 8640
+	}
 	if cfg.P2P.Ping.Interval == 0 {
 		cfg.P2P.Ping.Interval = 30 * time.Second
 	}
@@ -159,6 +162,8 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 	cfgBaseProto.P2PNotaryRequestPayloadPoolSize = int(cfg.P2PNotaryRequestPayloadPoolSize)
 	cfgBaseProto.MaxTraceableBlocks = cfg.MaxTraceableBlocks
 	cfgBaseProto.Genesis.MaxTraceableBlocks = cfg.MaxTraceableBlocks
+	cfgBaseProto.MaxValidUntilBlockIncrement = cfg.MaxValidUntilBlockIncrement
+	cfgBaseProto.Genesis.MaxValidUntilBlockIncrement = cfg.MaxValidUntilBlockIncrement
 	cfgBaseProto.Hardforks = cfg.Hardforks.Name
 	if cfg.ValidatorsHistory.Height != nil {
 		cfgBaseProto.ValidatorsHistory = make(map[uint32]uint32, len(cfg.ValidatorsHistory.Height))


### PR DESCRIPTION
Adapt to the new TimePerBlock handling (it's a part of the Policy contract now),