### PR TITLE
blockchain: decrease default proto tick interval

### DIFF
--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -116,7 +116,7 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 		cfg.P2P.DialTimeout = time.Minute
 	}
 	if cfg.P2P.ProtoTickInterval == 0 {
-		cfg.P2P.ProtoTickInterval = 2 * time.Second
+		cfg.P2P.ProtoTickInterval = 500 * time.Millisecond
 	}
 	if cfg.MaxTraceableBlocks == 0 {
 		cfg.MaxTraceableBlocks = 17280


### PR DESCRIPTION
Context: slow P2P sync on NeoFS IR nodes with internal consensus. This commit decreases default P2P proto tick interval which directly affects the frequency of ping/pong message handlers. A side effect is more frequent requests for missing blocks, and hence, faster P2P sync. Also, I'd say that previous value (2s) is too slow for 1-second networks.

Despite the fact that P2P synchronisation benefits from this commit, the real effect of this commit on the NeoFS performance must be evaluated, because this commit significantly increases the number of P2P messages in the network.