### PR TITLE
pkg/timers: do not skip delta handlers ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - Write cache using too much CPU (#3642)
 - Split object with link not found stuck in GC cycle (#3653)
 - Quotas TTL (#3665)
+- SN load reporting race (#3652)
 
 ### Changed
 - Move `fschain_autodeploy` into `fschain.disable_autodeploy` in IR config (#3619)

--- a/cmd/neofs-node/container.go
+++ b/cmd/neofs-node/container.go
@@ -179,19 +179,9 @@ func initSizeLoadReports(c *cfg) {
 
 			return
 		}
-		height, err := c.cli.GetBlockCount()
-		if err != nil {
-			l.Warn("failed to get the current height to reset epoch timer", zap.Error(err))
-			return
-		}
-		currH, err := c.cli.GetBlockHeader(height - 1)
-		if err != nil {
-			l.Warn("failed to get the current block to reset epoch timer", zap.Error(err))
-			return
-		}
 
 		const msInS = 1000
-		c.cfgMorph.epochTimers.Reset(lastTickH.Timestamp, currH.Timestamp, epochDuration*msInS)
+		c.cfgMorph.epochTimers.Reset(lastTickH.Timestamp, epochDuration*msInS)
 	})
 }
 

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -254,17 +254,8 @@ func (s *Server) resetEpochTimer(lastTickHeight uint32) (uint64, error) {
 		return 0, fmt.Errorf("can't read last tick's block header (#%d): %w", lastTick, err)
 	}
 
-	height, err := s.fsChainClient.GetBlockCount()
-	if err != nil {
-		return 0, fmt.Errorf("can't read current chain height: %w", err)
-	}
-	currH, err := s.fsChainClient.GetBlockHeader(height - 1)
-	if err != nil {
-		return 0, fmt.Errorf("can't read current block (#%d): %w", height-1, err)
-	}
-
 	const msInS = 1000
-	s.epochTimers.Reset(lastTickH.Timestamp, currH.Timestamp, epochDuration*msInS)
+	s.epochTimers.Reset(lastTickH.Timestamp, epochDuration*msInS)
 
 	return lastTickH.Timestamp + epochDuration*msInS, nil
 }

--- a/pkg/timers/timer.go
+++ b/pkg/timers/timer.go
@@ -75,9 +75,8 @@ func (et *EpochTimers) UpdateTime(curr uint64) {
 
 // Reset must be called every time [EpochTimers] user receives information
 // about new epoch event. lastTick must be block's timestamp that contains new
-// epoch event; curr must be the last known block's timestamp; dur is an actual
-// epoch duration in milliseconds.
-func (et *EpochTimers) Reset(lastTick, curr, dur uint64) {
+// epoch event; dur is an actual epoch duration in milliseconds.
+func (et *EpochTimers) Reset(lastTick, dur uint64) {
 	et.m.Lock()
 	defer et.m.Unlock()
 
@@ -86,7 +85,7 @@ func (et *EpochTimers) Reset(lastTick, curr, dur uint64) {
 
 	for _, dh := range et.deltaHandlers {
 		dh.nextTickAt = lastTick + dur*dh.mul/dh.div
-		dh.done = dh.nextTickAt < curr
+		dh.done = false
 	}
 }
 


### PR DESCRIPTION
It was intended to prevent apps from making useless handler calls when they are
outdated. Still, in practice, it introduced a race condition and skips events
that must occur immediately at the new epoch event or near it. Treat every
sub-epoch timer as not-called-yet at every `Reset` call; calling at the wrong
time (when there is an incredible latency) is less error-prone than not calling
at all. Closes #3652.