### PR TITLE
engine: store lock object with locked at the same shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog for NeoFS Node
 - Inability to list 2K+ containers via API (#3558)
 - Not using the IR `fee.main_chain` config parameter (#3584)
 - Metadata signatures submission (#3591)
-- Expired lock still locked the object (#3601)
+- Expired lock still locked the object (#3601, #3616)
 - Empty storage and error-free startup when changing layout parameters (#3594)
 - Flaky storage evacuation unit test (#3605)
 - Incorrect search request from SN when processing tombstones (#3610)

--- a/pkg/local_object_storage/engine/lock.go
+++ b/pkg/local_object_storage/engine/lock.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 
+	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/util/logicerr"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
@@ -40,9 +41,9 @@ func (e *StorageEngine) Lock(idCnr cid.ID, locker oid.ID, locked []oid.ID) error
 }
 
 func (e *StorageEngine) lock(idCnr cid.ID, locker, locked oid.ID) error {
-	err := e.lockSingle(idCnr, locker, locked, true)
+	err := e.lockSingle(idCnr, locker, locked, true, nil, nil)
 	if errors.Is(err, errLockFailed) {
-		err = e.lockSingle(idCnr, locker, locked, false)
+		err = e.lockSingle(idCnr, locker, locked, false, nil, nil)
 	}
 	if err != nil {
 		return logicerr.Wrap(err)
@@ -51,7 +52,20 @@ func (e *StorageEngine) lock(idCnr cid.ID, locker, locked oid.ID) error {
 	return nil
 }
 
-func (e *StorageEngine) lockSingle(idCnr cid.ID, locker, locked oid.ID, checkExists bool) error {
+// lockWithObject creates lock metadata and stores the lock object in the same shard
+func (e *StorageEngine) lockWithObject(idCnr cid.ID, locker, locked oid.ID, lockObj *objectSDK.Object, objBin []byte) error {
+	err := e.lockSingle(idCnr, locker, locked, true, lockObj, objBin)
+	if errors.Is(err, errLockFailed) {
+		err = e.lockSingle(idCnr, locker, locked, false, lockObj, objBin)
+	}
+	if err != nil {
+		return logicerr.Wrap(err)
+	}
+
+	return nil
+}
+
+func (e *StorageEngine) lockSingle(idCnr cid.ID, locker, locked oid.ID, checkExists bool, lockObj *objectSDK.Object, objBin []byte) error {
 	// code is pretty similar to inhumeAddr, maybe unify?
 	var (
 		addrLocked oid.Address
@@ -61,7 +75,7 @@ func (e *StorageEngine) lockSingle(idCnr cid.ID, locker, locked oid.ID, checkExi
 	addrLocked.SetContainer(idCnr)
 	addrLocked.SetObject(locked)
 
-	for _, sh := range e.sortedShards(addrLocked) {
+	for i, sh := range e.sortedShards(addrLocked) {
 		if checkExists {
 			exists, err := sh.Exists(addrLocked, false)
 			if err != nil {
@@ -107,6 +121,24 @@ func (e *StorageEngine) lockSingle(idCnr cid.ID, locker, locked oid.ID, checkExi
 			}
 		} else {
 			status = nil
+
+			// if we have a lock object, store it immediately after successful lock
+			if lockObj != nil {
+				e.mtx.RLock()
+				pool, ok := e.shardPools[sh.ID().String()]
+				e.mtx.RUnlock()
+				if !ok {
+					// Shard was concurrently removed, skip.
+					continue
+				}
+
+				lockAddr := object.AddressOf(lockObj)
+
+				putDone, exists, _ := e.putToShard(sh, i, pool, lockAddr, lockObj, objBin)
+				if putDone || exists {
+					return nil
+				}
+			}
 		}
 
 		// if object is root we continue since information about it

--- a/pkg/local_object_storage/engine/lock_test.go
+++ b/pkg/local_object_storage/engine/lock_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -355,4 +356,162 @@ func testLockRemoved(t *testing.T, shardNum int) {
 			require.ErrorIs(t, err, apistatus.ErrObjectNotFound)
 		})
 	}
+}
+
+func TestSplitObjectLockExpiration(t *testing.T) {
+	const numOfShards = 3
+
+	dir := t.TempDir()
+	es := &asyncEpochState{e: 10}
+	e := New()
+
+	for i := range numOfShards {
+		_, err := e.AddShard(
+			shard.WithBlobstor(
+				newStorage(filepath.Join(dir, fmt.Sprintf("fstree%d", i))),
+			),
+			shard.WithMetaBaseOptions(
+				meta.WithPath(filepath.Join(dir, fmt.Sprintf("metabase%d", i))),
+				meta.WithPermissions(0700),
+				meta.WithEpochState(es),
+			),
+			shard.WithExpiredObjectsCallback(e.processExpiredObjects),
+			shard.WithExpiredLocksCallback(e.processExpiredLocks),
+			// shard.WithGCRemoverSleepInterval(100*time.Millisecond),
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, e.Open())
+	require.NoError(t, e.Init())
+	t.Cleanup(func() { _ = e.Close() })
+
+	cnr := cidtest.ID()
+	parentID := oidtest.ID()
+	splitID := object.NewSplitID()
+
+	parent := generateObjectWithCID(cnr)
+	parent.SetID(parentID)
+	parent.SetPayload(nil)
+	parentAddr := objectcore.AddressOf(parent)
+
+	const childCount = 3
+	children := make([]*object.Object, childCount)
+	childIDs := make([]oid.ID, childCount)
+	childAddrs := make([]oid.Address, childCount)
+
+	for i := range children {
+		children[i] = generateObjectWithCID(cnr)
+		if i != 0 {
+			children[i].SetPreviousID(childIDs[i-1])
+		}
+		if i == len(children)-1 {
+			children[i].SetParent(parent)
+		}
+		children[i].SetSplitID(splitID)
+		children[i].SetPayload([]byte{byte(i), byte(i + 1), byte(i + 2)})
+		children[i].SetPayloadSize(3)
+		childIDs[i] = children[i].GetID()
+		childAddrs[i] = objectcore.AddressOf(children[i])
+	}
+
+	link := generateObjectWithCID(cnr)
+	link.SetParent(parent)
+	link.SetParentID(parentID)
+	link.SetSplitID(splitID)
+	link.SetChildren(childIDs...)
+
+	for i := range children {
+		require.NoError(t, e.Put(children[i], nil))
+	}
+	require.NoError(t, e.Put(link, nil))
+
+	_, err := e.Get(parentAddr)
+	var splitErr *object.SplitInfoError
+	require.ErrorAs(t, err, &splitErr)
+	require.Equal(t, splitID, splitErr.SplitInfo().SplitID())
+
+	t.Run("split object lock with expiring locker", func(t *testing.T) {
+		lockObj := generateObjectWithCID(cnr)
+		lockObj.SetType(object.TypeLock)
+		addExpirationAttribute(lockObj, es.CurrentEpoch()+1)
+
+		lockObj.AssociateLocked(parentID)
+
+		require.NoError(t, e.Put(lockObj, nil))
+
+		l, err := e.IsLocked(parentAddr)
+		require.NoError(t, err)
+		require.True(t, l)
+
+		// Advance epoch but keep lock valid
+		tickEpoch(es, e)
+
+		l, err = e.IsLocked(parentAddr)
+		require.NoError(t, err)
+		require.True(t, l)
+
+		// Advance epoch again - now lock should expire
+		tickEpoch(es, e)
+
+		l, err = e.IsLocked(parentAddr)
+		require.NoError(t, err)
+		require.False(t, l)
+	})
+}
+
+func TestSimpleLockExpiration(t *testing.T) {
+	const numOfShards = 2
+	dir := t.TempDir()
+	es := &asyncEpochState{e: 10}
+	e := New()
+
+	for i := range numOfShards {
+		_, err := e.AddShard(
+			shard.WithBlobstor(
+				newStorage(filepath.Join(dir, fmt.Sprintf("fstree%d", i))),
+			),
+			shard.WithMetaBaseOptions(
+				meta.WithPath(filepath.Join(dir, fmt.Sprintf("metabase%d", i))),
+				meta.WithPermissions(0700),
+				meta.WithEpochState(es),
+			),
+			// shard.WithExpiredObjectsCallback(e.processExpiredObjects),
+			// shard.WithExpiredLocksCallback(e.processExpiredLocks),
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, e.Open())
+	require.NoError(t, e.Init())
+	t.Cleanup(func() { _ = e.Close() })
+
+	cnr := cidtest.ID()
+	obj := generateObjectWithCID(cnr)
+	objID := obj.GetID()
+	objAddr := objectcore.AddressOf(obj)
+
+	lock := generateObjectWithCID(cnr)
+	lock.SetType(object.TypeLock)
+	lock.AssociateLocked(objID)
+	addExpirationAttribute(lock, es.CurrentEpoch()+1)
+
+	require.NoError(t, e.Put(obj, nil))
+	require.NoError(t, e.Put(lock, nil))
+
+	locked, err := e.IsLocked(objAddr)
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	// Advance epoch but keep lock valid
+	tickEpoch(es, e)
+
+	locked, err = e.IsLocked(objAddr)
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	// Advance epoch again - now lock should expire
+	tickEpoch(es, e)
+
+	locked, err = e.IsLocked(objAddr)
+	require.NoError(t, err)
+	require.False(t, locked)
 }

--- a/pkg/local_object_storage/engine/put.go
+++ b/pkg/local_object_storage/engine/put.go
@@ -71,9 +71,11 @@ func (e *StorageEngine) Put(obj *objectSDK.Object, objBin []byte) error {
 	case objectSDK.TypeLock:
 		locked := obj.AssociatedObject()
 		if !locked.IsZero() {
-			if err := e.lock(addr.Container(), addr.Object(), locked); err != nil {
+			if err := e.lockWithObject(addr.Container(), addr.Object(), locked, obj, objBin); err != nil {
 				return err
 			}
+			// lock object has been stored, no need to continue with normal Put flow
+			return nil
 		}
 	default:
 	}


### PR DESCRIPTION
Is this solution appropriate? Should we also consider a put service that uses [Lock](https://github.com/nspcc-dev/neofs-node/blob/2a76d3169b27dfd6bde7ccdea5e5bed5c1303f9f/pkg/services/object/put/local.go#L49)?