### PR TITLE
container: reduce the number of fetched iterator items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for NeoFS Node
 - Send on closed channel panic in node's new epoch handler (#3529)
 - Tomstoned objects revival not working (#3542)
 - Negative logic object counters in metabase (#3555)
+- Inability to list 2K+ containers via API (#3558)
 
 ### Changed
 - Stream payload without buffering to reduce memory usage in CLI `Get/Put` operations (#3535)

--- a/pkg/morph/client/container/client.go
+++ b/pkg/morph/client/container/client.go
@@ -41,8 +41,10 @@ const (
 
 	// iteratorPrefetchNumber is a number of stack items to prefetch in the
 	// first call of iterator-based methods. neo-go's stack elements default
-	// limit is 2048, make it less a little.
-	iteratorPrefetchNumber = 2000
+	// limit is 2048, but JSON output is then limited to 128K, given that
+	// each item has ~30 bytes overhead for type/value structure using large
+	// values is dangerous here.
+	iteratorPrefetchNumber = 512
 )
 
 var (


### PR DESCRIPTION
An attempt to list 2K+ containers ended up this way:

    error	handler/util.go:34	call method	{"status": 500, "request_id": "0cedec2b-935d-4575-a0c2-94ed4650c978", "method": "ListBuckets", "bucket": "", "object": "", "description": "something went wrong", "error": "list user containers via connection pool: status: code = 1024 message = json error: too big: size"}

We're trying to get 2K items from the iterator in a single call, each item is base64 of CID, so it's 42 bytes, but then it's wrapped into VM type/value struct like this:

    {"value":"","type":"ByteString"}

which adds another 32 bytes. For 2K elements this yields 144K JSON (not including other data which is also present) which NeoGo refuses to return given that the maximum size is 128K (https://github.com/nspcc-dev/neo-go/pull/3185). Fetching in smaller chunks should fix the problem (for other iterator-based methods as well).