### PR TITLE
*: use wallet scrypt params instead of default ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for NeoFS Node
 - Split object with link not found stuck in GC cycle (#3653)
 - Quotas TTL (#3665)
 - SN load reporting race (#3652)
+- Incompatibility with wallets using non-standard scrypt parameters (#3675)
 
 ### Changed
 - Move `fschain_autodeploy` into `fschain.disable_autodeploy` in IR config (#3619)

--- a/cmd/neofs-adm/internal/modules/fschain/generate.go
+++ b/cmd/neofs-adm/internal/modules/fschain/generate.go
@@ -119,7 +119,7 @@ func addMultisigAccount(w *wallet.Wallet, m int, name, password string, pubs key
 	if err := acc.ConvertMultisig(m, pubs); err != nil {
 		return err
 	}
-	if err := acc.Encrypt(password, keys.NEP2ScryptParams()); err != nil {
+	if err := acc.Encrypt(password, w.Scrypt); err != nil {
 		return err
 	}
 	w.AddAccount(acc)

--- a/cmd/neofs-adm/internal/modules/fschain/generate_test.go
+++ b/cmd/neofs-adm/internal/modules/fschain/generate_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neo-go/cli/input"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/client"
@@ -67,7 +66,7 @@ func TestGenerateAlphabet(t *testing.T) {
 		require.NoError(t, err, "wallet doesn't exist")
 		require.Equal(t, 3, len(w.Accounts), "not all accounts were created")
 		for _, a := range w.Accounts {
-			err := a.Decrypt(strconv.FormatUint(i, 10), keys.NEP2ScryptParams())
+			err := a.Decrypt(strconv.FormatUint(i, 10), w.Scrypt)
 			require.NoError(t, err, "can't decrypt account")
 			switch a.Label {
 			case consensusAccountName:
@@ -118,7 +117,7 @@ func TestCreateWallets(t *testing.T) {
 		require.NoError(t, err)
 
 		acc := w.GetAccount(hashes[i])
-		require.NoError(t, acc.Decrypt(password, keys.NEP2ScryptParams()))
+		require.NoError(t, acc.Decrypt(password, w.Scrypt))
 
 		require.Equal(t, label, acc.Label)
 	}

--- a/cmd/neofs-adm/internal/modules/fschain/initialize.go
+++ b/cmd/neofs-adm/internal/modules/fschain/initialize.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/actor"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/invoker"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/trigger"
@@ -145,7 +144,7 @@ func openAlphabetWallets(v *viper.Viper, walletDir string) ([]*wallet.Wallet, er
 		}
 
 		for i := range w.Accounts {
-			if err := w.Accounts[i].Decrypt(password, keys.NEP2ScryptParams()); err != nil {
+			if err := w.Accounts[i].Decrypt(password, w.Scrypt); err != nil {
 				return nil, fmt.Errorf("can't unlock wallet: %w", err)
 			}
 		}

--- a/cmd/neofs-adm/internal/modules/fschain/notary.go
+++ b/cmd/neofs-adm/internal/modules/fschain/notary.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/cli/input"
 	"github.com/nspcc-dev/neo-go/pkg/core/transaction"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/actor"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/gas"
@@ -54,7 +53,7 @@ func depositNotary(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("can't get password: %w", err)
 	}
 
-	err = acc.Decrypt(pass, keys.NEP2ScryptParams())
+	err = acc.Decrypt(pass, w.Scrypt)
 	if err != nil {
 		return fmt.Errorf("can't unlock account: %w", err)
 	}

--- a/cmd/neofs-adm/internal/modules/fschain/quota.go
+++ b/cmd/neofs-adm/internal/modules/fschain/quota.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/nspcc-dev/neo-go/cli/input"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/actor"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient/invoker"
@@ -263,7 +262,7 @@ func unlockWallet(w *wallet.Wallet, accAddr util.Uint160) (*wallet.Account, erro
 		return nil, fmt.Errorf("failed to read account password: %w", err)
 	}
 
-	err = acc.Decrypt(pass, keys.NEP2ScryptParams())
+	err = acc.Decrypt(pass, w.Scrypt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unlock the account with password: %w", err)
 	}

--- a/cmd/neofs-adm/internal/modules/fschain/verified_domains.go
+++ b/cmd/neofs-adm/internal/modules/fschain/verified_domains.go
@@ -145,7 +145,7 @@ func verifiedNodesDomainSetAccessList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to read account password: %w", err)
 	}
 
-	err = acc.Decrypt(pass, keys.NEP2ScryptParams())
+	err = acc.Decrypt(pass, w.Scrypt)
 	if err != nil {
 		return fmt.Errorf("failed to unlock the account with password: %w", err)
 	}

--- a/cmd/neofs-adm/internal/modules/storagecfg/root.go
+++ b/cmd/neofs-adm/internal/modules/storagecfg/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/chzyer/readline"
 	"github.com/nspcc-dev/neo-go/cli/flags"
 	"github.com/nspcc-dev/neo-go/cli/input"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/fixedn"
 	"github.com/nspcc-dev/neo-go/pkg/rpcclient"
@@ -140,7 +139,7 @@ func storageConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = acc.Decrypt(c.Wallet.Password, keys.NEP2ScryptParams())
+	err = acc.Decrypt(c.Wallet.Password, w.Scrypt)
 	if err != nil {
 		return err
 	}

--- a/cmd/neofs-cli/internal/key/key_test.go
+++ b/cmd/neofs-cli/internal/key/key_test.go
@@ -35,12 +35,12 @@ func Test_getOrGenerate(t *testing.T) {
 
 	acc1, err := wallet.NewAccount()
 	require.NoError(t, err)
-	require.NoError(t, acc1.Encrypt("pass", keys.NEP2ScryptParams()))
+	require.NoError(t, acc1.Encrypt("pass", w.Scrypt))
 	w.AddAccount(acc1)
 
 	acc2, err := wallet.NewAccount()
 	require.NoError(t, err)
-	require.NoError(t, acc2.Encrypt("pass", keys.NEP2ScryptParams()))
+	require.NoError(t, acc2.Encrypt("pass", w.Scrypt))
 	acc2.Default = true
 	w.AddAccount(acc2)
 	require.NoError(t, w.Save())

--- a/cmd/neofs-cli/internal/key/wallet.go
+++ b/cmd/neofs-cli/internal/key/wallet.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/cli/flags"
 	"github.com/nspcc-dev/neo-go/cli/input"
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
 	"github.com/nspcc-dev/neofs-node/cmd/neofs-cli/internal/common"
@@ -52,7 +51,7 @@ func FromWallet(cmd *cobra.Command, w *wallet.Wallet, addrStr string) (*ecdsa.Pr
 		return nil, ErrInvalidPassword
 	}
 
-	if err := acc.Decrypt(pass, keys.NEP2ScryptParams()); err != nil {
+	if err := acc.Decrypt(pass, w.Scrypt); err != nil {
 		common.PrintVerbose(cmd, "Can't decrypt account: %v", err)
 		return nil, ErrInvalidPassword
 	}

--- a/pkg/innerring/innerring.go
+++ b/pkg/innerring/innerring.go
@@ -370,7 +370,7 @@ func New(ctx context.Context, log *zap.Logger, cfg *config.Config, errChan chan<
 	var consensusAcc *wallet.Account
 
 	for i := range wlt.Accounts {
-		err = wlt.Accounts[i].Decrypt(walletPass, keys.NEP2ScryptParams())
+		err = wlt.Accounts[i].Decrypt(walletPass, wlt.Scrypt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt account '%s' (%s) in wallet '%s': %w", wlt.Accounts[i].Label, cfg.Wallet.Address, walletPath, err)
 		}

--- a/pkg/util/config/crypto.go
+++ b/pkg/util/config/crypto.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 
-	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/encoding/address"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/nspcc-dev/neo-go/pkg/wallet"
@@ -34,7 +33,7 @@ func LoadAccount(path, addr, password string) (*wallet.Account, error) {
 		return nil, errors.New("account is missing")
 	}
 
-	if err := acc.Decrypt(password, keys.NEP2ScryptParams()); err != nil {
+	if err := acc.Decrypt(password, w.Scrypt); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Even though we're always using the same Scrypt parameters everywhere (except for some NeoGo internal tests), NEP-6 itself doesn't limit wallet in what scrypt settings they use, so the default ones might be wrong for some specific wallet and this can lead to decryption failure.