### PR TITLE
writecache: improve reads, don't check fstree is it's not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for NeoFS Node
 - Make `MaintenanceModeAllowed` network setting always allowed (#3360)
 - Use local BoltDB fork with improved performance (#3372)
 - Cache only non-empty netmap (#3378)
+- Improved read performance for writecache-enabled configurations (#3380)
 
 ### Removed
 - `blobstor` package (#3371)

--- a/pkg/local_object_storage/writecache/get.go
+++ b/pkg/local_object_storage/writecache/get.go
@@ -11,6 +11,9 @@ import (
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in write-cache.
 func (c *cache) Get(addr oid.Address) (*objectSDK.Object, error) {
+	if !c.objCounters.HasAddress(addr) {
+		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
+	}
 	obj, err := c.fsTree.Get(addr)
 	if err != nil {
 		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
@@ -23,6 +26,9 @@ func (c *cache) Get(addr oid.Address) (*objectSDK.Object, error) {
 //
 // Returns an error of type apistatus.ObjectNotFound if the requested object is missing in write-cache.
 func (c *cache) Head(addr oid.Address) (*objectSDK.Object, error) {
+	if !c.objCounters.HasAddress(addr) {
+		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
+	}
 	obj, err := c.Get(addr)
 	if err != nil {
 		return nil, err
@@ -32,6 +38,9 @@ func (c *cache) Head(addr oid.Address) (*objectSDK.Object, error) {
 }
 
 func (c *cache) GetBytes(addr oid.Address) ([]byte, error) {
+	if !c.objCounters.HasAddress(addr) {
+		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
+	}
 	b, err := c.fsTree.GetBytes(addr)
 	if err != nil {
 		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})

--- a/pkg/local_object_storage/writecache/state.go
+++ b/pkg/local_object_storage/writecache/state.go
@@ -36,6 +36,13 @@ func (x *counters) Size() uint64 {
 	return x.size
 }
 
+func (x *counters) HasAddress(addr oid.Address) bool {
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	_, ok := x.objMap[addr]
+	return ok
+}
+
 func (x *counters) Map() map[oid.Address]uint64 {
 	x.mu.RLock()
 	defer x.mu.RUnlock()


### PR DESCRIPTION
We have a complete object list in memory, it's easy to check it. This should improve read performance for objects that are gone from write cache.