### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -285,10 +285,7 @@ func (db *DB) GetGarbage(limit int) ([]oid.Address, []cid.ID, error) {
 	}
 
 	const reasonableLimit = 1000
-	initCap := reasonableLimit
-	if limit < initCap {
-		initCap = limit
-	}
+	initCap := min(limit, reasonableLimit)
 
 	var addrBuff oid.Address
 	var cidBuff cid.ID

--- a/pkg/morph/client/notary.go
+++ b/pkg/morph/client/notary.go
@@ -164,10 +164,7 @@ func (c *Client) DepositNotary(amount fixedn.Fixed8, delta uint32) error {
 		return fmt.Errorf("can't get previous expiration value: %w", err)
 	}
 
-	till := int64(bc + delta)
-	if till < currentTill {
-		till = currentTill
-	}
+	till := max(int64(bc+delta), currentTill)
 
 	return c.depositNotary(conn, amount, till)
 }

--- a/pkg/services/object/internal/client/client.go
+++ b/pkg/services/object/internal/client/client.go
@@ -330,10 +330,7 @@ func PayloadRange(prm PayloadRangePrm) (*PayloadRangeRes, error) {
 		return nil, new(apistatus.ObjectOutOfRange)
 	}
 
-	ln := prm.ln
-	if ln > maxInitialBufferSize {
-		ln = maxInitialBufferSize
-	}
+	ln := min(prm.ln, maxInitialBufferSize)
 
 	w := bytes.NewBuffer(make([]byte, ln))
 	_, err = io.CopyN(w, rdr, int64(prm.ln))

--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -1464,10 +1464,7 @@ func (s *searchStream) WriteIDs(ids []oid.ID) error {
 			Body: &protoobject.SearchResponse_Body{},
 		}
 
-		cut := maxObjAddrRespAmount
-		if cut > len(ids) {
-			cut = len(ids)
-		}
+		cut := min(maxObjAddrRespAmount, len(ids))
 
 		r.Body.IdList = make([]*refs.ObjectID, cut)
 		for i := range cut {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.