### PR TITLE
go.mod: switch to nspcc-dev/bbolt completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for NeoFS Node
 - Alphabet nodes send basic storage income based on the new Reports API from `container` contract (#3053)
 - Use stream API of FSTree for object service `Get` operation (#3466)
 - Use meta buckets to mark containers with GC (#3561)
+- Switched to local BoltDB fork based on go.etcd.io/bbolt version 1.4.3 (#3576)
 
 ### Removed
 - `neofs-cli object head --main-only` no-op flag (#3509)

--- a/cmd/neofs-lens/internal/meta/root.go
+++ b/cmd/neofs-lens/internal/meta/root.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/spf13/cobra"
-	"go.etcd.io/bbolt"
 )
 
 var (

--- a/cmd/neofs-lens/internal/storage/root.go
+++ b/cmd/neofs-lens/internal/storage/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/config"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/common"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
@@ -15,7 +16,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/util"
 	"github.com/panjf2000/ants/v2"
 	"github.com/spf13/cobra"
-	"go.etcd.io/bbolt"
 )
 
 var (

--- a/cmd/neofs-lens/internal/storage/sanity.go
+++ b/cmd/neofs-lens/internal/storage/sanity.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/bbolt"
 	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-node/config"
 	engineconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine"
@@ -20,7 +21,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/spf13/cobra"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/cmd/neofs-node/storage.go
+++ b/cmd/neofs-node/storage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	engineconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/engine"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/common"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
@@ -17,7 +18,6 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/panjf2000/ants/v2"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/nspcc-dev/neofs-node
 
 go 1.23
 
-replace go.etcd.io/bbolt v1.4.0 => github.com/nspcc-dev/bbolt v0.0.0-20250612101626-5df2544a4a22
-
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cheggaaa/pb v1.0.29
@@ -19,6 +17,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/mxschmitt/golang-combinations v1.2.0
+	github.com/nspcc-dev/bbolt v0.0.0-20250911202005-807225ebb0c8
 	github.com/nspcc-dev/hrw/v2 v2.0.3
 	github.com/nspcc-dev/locode-db v0.6.0
 	github.com/nspcc-dev/neo-go v0.111.0
@@ -34,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0
-	go.etcd.io/bbolt v1.4.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
 	golang.org/x/net v0.35.0
@@ -97,6 +95,7 @@ require (
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/urfave/cli/v2 v2.27.6 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+	go.etcd.io/bbolt v1.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxschmitt/golang-combinations v1.2.0 h1:V5E7MncIK8Yr1SL/SpdqMuSquFsfoIs5auI7Y3n8z14=
 github.com/mxschmitt/golang-combinations v1.2.0/go.mod h1:RCm5eR03B+JrBOMRDLsKZWShluXdrHu+qwhPEJ0miBM=
-github.com/nspcc-dev/bbolt v0.0.0-20250612101626-5df2544a4a22 h1:M5Nmg1iCnbZngzIBDIlMr9vW+okFfcSMBvBlXG8r+14=
-github.com/nspcc-dev/bbolt v0.0.0-20250612101626-5df2544a4a22/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
+github.com/nspcc-dev/bbolt v0.0.0-20250911202005-807225ebb0c8 h1:lYMHisGPtL70vqCe/M+cU27HMZcV2PTYTaRmO7qxhMQ=
+github.com/nspcc-dev/bbolt v0.0.0-20250911202005-807225ebb0c8/go.mod h1:iYl+DCkSLXgVCeQWyC+kqS9V1fAQCA74JZtptwjNYpc=
 github.com/nspcc-dev/dbft v0.4.0 h1:4/atD4GrrMEtrYBDiZPrPzdKZ6ws7PR/cg0M4DEdVeI=
 github.com/nspcc-dev/dbft v0.4.0/go.mod h1:msYlF5GIGwOZ9jUIHttBAAtiqJ29jzV8PPKKv1avXAI=
 github.com/nspcc-dev/go-ordered-json v0.0.0-20250226190835-fb3f82b1f468 h1:qOd9/UANpXOME/3RTSa/dJoSzdVwYOkD32XQah0xj1E=
@@ -306,6 +306,8 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
+go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0/go.mod h1:p8pYQP+m5XfbZm9fxtSKAbM6oIllS7s2AfxrChvc7iw=
 go.opentelemetry.io/otel v1.32.0 h1:WnBN+Xjcteh0zdk01SVqV55d/m62NJLJdIyb4y/WO5U=

--- a/pkg/local_object_storage/engine/control_test.go
+++ b/pkg/local_object_storage/engine/control_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
@@ -16,7 +17,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/writecache"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap/zaptest"
 )
 

--- a/pkg/local_object_storage/metabase/containers.go
+++ b/pkg/local_object_storage/metabase/containers.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
+	bolterrors "github.com/nspcc-dev/bbolt/errors"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"go.etcd.io/bbolt"
-	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 const (

--- a/pkg/local_object_storage/metabase/control.go
+++ b/pkg/local_object_storage/metabase/control.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/nspcc-dev/bbolt"
+	bolterrors "github.com/nspcc-dev/bbolt/errors"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	"github.com/nspcc-dev/neofs-node/pkg/util"
-	"go.etcd.io/bbolt"
-	bolterrors "go.etcd.io/bbolt/errors"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/counter.go
+++ b/pkg/local_object_storage/metabase/counter.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 var objectPhyCounterKey = []byte("phy_counter")

--- a/pkg/local_object_storage/metabase/db.go
+++ b/pkg/local_object_storage/metabase/db.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/db_test.go
+++ b/pkg/local_object_storage/metabase/db_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/internal/testutil"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
@@ -20,7 +21,6 @@ import (
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 type epochState struct{ e uint64 }

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -3,11 +3,11 @@ package meta
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/ec.go
+++ b/pkg/local_object_storage/metabase/ec.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	iec "github.com/nspcc-dev/neofs-node/internal/ec"
 	islices "github.com/nspcc-dev/neofs-node/internal/slices"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
@@ -13,7 +14,6 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // ResolveECPart resolves object that carries EC part produced within cnr for

--- a/pkg/local_object_storage/metabase/ec_test.go
+++ b/pkg/local_object_storage/metabase/ec_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	iec "github.com/nspcc-dev/neofs-node/internal/ec"
 	"github.com/nspcc-dev/neofs-node/internal/testutil"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
@@ -16,7 +17,6 @@ import (
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 func BenchmarkDB_ResolveECPart(b *testing.B) {

--- a/pkg/local_object_storage/metabase/exists.go
+++ b/pkg/local_object_storage/metabase/exists.go
@@ -7,13 +7,13 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // objectStatus(), inGraveyard() and inGraveyardWithKey() return codes.

--- a/pkg/local_object_storage/metabase/get.go
+++ b/pkg/local_object_storage/metabase/get.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
@@ -17,7 +18,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/nspcc-dev/tzhash/tz"
-	"go.etcd.io/bbolt"
 )
 
 // Get returns partial object header data for specified address (as stored in

--- a/pkg/local_object_storage/metabase/graveyard.go
+++ b/pkg/local_object_storage/metabase/graveyard.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // GarbageObject represents descriptor of the

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 var errBreakBucketForEach = errors.New("bucket ForEach break")

--- a/pkg/local_object_storage/metabase/iterators.go
+++ b/pkg/local_object_storage/metabase/iterators.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/nspcc-dev/bbolt"
 	islices "github.com/nspcc-dev/neofs-node/internal/slices"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/last_resync_epoch.go
+++ b/pkg/local_object_storage/metabase/last_resync_epoch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"go.etcd.io/bbolt"
+	"github.com/nspcc-dev/bbolt"
 )
 
 var lastResyncEpochKey = []byte("last_resync_epoch")

--- a/pkg/local_object_storage/metabase/list.go
+++ b/pkg/local_object_storage/metabase/list.go
@@ -3,11 +3,11 @@ package meta
 import (
 	"bytes"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // ErrEndOfListing is returned from object listing with cursor

--- a/pkg/local_object_storage/metabase/list_test.go
+++ b/pkg/local_object_storage/metabase/list_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
@@ -12,7 +13,6 @@ import (
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 func BenchmarkListWithCursor(b *testing.B) {

--- a/pkg/local_object_storage/metabase/lock.go
+++ b/pkg/local_object_storage/metabase/lock.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/metadata.go
+++ b/pkg/local_object_storage/metabase/metadata.go
@@ -8,13 +8,13 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/metadata_test.go
+++ b/pkg/local_object_storage/metabase/metadata_test.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
+	bolterrors "github.com/nspcc-dev/bbolt/errors"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	metatest "github.com/nspcc-dev/neofs-node/pkg/util/meta/test"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
@@ -24,8 +26,6 @@ import (
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
-	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 func sortObjectIDs(ids []oid.ID) []oid.ID {

--- a/pkg/local_object_storage/metabase/movable.go
+++ b/pkg/local_object_storage/metabase/movable.go
@@ -3,8 +3,8 @@ package meta
 import (
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // ToMoveIt marks objects to move it into another shard. This useful for

--- a/pkg/local_object_storage/metabase/put.go
+++ b/pkg/local_object_storage/metabase/put.go
@@ -7,6 +7,7 @@ import (
 	gio "io"
 	"slices"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	objectCore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	storagelog "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/internal/log"
@@ -14,7 +15,6 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 var (

--- a/pkg/local_object_storage/metabase/revive.go
+++ b/pkg/local_object_storage/metabase/revive.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // ErrObjectWasNotRemoved is returned when object neither in the graveyard nor was marked with GC mark.

--- a/pkg/local_object_storage/metabase/select.go
+++ b/pkg/local_object_storage/metabase/select.go
@@ -7,11 +7,11 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // Select returns list of addresses of objects that match search filters.

--- a/pkg/local_object_storage/metabase/shard_id.go
+++ b/pkg/local_object_storage/metabase/shard_id.go
@@ -3,7 +3,7 @@ package meta
 import (
 	"bytes"
 
-	"go.etcd.io/bbolt"
+	"github.com/nspcc-dev/bbolt"
 )
 
 var (

--- a/pkg/local_object_storage/metabase/status.go
+++ b/pkg/local_object_storage/metabase/status.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"slices"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	objectSDK "github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 // BucketValue pairs a bucket index and a value that relates

--- a/pkg/local_object_storage/metabase/util.go
+++ b/pkg/local_object_storage/metabase/util.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/nspcc-dev/bbolt"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 )
 
 const attributeDelimiterLen = 1

--- a/pkg/local_object_storage/metabase/version.go
+++ b/pkg/local_object_storage/metabase/version.go
@@ -8,13 +8,13 @@ import (
 	"slices"
 
 	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/local_object_storage/metabase/version_test.go
+++ b/pkg/local_object_storage/metabase/version_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/internal/testutil"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
@@ -28,7 +29,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/nspcc-dev/tzhash/tz"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )

--- a/pkg/local_object_storage/shard/metrics_test.go
+++ b/pkg/local_object_storage/shard/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
@@ -15,7 +16,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 type metricsStore struct {

--- a/pkg/local_object_storage/writecache/migrate_test.go
+++ b/pkg/local_object_storage/writecache/migrate_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 func TestMigrateFromBolt(t *testing.T) {

--- a/pkg/local_object_storage/writecache/writecache.go
+++ b/pkg/local_object_storage/writecache/writecache.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/services/meta/notifications_test.go
+++ b/pkg/services/meta/notifications_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neo-go/pkg/core/block"
 	"github.com/nspcc-dev/neo-go/pkg/core/mpt"
 	"github.com/nspcc-dev/neo-go/pkg/core/state"
@@ -33,7 +34,6 @@ import (
 	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap/zaptest"
 )
 

--- a/pkg/services/session/storage/persistent/executor.go
+++ b/pkg/services/session/storage/persistent/executor.go
@@ -4,8 +4,8 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
-	"go.etcd.io/bbolt"
 )
 
 // Store saves parameterized private key in the underlying Bolt database.

--- a/pkg/services/session/storage/persistent/executor_test.go
+++ b/pkg/services/session/storage/persistent/executor_test.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
 func TestTokenStore(t *testing.T) {

--- a/pkg/services/session/storage/persistent/storage.go
+++ b/pkg/services/session/storage/persistent/storage.go
@@ -6,9 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/services/session/storage"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
-	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
 )
 

--- a/pkg/services/session/storage/persistent/util.go
+++ b/pkg/services/session/storage/persistent/util.go
@@ -6,8 +6,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/nspcc-dev/bbolt"
 	"github.com/nspcc-dev/neofs-node/pkg/services/session/storage"
-	"go.etcd.io/bbolt"
 )
 
 const keyOffset = 8

--- a/pkg/util/state/storage.go
+++ b/pkg/util/state/storage.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"go.etcd.io/bbolt"
+	"github.com/nspcc-dev/bbolt"
 )
 
 // PersistentStorage is a wrapper around persistent K:V db that


### PR DESCRIPTION
1. It updates to BoltDB 1.4.3 effectively with some fixes (but requires additional testing now).
2. We can't solve https://github.com/nspcc-dev/neo-go/issues/3964 without using a module of our own and we want to use the same BoltDB version in all projects.
3. This is supposed to be temporary, but no one knows how long https://github.com/etcd-io/bbolt/pull/998 (or some alternative) will take.