### PR TITLE
fstree: serve `HEAD` from the storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 - Support for announced address specification in IR consensus P2P config (#3361)
 - IR node can verify SN with an external validator (#3356)
+- `Head` operation for FSTree (#3383)
 
 ### Fixed
 - Split object with a missing link object can't be retrieved in some cases (#3337)

--- a/pkg/local_object_storage/blobstor/common/storage.go
+++ b/pkg/local_object_storage/blobstor/common/storage.go
@@ -26,6 +26,7 @@ type Storage interface {
 	GetBytes(oid.Address) ([]byte, error)
 	Get(oid.Address) (*objectSDK.Object, error)
 	GetRange(oid.Address, uint64, uint64) ([]byte, error)
+	Head(oid.Address) (*objectSDK.Object, error)
 	Exists(oid.Address) (bool, error)
 	Put(oid.Address, []byte) error
 	PutBatch(map[oid.Address][]byte) error

--- a/pkg/local_object_storage/blobstor/fstree/head.go
+++ b/pkg/local_object_storage/blobstor/fstree/head.go
@@ -1,0 +1,145 @@
+package fstree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+)
+
+const (
+	fieldObjectPayload = 4
+	maxHeaderSize      = 16 * 1024 // 16 KiB
+)
+
+// Head returns an object's header from the storage by address without reading the full payload.
+// It reads only the first maxHeaderSize bytes, which should contain the header information.
+func (t *FSTree) Head(addr oid.Address) (*objectSDK.Object, error) {
+	p := t.treePath(addr)
+
+	f, err := os.Open(p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
+		}
+		return nil, fmt.Errorf("read file %q: %w", p, err)
+	}
+	defer f.Close()
+
+	data, err := extractHeaderOnly(addr.Object(), f)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
+		}
+		return nil, fmt.Errorf("extract object header from %q: %w", p, err)
+	}
+
+	data, err = t.Decompress(data)
+	if err != nil {
+		return nil, fmt.Errorf("decompress header data %q: %w", p, err)
+	}
+
+	obj := objectSDK.New()
+	if err := obj.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("decode object header: %w", err)
+	}
+
+	return obj, nil
+}
+
+// extractHeaderOnly reads the header of an object from a file.
+func extractHeaderOnly(id oid.ID, f *os.File) ([]byte, error) {
+	var (
+		comBuf     [combinedDataOff]byte
+		isCombined bool
+	)
+
+	for {
+		n, err := io.ReadFull(f, comBuf[:])
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				if !isCombined {
+					return comBuf[:n], nil
+				}
+				return nil, fs.ErrNotExist
+			}
+			return nil, err
+		}
+		thisOID, l := parseCombinedPrefix(comBuf)
+		if thisOID == nil {
+			if isCombined {
+				return nil, errors.New("malformed combined file")
+			}
+			_, err = f.Seek(0, io.SeekStart)
+			if err != nil {
+				return nil, fmt.Errorf("seek to start of file: %w", err)
+			}
+
+			return readUntilPayload(f)
+		}
+		isCombined = true
+		if bytes.Equal(thisOID, id[:]) {
+			return readUntilPayload(f)
+		}
+		_, err = f.Seek(int64(l), 1)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func readUntilPayload(f *os.File) ([]byte, error) {
+	data := make([]byte, maxHeaderSize)
+
+	n, err := f.Read(data)
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	data = data[:n]
+
+	var out []byte
+	offset := 0
+
+	for offset < len(data) {
+		tag, tagLen := binary.Uvarint(data[offset:])
+		if tagLen <= 0 {
+			return nil, fmt.Errorf("invalid varint tag at offset %d", offset)
+		}
+		fieldNum := int(tag >> 3)
+		wireType := int(tag & 0x7)
+
+		// wireType != protowire.BytesType
+		if wireType != 2 {
+			return nil, fmt.Errorf("unsupported wire type: %d", wireType)
+		}
+
+		if fieldNum == fieldObjectPayload {
+			return out, nil
+		}
+
+		offset += tagLen
+
+		fieldLen, lenLen := binary.Uvarint(data[offset:])
+		if lenLen <= 0 {
+			return nil, fmt.Errorf("invalid varint length at offset %d", offset)
+		}
+		offset += lenLen
+
+		fieldEnd := offset + int(fieldLen)
+		if fieldEnd > len(data) {
+			return nil, fmt.Errorf("field exceeds data boundary")
+		}
+		out = append(out, data[offset-tagLen-lenLen:fieldEnd]...)
+		offset = fieldEnd
+	}
+
+	return out, nil
+}

