### PR TITLE
go.mod: upgrade NeoGo to 0.110.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Changelog for NeoFS Node
 ### Updated
 - `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250530123548-f8dbe53f3996` (#3373)
 - neofs-contracts to 0.23.0 (#3375)
+- NeoGo dependency to 0.110.0 (#3392)
 
 ### Updating from v0.46.1
 Remove `max_object_size` configuration from write caches, it's no longer needed.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/nspcc-dev/hrw/v2 v2.0.3
 	github.com/nspcc-dev/locode-db v0.6.0
-	github.com/nspcc-dev/neo-go v0.109.1
+	github.com/nspcc-dev/neo-go v0.110.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.23.0
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/nspcc-dev/hrw/v2 v2.0.3 h1:GUIitIiDpAaQat9SZccp7XVAuwtqaM40+uZ9D8Q4A8
 github.com/nspcc-dev/hrw/v2 v2.0.3/go.mod h1:VWlFSGGPcHG1abuIDJb5u83tIF2EqOatC8Z7svZmgWQ=
 github.com/nspcc-dev/locode-db v0.6.0 h1:EdRUug+sL0EMLZgucLETD6bnegKjyEZh+D5x4r5VMvY=
 github.com/nspcc-dev/locode-db v0.6.0/go.mod h1:mJLXdzlcRucr3AFUvf5fJH+rFv1bJuU85e1jtDHDTz8=
-github.com/nspcc-dev/neo-go v0.109.1 h1:2Bm7OSI271pBeDTqmjVH35iuD9yML8K7hi24FijuRZo=
-github.com/nspcc-dev/neo-go v0.109.1/go.mod h1:Sv/mc0zbRUauA2HhA0TMy6L/lYMIe7pnI2QQers9elM=
+github.com/nspcc-dev/neo-go v0.110.0 h1:dF7C4zU5pw3oydfr5SIKHJ31hElgdWwfUVgVH2KB4x4=
+github.com/nspcc-dev/neo-go v0.110.0/go.mod h1:Sv/mc0zbRUauA2HhA0TMy6L/lYMIe7pnI2QQers9elM=
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115 h1:VWIceT+fh7sB5H+J5hhOIN+pWCy9/PHcvpvjSXteIQg=
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250423172732-0e55bd820115/go.mod h1:3byneDNT60tiD8MSyGSyjpI1uVp9v+coySegJoQPF8c=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK0EMGLvunXcFyq7fBURS/CsN4MH+4nlYiqn6pTwWAU=


### PR DESCRIPTION
tx batching is updated to use 5% block time by default here. Connection management improved and Faun introduced.