### PR TITLE
go.mod: upgrade to the latest and greatest NeoGo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Changelog for NeoFS Node
 ### Updated
 - `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250514113748-9abf8c619246` (#3255, #3345)
 - `github.com/nspcc-dev/neofs-contract` dependency to `v0.22.0` (#3282, #3305, #3323)
-- `github.com/nspcc-dev/neo-go` dependency to `v0.109.0` (#3298, #3335)
+- `github.com/nspcc-dev/neo-go` dependency to `v0.109.1` (#3298, #3335, #3348)
 
 ### Updating from v0.45.2
 `apiclient.allow_external` field must be dropped from any SN configuration.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/nspcc-dev/hrw/v2 v2.0.3
 	github.com/nspcc-dev/locode-db v0.6.0
-	github.com/nspcc-dev/neo-go v0.109.0
+	github.com/nspcc-dev/neo-go v0.109.1
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.22.0
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250514113748-9abf8c619246

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/nspcc-dev/hrw/v2 v2.0.3 h1:GUIitIiDpAaQat9SZccp7XVAuwtqaM40+uZ9D8Q4A8
 github.com/nspcc-dev/hrw/v2 v2.0.3/go.mod h1:VWlFSGGPcHG1abuIDJb5u83tIF2EqOatC8Z7svZmgWQ=
 github.com/nspcc-dev/locode-db v0.6.0 h1:EdRUug+sL0EMLZgucLETD6bnegKjyEZh+D5x4r5VMvY=
 github.com/nspcc-dev/locode-db v0.6.0/go.mod h1:mJLXdzlcRucr3AFUvf5fJH+rFv1bJuU85e1jtDHDTz8=
-github.com/nspcc-dev/neo-go v0.109.0 h1:1oqIjDOB3mOlsdufvWNv8AYX3I8Kk3f0lhZyPzbuzGw=
-github.com/nspcc-dev/neo-go v0.109.0/go.mod h1:Sv/mc0zbRUauA2HhA0TMy6L/lYMIe7pnI2QQers9elM=
+github.com/nspcc-dev/neo-go v0.109.1 h1:2Bm7OSI271pBeDTqmjVH35iuD9yML8K7hi24FijuRZo=
+github.com/nspcc-dev/neo-go v0.109.1/go.mod h1:Sv/mc0zbRUauA2HhA0TMy6L/lYMIe7pnI2QQers9elM=
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115 h1:VWIceT+fh7sB5H+J5hhOIN+pWCy9/PHcvpvjSXteIQg=
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115/go.mod h1:3byneDNT60tiD8MSyGSyjpI1uVp9v+coySegJoQPF8c=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK0EMGLvunXcFyq7fBURS/CsN4MH+4nlYiqn6pTwWAU=


### PR DESCRIPTION
0.109.1 is out and we need it.