### PR TITLE
ir: drain and close deployment notification channels, fix #3237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 - Missing garbage, graveyard and to-move buckets in object metabase status (#3485)
 - Incorrect garbage bucket setting in metabase on tombstone writing (#3484)
 - Incorrect garbage bucket items via metabase migration (#3484)
+- Rare IR deadlocks during contract deployment (#3237)
 
 ### Changed
 


### PR DESCRIPTION
The problem is that deploy code subscribes and never unsubscribes while it spawns some readers that are bound to deploy context. So once Deploy() is done they can (and should) exit, but we still haven't performed unsubscription, so there is a race between events and unsubscription that's especially annoying with small block times.

Ideally it's deploy code that should be doing this (it spawns receivers), but draining here concurrently to deploy threads should be sufficient too.