### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/innerring/nns.go
+++ b/pkg/innerring/nns.go
@@ -3,6 +3,7 @@ package innerring
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/nep11"
@@ -48,10 +49,8 @@ func (x *neoFSNNS) CheckDomainRecord(domain string, record string) error {
 		return fmt.Errorf("get all text records of the NNS domain %q: %w", domain, err)
 	}
 
-	for i := range records {
-		if records[i] == record {
-			return nil
-		}
+	if slices.Contains(records, record) {
+		return nil
 	}
 
 	return privatedomains.ErrMissingDomainRecord

--- a/pkg/innerring/processors/netmap/nodevalidation/privatedomains/validator_test.go
+++ b/pkg/innerring/processors/netmap/nodevalidation/privatedomains/validator_test.go
@@ -3,6 +3,7 @@ package privatedomains
 import (
 	"encoding/hex"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
@@ -63,10 +64,8 @@ func (x *testNNS) CheckDomainRecord(domainName string, record string) error {
 		return errors.New("missing domain")
 	}
 
-	for i := range recs {
-		if recs[i] == record {
-			return nil
-		}
+	if slices.Contains(recs, record) {
+		return nil
 	}
 
 	return ErrMissingDomainRecord

--- a/pkg/network/group.go
+++ b/pkg/network/group.go
@@ -136,10 +136,8 @@ func WriteToNodeInfo(g AddressGroup, ni *netmap.NodeInfo) {
 // at least one common address.
 func (x AddressGroup) Intersects(x2 AddressGroup) bool {
 	for i := range x {
-		for j := range x2 {
-			if x[i].equal(x2[j]) {
-				return true
-			}
+		if slices.ContainsFunc(x2, x[i].equal) {
+			return true
 		}
 	}
 

--- a/pkg/services/object/acl/v2/util_test.go
+++ b/pkg/services/object/acl/v2/util_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"slices"
 	"testing"
 
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
@@ -42,14 +43,7 @@ func TestIsVerbCompatible(t *testing.T) {
 
 	for op, list := range table {
 		for _, verb := range verbs {
-			var contains bool
-			for _, v := range list {
-				if v == verb {
-					contains = true
-					break
-				}
-			}
-
+			var contains = slices.Contains(list, verb)
 			tok.ForVerb(verb)
 
 			require.Equal(t, contains, assertVerb(tok, op),


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.