### PR TITLE
ir: unify basic income collection and distribution, fix #3338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog for NeoFS Node
 - SN no longer fails tombstone verification on `ALREADY_REMOVED` member's status (#3327)
 - Panic in search (#3333)
 - Insufficient fee for some operations (#3339)
+- Race between basic income processing stages leading to distribution failures in some cases (#3338)
 
 ### Changed
 - IR calls `ObjectService.SearchV2` to select SG objects now (#3144)

--- a/pkg/innerring/blocktimer.go
+++ b/pkg/innerring/blocktimer.go
@@ -33,8 +33,7 @@ type (
 		stopEstimationDMul uint32 // X: X/Y of epoch in blocks
 		stopEstimationDDiv uint32 // Y: X/Y of epoch in blocks
 
-		collectBasicIncome    subEpochEventHandler
-		distributeBasicIncome subEpochEventHandler
+		basicIncome subEpochEventHandler
 	}
 )
 
@@ -76,30 +75,16 @@ func newEpochTimer(args *epochTimerArgs) *timer.BlockTimer {
 		})
 
 	epochTimer.OnDelta(
-		args.collectBasicIncome.durationMul,
-		args.collectBasicIncome.durationDiv,
+		args.basicIncome.durationMul,
+		args.basicIncome.durationDiv,
 		func() {
 			epochN := args.epoch.EpochCounter()
 			if epochN == 0 { // estimates are invalid in genesis epoch
 				return
 			}
 
-			args.collectBasicIncome.handler(
-				settlement.NewBasicIncomeCollectEvent(epochN - 1),
-			)
-		})
-
-	epochTimer.OnDelta(
-		args.distributeBasicIncome.durationMul,
-		args.distributeBasicIncome.durationDiv,
-		func() {
-			epochN := args.epoch.EpochCounter()
-			if epochN == 0 { // estimates are invalid in genesis epoch
-				return
-			}
-
-			args.distributeBasicIncome.handler(
-				settlement.NewBasicIncomeDistributeEvent(epochN - 1),
+			args.basicIncome.handler(
+				settlement.NewBasicIncomeEvent(epochN - 1),
 			)
 		})
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -1005,13 +1005,8 @@ func New(ctx context.Context, log *zap.Logger, cfg *config.Config, errChan chan<
 		epoch:              server,
 		stopEstimationDMul: cfg.Timers.StopEstimation.Mul,
 		stopEstimationDDiv: cfg.Timers.StopEstimation.Div,
-		collectBasicIncome: subEpochEventHandler{
-			handler:     settlementProcessor.HandleIncomeCollectionEvent,
-			durationMul: cfg.Timers.CollectBasicIncome.Mul,
-			durationDiv: cfg.Timers.CollectBasicIncome.Div,
-		},
-		distributeBasicIncome: subEpochEventHandler{
-			handler:     settlementProcessor.HandleIncomeDistributionEvent,
+		basicIncome: subEpochEventHandler{
+			handler:     settlementProcessor.HandleBasicIncomeEvent,
 			durationMul: cfg.Timers.CollectBasicIncome.Mul,
 			durationDiv: cfg.Timers.CollectBasicIncome.Div,
 		},

--- a/pkg/innerring/processors/settlement/events.go
+++ b/pkg/innerring/processors/settlement/events.go
@@ -10,10 +10,7 @@ type AuditEvent struct {
 	epoch uint64
 }
 
-type (
-	BasicIncomeCollectEvent    = AuditEvent
-	BasicIncomeDistributeEvent = AuditEvent
-)
+type BasicIncomeEvent = AuditEvent
 
 // MorphEvent implements Neo: FS chain event.
 func (e AuditEvent) MorphEvent() {}
@@ -31,16 +28,9 @@ func (e AuditEvent) Epoch() uint64 {
 	return e.epoch
 }
 
-// NewBasicIncomeCollectEvent for epoch.
-func NewBasicIncomeCollectEvent(epoch uint64) event.Event {
-	return BasicIncomeCollectEvent{
-		epoch: epoch,
-	}
-}
-
-// NewBasicIncomeDistributeEvent for epoch.
-func NewBasicIncomeDistributeEvent(epoch uint64) event.Event {
-	return BasicIncomeDistributeEvent{
+// NewBasicIncomeEvent for epoch.
+func NewBasicIncomeEvent(epoch uint64) event.Event {
+	return BasicIncomeEvent{
 		epoch: epoch,
 	}
 }

--- a/pkg/innerring/processors/settlement/processor.go
+++ b/pkg/innerring/processors/settlement/processor.go
@@ -2,9 +2,7 @@ package settlement
 
 import (
 	"fmt"
-	"sync"
 
-	"github.com/nspcc-dev/neofs-node/pkg/innerring/processors/settlement/basic"
 	nodeutil "github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
@@ -27,9 +25,6 @@ type (
 		auditProc AuditProcessor
 
 		basicIncome BasicIncomeInitializer
-
-		contextMu      sync.Mutex
-		incomeContexts map[uint64]*basic.IncomeSettlementContext
 	}
 
 	// Prm groups the required parameters of Processor's constructor.
@@ -67,11 +62,10 @@ func New(prm Prm, opts ...Option) *Processor {
 	)
 
 	return &Processor{
-		log:            o.log,
-		state:          prm.State,
-		pool:           pool,
-		auditProc:      prm.AuditProcessor,
-		basicIncome:    prm.BasicIncome,
-		incomeContexts: make(map[uint64]*basic.IncomeSettlementContext),
+		log:         o.log,
+		state:       prm.State,
+		pool:        pool,
+		auditProc:   prm.AuditProcessor,
+		basicIncome: prm.BasicIncome,
 	}
 }

--- a/pkg/innerring/settlement.go
+++ b/pkg/innerring/settlement.go
@@ -215,14 +215,8 @@ func (s settlementDeps) Transfer(sender, recipient user.ID, amount *big.Int, det
 		zap.String("details", hex.EncodeToString(details)),
 	)
 
-	if !amount.IsInt64() {
-		s.log.Error("amount can not be represented as an int64")
-
-		return
-	}
-
 	params := balanceClient.TransferPrm{
-		Amount:  amount.Int64(),
+		Amount:  amount,
 		From:    sender,
 		To:      recipient,
 		Details: details,

--- a/pkg/innerring/settlement.go
+++ b/pkg/innerring/settlement.go
@@ -215,14 +215,7 @@ func (s settlementDeps) Transfer(sender, recipient user.ID, amount *big.Int, det
 		zap.String("details", hex.EncodeToString(details)),
 	)
 
-	params := balanceClient.TransferPrm{
-		Amount:  amount,
-		From:    sender,
-		To:      recipient,
-		Details: details,
-	}
-
-	err := s.balanceClient.TransferX(params)
+	err := s.balanceClient.TransferX(sender, recipient, amount, details)
 	if err != nil {
 		log.Error(fmt.Sprintf("%s: could not send transfer", s.settlementCtx),
 			zap.Error(err),

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -3,7 +3,6 @@ package balance
 import (
 	"fmt"
 
-	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
@@ -22,22 +21,12 @@ type TransferPrm struct {
 // TransferX transfers p.Amount of GASe-12 from p.From to p.To
 // with details p.Details through direct smart contract call.
 func (c *Client) TransferX(p TransferPrm) error {
-	from, err := address.StringToUint160(p.From.EncodeToString())
-	if err != nil {
-		return err
-	}
-
-	to, err := address.StringToUint160(p.To.EncodeToString())
-	if err != nil {
-		return err
-	}
-
 	prm := client.InvokePrm{}
 	prm.SetMethod(transferXMethod)
-	prm.SetArgs(from, to, p.Amount, p.Details)
+	prm.SetArgs(p.From.ScriptHash(), p.To.ScriptHash(), p.Amount, p.Details)
 	prm.InvokePrmOptional = p.InvokePrmOptional
 
-	err = c.client.Invoke(prm)
+	err := c.client.Invoke(prm)
 	if err != nil {
 		return fmt.Errorf("could not invoke method (%s): %w", transferXMethod, err)
 	}

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -2,6 +2,7 @@ package balance
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
@@ -9,7 +10,7 @@ import (
 
 // TransferPrm groups parameters of TransferX method.
 type TransferPrm struct {
-	Amount int64
+	Amount *big.Int
 
 	From, To user.ID
 

--- a/pkg/morph/client/balance/transfer.go
+++ b/pkg/morph/client/balance/transfer.go
@@ -8,24 +8,12 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 )
 
-// TransferPrm groups parameters of TransferX method.
-type TransferPrm struct {
-	Amount *big.Int
-
-	From, To user.ID
-
-	Details []byte
-
-	client.InvokePrmOptional
-}
-
-// TransferX transfers p.Amount of GASe-12 from p.From to p.To
-// with details p.Details through direct smart contract call.
-func (c *Client) TransferX(p TransferPrm) error {
+// TransferX wraps smart contract call and allows to transfer the given amount
+// of picoGAS from "from" to "to" account with given details.
+func (c *Client) TransferX(from user.ID, to user.ID, amount *big.Int, details []byte) error {
 	prm := client.InvokePrm{}
 	prm.SetMethod(transferXMethod)
-	prm.SetArgs(p.From.ScriptHash(), p.To.ScriptHash(), p.Amount, p.Details)
-	prm.InvokePrmOptional = p.InvokePrmOptional
+	prm.SetArgs(from.ScriptHash(), to.ScriptHash(), amount, details)
 
 	err := c.client.Invoke(prm)
 	if err != nil {


### PR DESCRIPTION
Distribution is tightly related to collection and if we run them asynchronously we easily end up with

    info	settlement/calls.go:54	start basic income collection	{"epoch": 5}
    info	settlement/calls.go:99	start basic income distribution	{"epoch": 5}
    info	basic/distribute.go:17	zero total size of all estimated containers, skip distribution of funds

Even though there are valid estimations:

    debug	innerring/settlement.go:240	basic income: transfer was successfully sent	{"sender": "NPBzbkvZUcWjyMNmiQr8hXGg1E7jjHxkqe", "recipient": "NL1H4he1ggRajT1ZVqn23zveMRaH9jDvfh", "amount (GASe-12)": "1303851604461", "details": "410500000000000000"}