### PR TITLE
Support unsigned object GET/HEAD responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ Changelog for NeoFS Node
 - SN caches up to 1000 session token verification results until the next epoch (#3369)
 - SN no longer wastes memory for logger in ACL and GET/HEAD/RANGE handlers (#3408, #3412)
 - Inner ring ticks epoch based on real time, not blocks count (#3402)
+- IR, CLI and SN ignore signatures of object GET/HEAD responses (#3406)
+- IR, CLI and SN verify object checksums from GET/HEAD responses (except SN proxy case) (#3406)
 
 ### Removed
 
 ### Updated
+- `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250623124459-a9cfab652dc0` (#3406)
 
 ### Updating from v0.47.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for NeoFS Node
 - IR, CLI and SN verify object checksums from GET/HEAD responses (except SN proxy case) (#3406)
 - SN does not sign object GET/HEAD responses to requests with API version > v2.17 (#3406)
 - SN now verifies object header from proxy GET/HEAD responses against requested ID (#3406)
+- SN now verifies payload from proxy GET responses against in-header checksum (#3406)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
-- IR exponentially retries updating SN lists in the Container contract in error cases (#3344) 
+- IR exponentially retries updating SN lists in the Container contract in error cases (#3344)
 - Epoch stale after NEO RPC connection loss by IR (#3397)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for NeoFS Node
 - IR, CLI and SN ignore signatures of object GET/HEAD responses (#3406)
 - IR, CLI and SN verify object checksums from GET/HEAD responses (except SN proxy case) (#3406)
 - SN does not sign object GET/HEAD responses to requests with API version > v2.17 (#3406)
+- SN now verifies object header from proxy GET/HEAD responses against requested ID (#3406)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for NeoFS Node
 - Inner ring ticks epoch based on real time, not blocks count (#3402)
 - IR, CLI and SN ignore signatures of object GET/HEAD responses (#3406)
 - IR, CLI and SN verify object checksums from GET/HEAD responses (except SN proxy case) (#3406)
+- SN does not sign object GET/HEAD responses to requests with API version > v2.17 (#3406)
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.110.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.23.0
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250623124459-a9cfab652dc0
 	github.com/nspcc-dev/tzhash v1.8.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/panjf2000/ants/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.23.0 h1:F5ciU0wPqSbycPY8qOtb4PvgnSZBNQ5Jp9tdeVSKu4o=
 github.com/nspcc-dev/neofs-contract v0.23.0/go.mod h1:it6Su92UvEFQDsMOfDIXapLu0j5TQSOvkS2YdUlPdgo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb h1:aQ6W8/8SIvcJwH1QF+NuwB8Uvt6LYFCOcRHLgynejeA=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250610144537-4b8bd696a7eb/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250623124459-a9cfab652dc0 h1:cWNNmSe0fJd81URPq8dp/8nkJywuO655/M8gdFgfVWg=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.13.0.20250623124459-a9cfab652dc0/go.mod h1:j/NUu5iOGFkOVYM42XoC1X9DZD0/y89Pws++w5vxtQk=
 github.com/nspcc-dev/rfc6979 v0.2.3 h1:QNVykGZ3XjFwM/88rGfV3oj4rKNBy+nYI6jM7q19hDI=
 github.com/nspcc-dev/rfc6979 v0.2.3/go.mod h1:q3sCL1Ed7homjqYK8KmFSzEmm+7Ngyo7PePbZanhaDE=
 github.com/nspcc-dev/tzhash v1.8.2 h1:ebRCbPoEuoqrhC6sSZmrT/jI3h1SzCWakxxV6gp5QAg=


### PR DESCRIPTION
* based on and blocked by https://github.com/nspcc-dev/neofs-sdk-go/pull/719

tested S3 and REST GWs require signatures to be presented. Passed tests assert proposed behavior is backward compatible. Note that clients which do _not_ set API version are also served with signatures