### PR TITLE
node/objectsvc: clean up signatures correctly

### DIFF
--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -205,7 +205,7 @@ func (t *distributedTarget) distributeObject(obj objectSDK.Object, objMeta objec
 		// the same placement policy; placement's len must be kept the same, do
 		// not nil the slice, keep it initialized
 		for i := range t.collectedSignatures {
-			clear(t.collectedSignatures[i])
+			t.collectedSignatures[i] = t.collectedSignatures[i][:0]
 		}
 	}()
 


### PR DESCRIPTION
Placement vectors must be the same length, but signatures should be cleaned up correctly. Problem was added in a9202b1c6b8776beb2ff8276144d7bb947934e00.