### PR TITLE
*: update contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/nspcc-dev/locode-db v0.8.1
 	github.com/nspcc-dev/neo-go v0.112.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
-	github.com/nspcc-dev/neofs-contract v0.23.1-0.20250923094803-bf67baf7e5c4
+	github.com/nspcc-dev/neofs-contract v0.23.1-0.20250928071444-e2ff883a3999
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.14.0.20250909131532-07fa82695f26
 	github.com/nspcc-dev/tzhash v1.8.3
 	github.com/panjf2000/ants/v2 v2.11.3

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250918092801-ae9c0aa1deed h1:sO
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20250918092801-ae9c0aa1deed/go.mod h1:3byneDNT60tiD8MSyGSyjpI1uVp9v+coySegJoQPF8c=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK0EMGLvunXcFyq7fBURS/CsN4MH+4nlYiqn6pTwWAU=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
-github.com/nspcc-dev/neofs-contract v0.23.1-0.20250923094803-bf67baf7e5c4 h1:77FMXMCdguCHUHbooWTNCK12vwJ7GQB01hpjTlS7854=
-github.com/nspcc-dev/neofs-contract v0.23.1-0.20250923094803-bf67baf7e5c4/go.mod h1:PPxjwRiK6hhXPXduvyojEqLMHNpgPaF+rULPhdFlzDg=
+github.com/nspcc-dev/neofs-contract v0.23.1-0.20250928071444-e2ff883a3999 h1:0U+0bO74WAc0B3pmRFoQMtlwJfqhf4yRdkEKoKqEIo4=
+github.com/nspcc-dev/neofs-contract v0.23.1-0.20250928071444-e2ff883a3999/go.mod h1:PPxjwRiK6hhXPXduvyojEqLMHNpgPaF+rULPhdFlzDg=
 github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.14.0.20250909131532-07fa82695f26 h1:GBzunGu1m9WO5cKNbPXyU6dO7r1O4FJNhSSWZfKe5co=
 github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.14.0.20250909131532-07fa82695f26/go.mod h1:0KUJG36JsjXxJzpals+jYMWpjSGINuja147K2OfmP4Q=
 github.com/nspcc-dev/rfc6979 v0.2.3 h1:QNVykGZ3XjFwM/88rGfV3oj4rKNBy+nYI6jM7q19hDI=

--- a/pkg/innerring/processors/settlement/calls.go
+++ b/pkg/innerring/processors/settlement/calls.go
@@ -79,7 +79,7 @@ func (p *Processor) HandleBasicIncomeEvent(e event.Event) {
 
 	l.Info("start basic income calculation...")
 
-	payments := p.calculatePayments(l, rate, epoch, cnrs)
+	payments := p.calculatePayments(l, rate, cnrs)
 
 	l.Info("basic income calculated, transfer tokens...", zap.Int("numberOfRecievers", len(payments.nodes)))
 
@@ -88,7 +88,7 @@ func (p *Processor) HandleBasicIncomeEvent(e event.Event) {
 	l.Debug("finished basic income distribution")
 }
 
-func (p *Processor) calculatePayments(l *zap.Logger, paymentRate, epoch uint64, cnrs []cid.ID) *incomeReceivers {
+func (p *Processor) calculatePayments(l *zap.Logger, paymentRate uint64, cnrs []cid.ID) *incomeReceivers {
 	var (
 		wg            errgroup.Group
 		transferTable = incomeReceivers{nodes: make(map[string][]payment)}
@@ -104,7 +104,7 @@ func (p *Processor) calculatePayments(l *zap.Logger, paymentRate, epoch uint64, 
 			}
 			owner := cnr.Owner()
 
-			reports, err := p.cnrClient.NodeReports(epoch, cID)
+			reports, err := p.cnrClient.NodeReports(cID)
 			if err != nil {
 				l.Warn("failed to get container reports, container will be skipped", zap.Stringer("cID", cID), zap.Error(err))
 				return nil

--- a/pkg/morph/client/container/load.go
+++ b/pkg/morph/client/container/load.go
@@ -70,11 +70,10 @@ func (c *Client) PutReport(cID cid.ID, storageSize, objsNumber uint64, key []byt
 	return nil
 }
 
-// NodeReports returns a list of container load reports for to the
-// specified epoch.
+// NodeReports returns a list of container load reports.
 // The list is composed through Container contract call.
-func (c *Client) NodeReports(epoch uint64, cID cid.ID) ([]Report, error) {
-	rr, err := c.client.TestInvokeIterator(fschaincontracts.IterateContainerReportsMethod, iteratorPrefetchNumber, epoch, cID[:])
+func (c *Client) NodeReports(cID cid.ID) ([]Report, error) {
+	rr, err := c.client.TestInvokeIterator(fschaincontracts.IterateContainerReportsMethod, iteratorPrefetchNumber, cID[:])
 	if err != nil {
 		return nil, fmt.Errorf("could not perform test invocation (%s): %w", fschaincontracts.IterateContainerReportsMethod, err)
 	}
@@ -128,10 +127,10 @@ func (s *Summary) FromStackItem(item stackitem.Item) error {
 
 // GetReportsSummary returns summary report based on preceding [PutReport]
 // calls made by storage nodes.
-func (c *Client) GetReportsSummary(epoch uint64, cID cid.ID) (Summary, error) {
+func (c *Client) GetReportsSummary(cID cid.ID) (Summary, error) {
 	prm := client.TestInvokePrm{}
 	prm.SetMethod(fschaincontracts.GetReportsSummaryMethod)
-	prm.SetArgs(epoch, cID[:])
+	prm.SetArgs(cID[:])
 
 	res, err := c.client.TestInvoke(prm)
 	if err != nil {


### PR DESCRIPTION
e2ff883a39997b2f87082c790773b8042889c31f was used. Container space loads have no epoch args anymore.