--- a/pkg/local_object_storage/blobstor/fstree/head_bench_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/head_bench_test.go
@@ -1,0 +1,114 @@
+package fstree
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	"github.com/nspcc-dev/neofs-sdk-go/checksum"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
+	"github.com/nspcc-dev/neofs-sdk-go/version"
+	"github.com/nspcc-dev/tzhash/tz"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkFSTree_HeadVsGet(b *testing.B) {
+	payloadSizes := []int{
+		0,           // Empty payload
+		100,         // 100 bytes
+		10 * 1024,   // 10 KB
+		100 * 1024,  // 100 KB
+		1024 * 1024, // 1 MB
+	}
+
+	for _, size := range payloadSizes {
+		b.Run(generateSizeLabel(size), func(b *testing.B) {
+			benchmarkHeadVsGet(b, size)
+		})
+	}
+}
+
+func generateSizeLabel(size int) string {
+	switch {
+	case size == 0:
+		return "Empty"
+	case size < 1024:
+		return fmt.Sprintf("%dB", size)
+	case size < 1024*1024:
+		return fmt.Sprintf("%dKB", size/1024)
+	default:
+		return fmt.Sprintf("%dMB", size/(1024*1024))
+	}
+}
+
+func benchmarkHeadVsGet(b *testing.B, payloadSize int) {
+	fsTree := New(WithPath(b.TempDir()))
+	require.NoError(b, fsTree.Open(false))
+	require.NoError(b, fsTree.Init())
+
+	obj := generateTestObject(payloadSize)
+	addr := object.AddressOf(obj)
+
+	require.NoError(b, fsTree.Put(addr, obj.Marshal()))
+
+	b.Run("Head", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for range b.N {
+			_, err := fsTree.Head(addr)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Get", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for range b.N {
+			_, err := fsTree.Get(addr)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func generateTestObject(payloadSize int) *objectSDK.Object {
+	var ver version.Version
+	ver.SetMajor(2)
+	ver.SetMinor(1)
+
+	obj := objectSDK.New()
+	obj.SetID(oidtest.ID())
+	obj.SetOwner(usertest.ID())
+	obj.SetContainerID(cidtest.ID())
+	obj.SetVersion(&ver)
+
+	if payloadSize > 0 {
+		payload := make([]byte, payloadSize)
+		_, _ = rand.Read(payload)
+		obj.SetPayload(payload)
+
+		csum := checksum.NewSHA256(sha256.Sum256(payload))
+
+		obj.SetPayloadChecksum(csum)
+		obj.SetPayloadHomomorphicHash(checksum.NewTillichZemor(tz.Sum(csum.Value())))
+	}
+
+	var attr1, attr2 objectSDK.Attribute
+	attr1.SetKey("benchmark")
+	attr1.SetValue("test")
+
+	attr2.SetKey("type")
+	attr2.SetValue("performance")
+
+	obj.SetAttributes(attr1, attr2)
+
+	return obj
+}

--- a/pkg/local_object_storage/shard/head_test.go
+++ b/pkg/local_object_storage/shard/head_test.go
@@ -2,14 +2,17 @@ package shard_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,4 +80,83 @@ func testHead(t *testing.T, sh *shard.Shard, addr oid.Address, raw bool, hasWrit
 		}, time.Second, time.Millisecond*100)
 	}
 	return res, err
+}
+
+func TestHeadStorage(t *testing.T) {
+	sh := newCustomShard(t, t.TempDir(), false, nil, shard.WithMode(mode.Degraded))
+	defer releaseShard(sh, t)
+
+	t.Run("empty payload", func(t *testing.T) {
+		obj := generateObject()
+		obj.SetPayload([]byte{})
+
+		err := sh.Put(obj, nil, 0)
+		require.NoError(t, err)
+
+		res, err := sh.Head(object.AddressOf(obj), false)
+		require.NoError(t, err)
+		require.Equal(t, obj.CutPayload(), res)
+		require.Empty(t, res.Payload())
+	})
+
+	t.Run("large payload", func(t *testing.T) {
+		obj := generateObject()
+		addPayload(obj, 1024*1024)
+
+		err := sh.Put(obj, nil, 0)
+		require.NoError(t, err)
+
+		res, err := sh.Head(object.AddressOf(obj), false)
+		require.NoError(t, err)
+		require.Equal(t, obj.CutPayload(), res)
+		require.Empty(t, res.Payload())
+	})
+
+	t.Run("many attributes", func(t *testing.T) {
+		obj := generateObject()
+		numAttrs := 100
+		for i := range numAttrs {
+			addAttribute(obj, fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i))
+		}
+
+		err := sh.Put(obj, nil, 0)
+		require.NoError(t, err)
+
+		res, err := sh.Head(object.AddressOf(obj), false)
+		require.NoError(t, err)
+		require.Equal(t, obj.CutPayload(), res)
+		require.Len(t, res.Attributes(), numAttrs)
+	})
+
+	t.Run("non-existent object", func(t *testing.T) {
+		fakeAddr := oid.Address{}
+		fakeAddr.SetContainer(cidtest.ID())
+		fakeAddr.SetObject(oidtest.ID())
+
+		_, err := sh.Head(fakeAddr, false)
+		require.Error(t, err)
+		require.True(t, shard.IsErrNotFound(err))
+	})
+
+	t.Run("different payload sizes", func(t *testing.T) {
+		payloadSizes := []int{0, 1, 100, 1024, 1024 * 1024}
+
+		for _, size := range payloadSizes {
+			t.Run(fmt.Sprintf("%dB", size), func(t *testing.T) {
+				obj := generateObject()
+				if size > 0 {
+					addPayload(obj, size)
+				} else {
+					obj.SetPayload([]byte{})
+				}
+
+				err := sh.Put(obj, nil, 0)
+				require.NoError(t, err)
+
+				res, err := sh.Head(object.AddressOf(obj), false)
+				require.NoError(t, err)
+				require.Equal(t, obj.CutPayload(), res)
+			})
+		}
+	})
 }

