### PR TITLE
Update SDK to the latest master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 - Split object with a missing link object can't be retrieved in some cases (#3337)
 - Invalid URI error text in `request create-container` CLI command (#3366)
 - Invalid object ID error text in `object delete` CLI command (#3366)
+- Old objects without a session token lifetime are not valid (#3373)
 
 ### Changed
 - Make `MaintenanceModeAllowed` network setting always allowed (#3360)
@@ -18,6 +19,7 @@ Changelog for NeoFS Node
 ### Removed
 
 ### Updated
+- `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250530123548-f8dbe53f3996` (#3373)
 
 ### Updating from v0.46.1
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.109.1
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.22.0
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250516062127-1f3abc2c67ca
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996
 	github.com/nspcc-dev/tzhash v1.8.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.22.0 h1:dxSm/NYyc7ZtWlhskH4e4yzXxf5pBCEOR3lLLmV98i8=
 github.com/nspcc-dev/neofs-contract v0.22.0/go.mod h1:it6Su92UvEFQDsMOfDIXapLu0j5TQSOvkS2YdUlPdgo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250516062127-1f3abc2c67ca h1:RNdFnPHOe1Pz5yyJka6hVefYP1HqBRiTLmRI1g/f0wE=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250516062127-1f3abc2c67ca/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996 h1:zEgBAbj3vNex6a2amiWtDOdL25MmtQBDZUhmNYNAK+w=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
 github.com/nspcc-dev/rfc6979 v0.2.3 h1:QNVykGZ3XjFwM/88rGfV3oj4rKNBy+nYI6jM7q19hDI=
 github.com/nspcc-dev/rfc6979 v0.2.3/go.mod h1:q3sCL1Ed7homjqYK8KmFSzEmm+7Ngyo7PePbZanhaDE=
 github.com/nspcc-dev/tzhash v1.8.2 h1:ebRCbPoEuoqrhC6sSZmrT/jI3h1SzCWakxxV6gp5QAg=


### PR DESCRIPTION
In this version of the SDK, old objects that do not yet have a lifetime in the session token are valid.

Closes #3359.