### PR TITLE
*: drop IR candidate fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changelog for NeoFS Node
 - neofs-cli storagegroup commands (#3442)
 - SG-based audit from IR and SN (#3442)
 - Support for audit fee setting (#3442)
+- Support for Inner Ring candidate fee setting (#3459)
 
 ### Updated
 - `github.com/nspcc-dev/neofs-sdk-go` dependency to `v1.0.0-rc.13.0.20250623124459-a9cfab652dc0` (#3406)

--- a/cmd/neofs-adm/internal/modules/config/config.go
+++ b/cmd/neofs-adm/internal/modules/config/config.go
@@ -19,7 +19,6 @@ type configTemplate struct {
 	MaxObjectSize           int
 	EpochDuration           int
 	BasicIncomeRate         int
-	CandidateFee            int
 	ContainerFee            int
 	ContainerAliasFee       int
 	WithdrawFee             int
@@ -35,7 +34,6 @@ network:
   basic_income_rate: {{ .BasicIncomeRate}}
   homomorphic_hash_disabled: {{ .HomomorphicHashDisabled}}
   fee:
-    candidate: {{ .CandidateFee}}
     container: {{ .ContainerFee}}
     container_alias: {{ .ContainerAliasFee }}
     withdraw: {{ .WithdrawFee}}
@@ -106,14 +104,13 @@ func defaultConfigPath() (string, error) {
 func generateConfigExample(appDir string, credSize int) (string, error) {
 	tmpl := configTemplate{
 		Endpoint:                "https://neo.rpc.node:30333",
-		MaxObjectSize:           67108864,      // 64 MiB
-		EpochDuration:           240,           // 1 hour with 15s per block
-		BasicIncomeRate:         1_0000_0000,   // 0.0001 GAS per GiB (Fixed12)
-		HomomorphicHashDisabled: false,         // object homomorphic hash is enabled
-		CandidateFee:            100_0000_0000, // 100.0 GAS (Fixed8)
-		ContainerFee:            1000,          // 0.000000001 * 7 GAS per container (Fixed12)
-		ContainerAliasFee:       500,           // ContainerFee / 2
-		WithdrawFee:             1_0000_0000,   // 1.0 GAS (Fixed8)
+		MaxObjectSize:           67108864,    // 64 MiB
+		EpochDuration:           240,         // 1 hour with 15s per block
+		BasicIncomeRate:         1_0000_0000, // 0.0001 GAS per GiB (Fixed12)
+		HomomorphicHashDisabled: false,       // object homomorphic hash is enabled
+		ContainerFee:            1000,        // 0.000000001 * 7 GAS per container (Fixed12)
+		ContainerAliasFee:       500,         // ContainerFee / 2
+		WithdrawFee:             1_0000_0000, // 1.0 GAS (Fixed8)
 		AlphabetNames:           make([]string, 0, credSize),
 	}
 

--- a/cmd/neofs-adm/internal/modules/config/config_test.go
+++ b/cmd/neofs-adm/internal/modules/config/config_test.go
@@ -29,7 +29,6 @@ func TestGenerateConfigExample(t *testing.T) {
 	require.Equal(t, 67108864, v.GetInt("network.max_object_size"))
 	require.Equal(t, 240, v.GetInt("network.epoch_duration"))
 	require.Equal(t, 100000000, v.GetInt("network.basic_income_rate"))
-	require.Equal(t, 10000000000, v.GetInt("network.fee.candidate"))
 	require.Equal(t, 1000, v.GetInt("network.fee.container"))
 	require.Equal(t, 100000000, v.GetInt("network.fee.withdraw"))
 

--- a/cmd/neofs-adm/internal/modules/fschain/config.go
+++ b/cmd/neofs-adm/internal/modules/fschain/config.go
@@ -67,7 +67,7 @@ func dumpNetworkConfig(cmd *cobra.Command, _ []string) error {
 		case netmapBasicIncomeRateKey,
 			netmapContainerFeeKey, netmapContainerAliasFeeKey,
 			netmapEigenTrustIterationsKey,
-			netmapEpochKey, netmapInnerRingCandidateFeeKey,
+			netmapEpochKey,
 			netmapMaxObjectSizeKey, netmapWithdrawFeeKey:
 			nbuf := make([]byte, 8)
 			copy(nbuf, v)
@@ -154,7 +154,7 @@ func parseConfigPair(kvStr string, force bool) (key string, val any, err error) 
 	case netmapBasicIncomeRateKey,
 		netmapContainerFeeKey, netmapContainerAliasFeeKey,
 		netmapEigenTrustIterationsKey,
-		netmapEpochKey, netmapInnerRingCandidateFeeKey,
+		netmapEpochKey,
 		netmapMaxObjectSizeKey, netmapWithdrawFeeKey:
 		val, err = strconv.ParseInt(valRaw, 10, 64)
 		if err != nil {

--- a/cmd/neofs-adm/internal/modules/fschain/initialize_deploy.go
+++ b/cmd/neofs-adm/internal/modules/fschain/initialize_deploy.go
@@ -51,7 +51,6 @@ const (
 	netmapEigenTrustIterationsKey    = "EigenTrustIterations"
 	netmapEigenTrustAlphaKey         = "EigenTrustAlpha"
 	netmapBasicIncomeRateKey         = "BasicIncomeRate"
-	netmapInnerRingCandidateFeeKey   = "InnerRingCandidateFee"
 	netmapWithdrawFeeKey             = "WithdrawFee"
 	netmapHomomorphicHashDisabledKey = "HomomorphicHashingDisabled"
 
@@ -445,7 +444,6 @@ func (c *initializeContext) getContractDeployData(ctrHash util.Uint160, ctrName 
 			{netmapContainerFeeKey, containerFeeInitFlag},
 			{netmapContainerAliasFeeKey, containerAliasFeeInitFlag},
 			{netmapBasicIncomeRateKey, incomeRateInitFlag},
-			{netmapInnerRingCandidateFeeKey, candidateFeeInitFlag},
 			{netmapWithdrawFeeKey, withdrawFeeInitFlag},
 		} {
 			i64, err := unwrap.Int64(c.ReadOnlyInvoker.Call(ctrHash, "config", kf.key))

--- a/cmd/neofs-adm/internal/modules/fschain/root.go
+++ b/cmd/neofs-adm/internal/modules/fschain/root.go
@@ -32,8 +32,6 @@ const (
 	containerAliasFeeInitFlag       = "network.fee.container_alias"
 	containerFeeCLIFlag             = "container-fee"
 	containerAliasFeeCLIFlag        = "container-alias-fee"
-	candidateFeeInitFlag            = "network.fee.candidate"
-	candidateFeeCLIFlag             = "candidate-fee"
 	homomorphicHashDisabledInitFlag = "network.homomorphic_hash_disabled"
 	homomorphicHashDisabledCLIFlag  = "homomorphic-disabled"
 	withdrawFeeInitFlag             = "network.fee.withdraw"

--- a/cmd/neofs-cli/modules/netmap/netinfo.go
+++ b/cmd/neofs-cli/modules/netmap/netinfo.go
@@ -53,7 +53,6 @@ var netInfoCmd = &cobra.Command{
 		cmd.Printf(format, "EigenTrust alpha", netInfo.EigenTrustAlpha())
 		cmd.Printf(format, "Number of EigenTrust iterations", netInfo.NumberOfEigenTrustIterations())
 		cmd.Printf(format, "Epoch duration", netInfo.EpochDuration())
-		cmd.Printf(format, "Inner Ring candidate fee", netInfo.IRCandidateFee())
 		cmd.Printf(format, "Maximum object size", netInfo.MaxObjectSize())
 		cmd.Printf(format, "Withdrawal fee", netInfo.WithdrawalFee())
 		cmd.Printf(format, "Homomorphic hashing disabled", netInfo.HomomorphicHashingDisabled())

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -480,7 +480,6 @@ func (c *cfg) GetNetworkInfo() (netmapSDK.NetworkInfo, error) {
 	ni.SetNamedContainerFee(netInfoMorph.ContainerAliasFee)
 	ni.SetNumberOfEigenTrustIterations(netInfoMorph.EigenTrustIterations)
 	ni.SetEigenTrustAlpha(netInfoMorph.EigenTrustAlpha)
-	ni.SetIRCandidateFee(netInfoMorph.IRCandidateFee)
 	ni.SetWithdrawalFee(netInfoMorph.WithdrawalFee)
 
 	if netInfoMorph.HomomorphicHashingDisabled {

--- a/pkg/innerring/config.go
+++ b/pkg/innerring/config.go
@@ -198,7 +198,6 @@ func setNetworkSettingsDefaults(netCfg *deploy.NetworkConfiguration) {
 	netCfg.StoragePrice = 0         // in GAS per 1GB (NeoFS Balance contract's decimals)
 	netCfg.ContainerFee = 1000      // in GAS per container (NeoFS Balance contract's decimals)
 	netCfg.ContainerAliasFee = 500  // in GAS per container (NeoFS Balance contract's decimals)
-	netCfg.IRCandidateFee = 0       // in GAS per candidate (Fixed8)
 	netCfg.WithdrawalFee = 0        // in GAS per withdrawal (Fixed8)
 	netCfg.EigenTrustIterations = 4
 	netCfg.EigenTrustAlpha = 0.1

--- a/pkg/innerring/network.go
+++ b/pkg/innerring/network.go
@@ -161,7 +161,7 @@ func convertKnownConfigValues(k, v string) (any, error) {
 	case netmapcore.BasicIncomeRateConfig,
 		netmapcore.ContainerFeeConfig, netmapcore.ContainerAliasFeeConfig,
 		netmapcore.EigenTrustIterationsConfig,
-		netmapcore.EpochDurationConfig, netmapcore.InnerRingCandidateFeeConfig,
+		netmapcore.EpochDurationConfig,
 		netmapcore.MaxObjectSizeConfig, netmapcore.WithdrawFeeConfig:
 		val, err = strconv.ParseInt(v, 10, 64)
 		if err != nil {

--- a/pkg/morph/client/netmap/config.go
+++ b/pkg/morph/client/netmap/config.go
@@ -18,7 +18,6 @@ const (
 	ContainerAliasFeeConfig       = "ContainerAliasFee"
 	EigenTrustIterationsConfig    = "EigenTrustIterations"
 	EigenTrustAlphaConfig         = "EigenTrustAlpha"
-	InnerRingCandidateFeeConfig   = "InnerRingCandidateFee"
 	WithdrawFeeConfig             = "WithdrawFee"
 	HomomorphicHashingDisabledKey = "HomomorphicHashingDisabled"
 )
@@ -105,17 +104,6 @@ func (c *Client) EigenTrustAlpha() (float64, error) {
 // Returns (false, nil) if config key is not found in the contract.
 func (c *Client) HomomorphicHashDisabled() (bool, error) {
 	return c.readBoolConfig(HomomorphicHashingDisabledKey)
-}
-
-// InnerRingCandidateFee returns global configuration value of fee paid by
-// node to be in inner ring candidates list.
-func (c *Client) InnerRingCandidateFee() (uint64, error) {
-	fee, err := c.readUInt64Config(InnerRingCandidateFeeConfig)
-	if err != nil {
-		return 0, fmt.Errorf("(%T) could not get inner ring candidate fee: %w", c, err)
-	}
-
-	return fee, nil
 }
 
 // WithdrawFee returns global configuration value of fee paid by user to
@@ -226,8 +214,6 @@ type NetworkConfiguration struct {
 
 	EigenTrustAlpha float64
 
-	IRCandidateFee uint64
-
 	WithdrawalFee uint64
 
 	HomomorphicHashingDisabled bool
@@ -290,8 +276,6 @@ func (c *Client) ReadNetworkConfiguration() (NetworkConfiguration, error) {
 			if err != nil {
 				return fmt.Errorf("invalid prm %s: %w", EigenTrustAlphaConfig, err)
 			}
-		case InnerRingCandidateFeeConfig:
-			res.IRCandidateFee = bytesToUint64(value)
 		case WithdrawFeeConfig:
 			res.WithdrawalFee = bytesToUint64(value)
 		case HomomorphicHashingDisabledKey:


### PR DESCRIPTION
It's totally unused and useless. In standalone networks IR is committee, in mainnet/testsnet IR is set by main chain committee via designation contract. Registering candidates in neofs contract is a no-op for network.