### PR TITLE
object: optimize search result merger for EQ case, fix #3347

### DIFF
--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -2040,8 +2040,11 @@ func (s *Server) ProcessSearch(ctx context.Context, req *protoobject.SearchV2Req
 			firstFilter *object.SearchFilter
 		)
 		if len(attrs) > 0 {
-			firstAttr = fs[0].Header()
 			firstFilter = &ofs[0].SearchFilter
+			// No reason to compare equal values.
+			if body.Filters[0].MatchType != protoobject.MatchType_STRING_EQUAL {
+				firstAttr = fs[0].Header()
+			}
 		}
 		cmpInt := firstAttr != "" && objectcore.IsIntegerSearchOp(fs[0].Operation())
 		var more bool


### PR DESCRIPTION
1. When the first filter is EQ comparing values makes zero sense.
2. We've got a panic after 5249ab03a1f14e721d322cc0971e43a67abc18d1: panic: runtime error: index out of range [0] with length 0

    goroutine 16844 [running]:
    github.com/nspcc-dev/neofs-node/pkg/core/object.MergeSearchResults(0x3e8?, {0xc00927e300, 0x12}, 0x0, {0xc001deaa20, 0x4, 0x834923cc0a0b85cb?}, {0xc006bde668, 0x4, 0x8})
	github.com/nspcc-dev/neofs-node/pkg/core/object/metadata.go:81 +0x110f
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).ProcessSearch(0xc00020c420, {0x13dde30, 0xc003099b30}, 0xc0019232c0)
	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:2048 +0xc53
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).processSearchRequest(0xc00020c420, {0x13dde30, 0xc003099b30}, 0xc0019232c0)
	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:1904 +0x646
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).SearchV2(0xc00020c420, {0x13dde30, 0xc003099b30}, 0xc0019232c0)
	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:1841 +0x2f3
    github.com/nspcc-dev/neofs-sdk-go/proto/object._ObjectService_SearchV2_Handler({0x11627c0, 0xc00020c420}, {0x13dde30, 0xc003099b30}, 0xc00212ac80, 0x0)
	github.com/nspcc-dev/neofs-sdk-go@v1.0.0-rc.13.0.20250514113748-9abf8c619246/proto/object/service_grpc.pb.go:839 +0x1a6
    google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000e9400, {0x13dde30, 0xc003099aa0}, 0xc0019618c0, 0xc000346d50, 0x1d65bb0, 0x0)
	google.golang.org/grpc@v1.70.0/server.go:1400 +0x103b
    google.golang.org/grpc.(*Server).handleStream(0xc0000e9400, {0x13dec00, 0xc002dc96c0}, 0xc0019618c0)
	google.golang.org/grpc@v1.70.0/server.go:1810 +0xbaa
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.70.0/server.go:1030 +0x7f
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 16832
	google.golang.org/grpc@v1.70.0/server.go:1041 +0x125

  And it's related to the fact that we're trying to compare missing values.