### PR TITLE
workflows: don't build Dockers in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
     needs: build_bins
     name: Build and push docker images
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       matrix:
         image: [adm, cli, ir, storage]


### PR DESCRIPTION
The only thing it does in PR is ensures that Docker images can be built, they're not pushed into any registry, so they can't be used and no one needs the result. Building in master is sufficient for the purpose of finding failed Docker builds (they don't break often), but we better avoid doing it in PRs since it takes a considerable amount of time blocking runners available to project/organization.