### PR TITLE
meta: fix expired lock still locked the object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Inability to list 2K+ containers via API (#3558)
 - Not using the IR `fee.main_chain` config parameter (#3584)
 - Metadata signatures submission (#3591)
+- Expired lock still locked the object (#3601)
 
 ### Changed
 - Stream payload without buffering to reduce memory usage in CLI `Get/Put` operations (#3535)


### PR DESCRIPTION
When checking the lock bucket, it now checks whether the lock has expired or not.