### PR TITLE
configutil: fix ENV variable rewrite entire structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Changelog for NeoFS Node
 - IR contract approval no longer supports neofsid accounts (#3256)
 - IR no longer processes bind/unbind neofsid requests (#3256)
 - SN `ExternalAddr` attribute is ignored now (#3235)
-- Use list instead of maps for options in node config (#3204)
+- Use list instead of maps for options in node config (#3204, #3341)
 - Token and object authentication errors are more detailed in status responses now (#3216, #3264)
 - IR uses NNS names for alphabet contracts now instead of Glagolitsa (#3268)
 - neofs-adm can handle any wallet names in its configuration (#3268)

--- a/internal/configutil/env.go
+++ b/internal/configutil/env.go
@@ -79,6 +79,9 @@ func processStructSlice(v *viper.Viper, elemType reflect.Type, baseKey, envPrefi
 	for i := 0; ; i++ {
 		idxPrefix := fmt.Sprintf("%s_%d", makeEnvKey(baseKey), i)
 		item := map[string]any{}
+		if i < len(sl) {
+			item = sl[i].(map[string]any)
+		}
 		found := false
 
 		for j := range elemType.NumField() {
@@ -116,9 +119,7 @@ func processStructSlice(v *viper.Viper, elemType reflect.Type, baseKey, envPrefi
 		if !found && i >= len(sl) {
 			break
 		}
-		if !found {
-			item = sl[i].(map[string]any)
-		} else {
+		if found {
 			updated = true
 		}
 		result = append(result, item)


### PR DESCRIPTION
Fix that new variable from the ENV that is part of an array can rewrite the entire structure, not just this variable.

https://github.com/nspcc-dev/neofs-testcases/issues/1051#issuecomment-2873675554