### PR TITLE
minor text cleanup

### DIFF
--- a/pkg/services/control/types.pb.go
+++ b/pkg/services/control/types.pb.go
@@ -564,7 +564,7 @@ func (x *BlobstorInfo) GetType() string {
 //     [ISO 3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 //     format. Calculated automatically from `Locode` attribute
 //   - Region \
-//     Country's administative subdivision where node is located. Calculated
+//     Country's administrative subdivision where node is located. Calculated
 //     automatically from `Locode` attribute based on `SubDiv` field. Presented
 //     in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format.
 //   - City \

--- a/pkg/services/control/types.proto
+++ b/pkg/services/control/types.proto
@@ -63,7 +63,7 @@ message NodeInfo {
     //   [ISO 3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
     //   format. Calculated automatically from `Locode` attribute
     // * Region \
-    //   Country's administative subdivision where node is located. Calculated
+    //   Country's administrative subdivision where node is located. Calculated
     //   automatically from `Locode` attribute based on `SubDiv` field. Presented
     //   in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format.
     // * City \


### PR DESCRIPTION
improved wording and consistency in code:
`administative` - `administrative`