### PR TITLE
shard: exit early if there are no objects to delete

### DIFF
--- a/pkg/local_object_storage/shard/delete.go
+++ b/pkg/local_object_storage/shard/delete.go
@@ -24,6 +24,10 @@ func (s *Shard) deleteObjs(addrs []oid.Address) error {
 		return ErrDegradedMode
 	}
 
+	if len(addrs) == 0 {
+		return nil
+	}
+
 	for _, addr := range addrs {
 		if s.hasWriteCache() {
 			err := s.writeCache.Delete(addr)


### PR DESCRIPTION
Regular GC cycle is very much noticeable in profiler even where there are no objects to drop. The problem is that deleteObjs() is being called with zero items and it opens a DB transaction even when it doesn't need one. DB transaction has a substantial cost to it since it will perform some changes to the file even if no key-values are changed. It can also affect other threads since DB write transaction is exclusive.