### PR TITLE
basic: skip basic income distribution if rate is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Basic income collection/distribution in networks with rate set to zero (#3352)
 
 ### Changed
 

--- a/pkg/innerring/processors/settlement/basic/collect.go
+++ b/pkg/innerring/processors/settlement/basic/collect.go
@@ -25,6 +25,11 @@ func (inc *IncomeSettlementContext) Collect() {
 		return
 	}
 
+	if cachedRate == 0 {
+		inc.log.Info("basic income rate is zero, skipping collection")
+		return
+	}
+
 	cnrEstimations, err := inc.estimations.Estimations(inc.epoch)
 	if err != nil {
 		inc.log.Error("can't fetch container size estimations",


### PR DESCRIPTION
Fixes #2186.