### PR TITLE
Fix tomstoned objects revival not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Send on closed channel panic in node's new epoch handler (#3529)
+- Tomstoned objects revival not working (#3542)
 
 ### Changed
 - Stream payload without buffering to reduce memory usage in CLI `Get/Put` operations (#3535)

--- a/pkg/local_object_storage/engine/revive_test.go
+++ b/pkg/local_object_storage/engine/revive_test.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
+	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageEngine_ReviveObject(t *testing.T) {
+	e := testNewEngineWithShardNum(t, 1)
+	defer func() { _ = e.Close() }()
+
+	cnr := cidtest.ID()
+
+	obj := generateObjectWithCID(cnr)
+	require.NoError(t, e.Put(obj, nil))
+	addr := object.AddressOf(obj)
+
+	ts := generateObjectWithCID(cnr)
+	ts.SetType(objectSDK.TypeTombstone)
+	addAttribute(ts, objectSDK.AttributeAssociatedObject, obj.GetID().EncodeToString())
+	addAttribute(ts, objectSDK.AttributeExpirationEpoch, "0")
+	tsAddr := object.AddressOf(ts)
+
+	require.NoError(t, e.Put(ts, nil))
+
+	_, err := e.Get(addr)
+	require.ErrorIs(t, err, apistatus.ErrObjectAlreadyRemoved)
+
+	rs, err := e.ReviveObject(addr)
+	require.NoError(t, err)
+	require.Equal(t, meta.ReviveStatusGraveyard, rs.Shards[0].Status.StatusType())
+	require.Equal(t, tsAddr, rs.Shards[0].Status.TombstoneAddress())
+
+	got, err := e.Get(addr)
+	require.NoError(t, err)
+	require.Equal(t, obj, got)
+
+	// tombstone metadata should be dropped, so getting TS must fail with not found
+	_, err = e.Get(tsAddr)
+	require.ErrorIs(t, err, apistatus.ErrObjectNotFound)
+}

--- a/pkg/local_object_storage/metabase/revive_test.go
+++ b/pkg/local_object_storage/metabase/revive_test.go
@@ -41,10 +41,15 @@ func TestDB_ReviveObject(t *testing.T) {
 		res, err := db.ReviveObject(object.AddressOf(raw))
 		require.NoError(t, err)
 		require.Equal(t, meta.ReviveStatusGraveyard, res.StatusType())
+		require.NotNil(t, res.TombstoneAddress())
 
 		exists, err = metaExists(db, object.AddressOf(raw))
 		require.NoError(t, err)
 		require.True(t, exists)
+
+		exists, err = metaExists(db, tombstoneID)
+		require.NoError(t, err)
+		require.False(t, exists)
 	})
 
 	t.Run("from GC", func(t *testing.T) {

--- a/pkg/local_object_storage/shard/revive.go
+++ b/pkg/local_object_storage/shard/revive.go
@@ -3,6 +3,7 @@ package shard
 import (
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"go.uber.org/zap"
 )
 
 // ReviveObject try to revive object in Shard, by remove records from graveyard and garbage.
@@ -17,5 +18,16 @@ func (s *Shard) ReviveObject(addr oid.Address) (meta.ReviveStatus, error) {
 	} else if s.GetMode().NoMetabase() {
 		return meta.ReviveStatus{}, ErrDegradedMode
 	}
-	return s.metaBase.ReviveObject(addr)
+
+	st, err := s.metaBase.ReviveObject(addr)
+	if err == nil {
+		if ts := st.TombstoneAddress(); !ts.Object().IsZero() {
+			if delErr := s.deleteObjs([]oid.Address{ts}); delErr != nil {
+				s.log.Debug("tombstone delete after revive failed", zap.Stringer("tombstone", ts), zap.Error(delErr))
+			} else {
+				s.log.Debug("tombstone deleted after revive", zap.Stringer("tombstone", ts))
+			}
+		}
+	}
+	return st, err
 }


### PR DESCRIPTION
Closes #3486.

Now, if you revive an object on a specific node, then it can only be retrieved on it. It will still be unavailable on other nodes. And the tombstone object is physically deleted only if it was in that node. Is this the right logic?