### PR TITLE
eacl: load headers lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for NeoFS Node
 - Cache only non-empty netmap (#3378)
 - Improved read performance for writecache-enabled configurations (#3380)
 - SN now uses cached container SN lists to detect in-container requests for access control (#3385)
+- Improved EACL processing performance by avoiding header requests in many cases (#3386)
 
 ### Removed
 - `blobstor` package (#3371)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.109.1
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.22.0
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb
 	github.com/nspcc-dev/tzhash v1.8.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.22.0 h1:dxSm/NYyc7ZtWlhskH4e4yzXxf5pBCEOR3lLLmV98i8=
 github.com/nspcc-dev/neofs-contract v0.22.0/go.mod h1:it6Su92UvEFQDsMOfDIXapLu0j5TQSOvkS2YdUlPdgo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996 h1:zEgBAbj3vNex6a2amiWtDOdL25MmtQBDZUhmNYNAK+w=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250530123548-f8dbe53f3996/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb h1:aQ6W8/8SIvcJwH1QF+NuwB8Uvt6LYFCOcRHLgynejeA=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
 github.com/nspcc-dev/rfc6979 v0.2.3 h1:QNVykGZ3XjFwM/88rGfV3oj4rKNBy+nYI6jM7q19hDI=
 github.com/nspcc-dev/rfc6979 v0.2.3/go.mod h1:q3sCL1Ed7homjqYK8KmFSzEmm+7Ngyo7PePbZanhaDE=
 github.com/nspcc-dev/tzhash v1.8.2 h1:ebRCbPoEuoqrhC6sSZmrT/jI3h1SzCWakxxV6gp5QAg=

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -250,7 +250,11 @@ func (c *Checker) CheckEACL(msg any, reqInfo v2.RequestInfo) error {
 		vu.WithAccount(*sa)
 	}
 
-	action, _ := c.validator.CalculateAction(vu)
+	action, _, err := c.validator.CalculateAction(vu)
+
+	if err != nil {
+		return err
+	}
 
 	if action != eaclSDK.ActionAllow {
 		return errEACLDeniedByRule

--- a/pkg/services/object/acl/eacl/v2/eacl_test.go
+++ b/pkg/services/object/acl/eacl/v2/eacl_test.go
@@ -145,13 +145,15 @@ func TestHeadRequest(t *testing.T) {
 }
 
 func checkAction(t *testing.T, expected eaclSDK.Action, v *eaclSDK.Validator, u *eaclSDK.ValidationUnit) {
-	actual, fromRule := v.CalculateAction(u)
+	actual, fromRule, err := v.CalculateAction(u)
+	require.NoError(t, err)
 	require.True(t, fromRule)
 	require.Equal(t, expected, actual)
 }
 
 func checkDefaultAction(t *testing.T, v *eaclSDK.Validator, u *eaclSDK.ValidationUnit) {
-	actual, fromRule := v.CalculateAction(u)
+	actual, fromRule, err := v.CalculateAction(u)
+	require.NoError(t, err)
 	require.False(t, fromRule)
 	require.Equal(t, eaclSDK.ActionAllow, actual)
 }


### PR DESCRIPTION
Most of the time they're not needed, so we can save some time. This is especially relevant for GETs or HEADs, header fetching has some significant cost to it (which is especially annoying since we're not reusing this header afterwards).