### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/pkg/morph/event/container/eacl.go
+++ b/pkg/morph/event/container/eacl.go
@@ -20,7 +20,7 @@ type SetEACL struct {
 // MorphEvent implements Neo:Morph Event interface.
 func (SetEACL) MorphEvent() {}
 
-// Table returns returns eACL table in a binary NeoFS API format.
+// Table returns eACL table in a binary NeoFS API format.
 func (x SetEACL) Table() []byte {
 	return x.table
 }

--- a/pkg/services/control/ir/service.go
+++ b/pkg/services/control/ir/service.go
@@ -56,7 +56,7 @@ func (x *NotaryRequestRequest_Body) SetArgs(v [][]byte) {
 	}
 }
 
-// SetBody sets notary request request body.
+// SetBody sets notary request body.
 func (x *NotaryRequestRequest) SetBody(v *NotaryRequestRequest_Body) {
 	if x != nil {
 		x.Body = v


### PR DESCRIPTION
remove redundant word in comment