--- a/pkg/local_object_storage/writecache/get.go
+++ b/pkg/local_object_storage/writecache/get.go
@@ -29,12 +29,12 @@ func (c *cache) Head(addr oid.Address) (*objectSDK.Object, error) {
 	if !c.objCounters.HasAddress(addr) {
 		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
 	}
-	obj, err := c.Get(addr)
+	obj, err := c.fsTree.Head(addr)
 	if err != nil {
-		return nil, err
+		return nil, logicerr.Wrap(apistatus.ObjectNotFound{})
 	}
 
-	return obj.CutPayload(), nil
+	return obj, nil
 }
 
 func (c *cache) GetBytes(addr oid.Address) ([]byte, error) {


### PR DESCRIPTION
Closes #2085.

```
goos: linux
goarch: amd64
pkg: github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkFSTree_HeadVsGet
BenchmarkFSTree_HeadVsGet/Empty
BenchmarkFSTree_HeadVsGet/Empty/Head
BenchmarkFSTree_HeadVsGet/Empty/Head-16    	   51844	     28350 ns/op	    2288 B/op	      33 allocs/op
BenchmarkFSTree_HeadVsGet/Empty/Get
BenchmarkFSTree_HeadVsGet/Empty/Get-16     	   39008	     29472 ns/op	    2240 B/op	      32 allocs/op
BenchmarkFSTree_HeadVsGet/100B
BenchmarkFSTree_HeadVsGet/100B/Head
BenchmarkFSTree_HeadVsGet/100B/Head-16     	   48838	     29173 ns/op	    2736 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/100B/Get
BenchmarkFSTree_HeadVsGet/100B/Get-16      	   39392	     35613 ns/op	    2896 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/10KB
BenchmarkFSTree_HeadVsGet/10KB/Head
BenchmarkFSTree_HeadVsGet/10KB/Head-16     	   32133	     31803 ns/op	    2736 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/10KB/Get
BenchmarkFSTree_HeadVsGet/10KB/Get-16      	   23450	     47310 ns/op	   23520 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/100KB
BenchmarkFSTree_HeadVsGet/100KB/Head
BenchmarkFSTree_HeadVsGet/100KB/Head-16    	   48626	     30835 ns/op	    2736 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/100KB/Get
BenchmarkFSTree_HeadVsGet/100KB/Get-16     	    8876	    133707 ns/op	  215393 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/1MB
BenchmarkFSTree_HeadVsGet/1MB/Head
BenchmarkFSTree_HeadVsGet/1MB/Head-16      	   41428	     31624 ns/op	    2736 B/op	      39 allocs/op
BenchmarkFSTree_HeadVsGet/1MB/Get
BenchmarkFSTree_HeadVsGet/1MB/Get-16       	    1042	   1105492 ns/op	 2107974 B/op	      40 allocs/op
```