### PR TITLE
*: open bolt with no statistics

### DIFF
--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -33,6 +33,7 @@ func (db *DB) Open(readOnly bool) error {
 		db.boltOptions = &opts
 	}
 	db.boltOptions.ReadOnly = readOnly
+	db.boltOptions.NoStatistics = true
 
 	if readOnly {
 		db.mode = mode.ReadOnly

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -222,6 +222,7 @@ func (c *cache) migrate() error {
 	c.log.Info("migrating database", zap.String("path", path))
 	db, err := bbolt.Open(path, os.ModePerm, &bbolt.Options{
 		NoFreelistSync: true,
+		NoStatistics:   true,
 		ReadOnly:       true,
 		Timeout:        time.Second,
 	})

--- a/pkg/services/session/storage/persistent/storage.go
+++ b/pkg/services/session/storage/persistent/storage.go
@@ -40,7 +40,8 @@ func NewTokenStore(path string, opts ...Option) (*TokenStore, error) {
 
 	db, err := bbolt.Open(path, 0o600,
 		&bbolt.Options{
-			Timeout: cfg.timeout,
+			NoStatistics: true,
+			Timeout:      cfg.timeout,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("can't open bbolt at %s: %w", path, err)

--- a/pkg/util/state/storage.go
+++ b/pkg/util/state/storage.go
@@ -19,7 +19,7 @@ var stateBucket = []byte("state")
 
 // NewPersistentStorage creates a new instance of a storage with 0o600 rights.
 func NewPersistentStorage(path string) (*PersistentStorage, error) {
-	db, err := bbolt.Open(path, 0o600, nil)
+	db, err := bbolt.Open(path, 0o600, &bbolt.Options{NoStatistics: true})
 	if err != nil {
 		return nil, fmt.Errorf("can't open bbolt at %s: %w", path, err)
 	}


### PR DESCRIPTION
An omission of 2f878435915cfb4f0be03d0aad3cf46fe36b2510.