### PR TITLE
*: use strings.Cut instead of strings.Split where appropriate

### DIFF
--- a/cmd/neofs-adm/internal/modules/fschain/config.go
+++ b/cmd/neofs-adm/internal/modules/fschain/config.go
@@ -142,13 +142,10 @@ func setConfigCmd(cmd *cobra.Command, args []string) error {
 }
 
 func parseConfigPair(kvStr string, force bool) (key string, val any, err error) {
-	kv := strings.SplitN(kvStr, "=", 2)
-	if len(kv) != 2 {
+	key, valRaw, found := strings.Cut(kvStr, "=")
+	if !found {
 		return "", nil, fmt.Errorf("invalid parameter format: must be 'key=val', got: %s", kvStr)
 	}
-
-	key = kv[0]
-	valRaw := kv[1]
 
 	switch key {
 	case netmapBasicIncomeRateKey,
@@ -163,7 +160,7 @@ func parseConfigPair(kvStr string, force bool) (key string, val any, err error) 
 	case netmapEigenTrustAlphaKey:
 		// just check that it could
 		// be parsed correctly
-		_, err = strconv.ParseFloat(kv[1], 64)
+		_, err = strconv.ParseFloat(valRaw, 64)
 		if err != nil {
 			err = fmt.Errorf("invalid value for %s key, expected float, got '%s'", key, valRaw)
 		}

--- a/cmd/neofs-adm/internal/modules/fschain/policy.go
+++ b/cmd/neofs-adm/internal/modules/fschain/policy.go
@@ -26,23 +26,23 @@ func setPolicyCmd(cmd *cobra.Command, args []string) error {
 
 	b := smartcontract.NewBuilder()
 	for i := range args {
-		kv := strings.SplitN(args[i], "=", 2)
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(args[i], "=")
+		if !found {
 			return errors.New("invalid parameter format, must be Parameter=Value")
 		}
 
-		switch kv[0] {
+		switch k {
 		case execFeeParam, storagePriceParam, setFeeParam:
 		default:
 			return fmt.Errorf("parameter must be one of %s, %s and %s", execFeeParam, storagePriceParam, setFeeParam)
 		}
 
-		value, err := strconv.ParseUint(kv[1], 10, 32)
+		value, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
-			return fmt.Errorf("can't parse parameter value '%s': %w", args[1], err)
+			return fmt.Errorf("can't parse parameter value '%s': %w", v, err)
 		}
 
-		b.InvokeMethod(policy.Hash, "set"+kv[0], int64(value))
+		b.InvokeMethod(policy.Hash, "set"+k, int64(value))
 	}
 
 	script, err := b.Script()

--- a/cmd/neofs-cli/modules/container/create.go
+++ b/cmd/neofs-cli/modules/container/create.go
@@ -213,27 +213,27 @@ func parseContainerPolicy(cmd *cobra.Command, policyString string) (*netmap.Plac
 
 func parseAttributes(dst *container.Container, attributes []string) error {
 	for i := range attributes {
-		kvPair := strings.Split(attributes[i], attributeDelimiter)
-		if len(kvPair) != 2 {
+		k, v, found := strings.Cut(attributes[i], attributeDelimiter)
+		if !found {
 			return errors.New("invalid container attribute")
 		}
 
-		if kvPair[0] == "Timestamp" && !containerNoTimestamp {
+		if k == "Timestamp" && !containerNoTimestamp {
 			return errors.New("can't override default timestamp attribute, use '--disable-timestamp' flag")
 		}
 
-		if kvPair[0] == "Name" && containerName != "" && kvPair[1] != containerName {
+		if k == "Name" && containerName != "" && v != containerName {
 			return errors.New("name from the '--name' flag and the 'Name' attribute are not equal, " +
 				"you need to use one of them or make them equal")
 		}
 
-		if kvPair[0] == "" {
+		if k == "" {
 			return errors.New("empty attribute key")
-		} else if kvPair[1] == "" {
-			return fmt.Errorf("empty attribute value for key %s", kvPair[0])
+		} else if v == "" {
+			return fmt.Errorf("empty attribute value for key %s", k)
 		}
 
-		dst.SetAttribute(kvPair[0], kvPair[1])
+		dst.SetAttribute(k, v)
 	}
 
 	if !containerNoTimestamp {

--- a/cmd/neofs-cli/modules/control/notary_request.go
+++ b/cmd/neofs-cli/modules/control/notary_request.go
@@ -63,12 +63,12 @@ func notaryRequest(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid number of args provided for 'setConfig', expected 1, got %d", len(args))
 		}
 
-		kv := strings.SplitN(args[0], "=", 2)
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(args[0], "=")
+		if !found {
 			return fmt.Errorf("invalid parameter format: must be 'key=val', got: %s", args[0])
 		}
 
-		body.SetArgs([][]byte{[]byte(kv[0]), []byte(kv[1])})
+		body.SetArgs([][]byte{[]byte(k), []byte(v)})
 	case "removeNode":
 		if len(args) != 1 {
 			return fmt.Errorf("invalid number of args provided for 'removeNode', expected 1, got %d", len(args))

--- a/cmd/neofs-cli/modules/object/put.go
+++ b/cmd/neofs-cli/modules/object/put.go
@@ -218,36 +218,36 @@ func parseObjectAttrs(cmd *cobra.Command, ctx context.Context) ([]object.Attribu
 
 	attrs := make([]object.Attribute, len(rawAttrs), len(rawAttrs)+3) // name + timestamp + expiration epoch attributes
 	for i := range rawAttrs {
-		kv := strings.SplitN(rawAttrs[i], "=", 2)
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(rawAttrs[i], "=")
+		if !found {
 			return nil, fmt.Errorf("invalid attribute format: %s", rawAttrs[i])
 		}
 
-		if kv[0] == object.AttributeTimestamp && !disableTime {
+		if k == object.AttributeTimestamp && !disableTime {
 			return nil, errors.New("can't override default timestamp attribute, use '--disable-timestamp' flag")
 		}
 
-		if kv[0] == object.AttributeFileName && !disableFilename {
+		if k == object.AttributeFileName && !disableFilename {
 			return nil, errors.New("can't override default filename attribute, use '--disable-filename' flag")
 		}
 
-		if kv[0] == object.AttributeExpirationEpoch {
+		if k == object.AttributeExpirationEpoch {
 			expAttrFound = true
 
-			if expiresOn > 0 && kv[1] != expAttrValue {
+			if expiresOn > 0 && v != expAttrValue {
 				return nil, errors.New("the value of the expiration attribute and the value from '--expire-at' or '--lifetime' flags are not equal, " +
 					"you need to use one of them or make them equal")
 			}
 		}
 
-		if kv[0] == "" {
+		if k == "" {
 			return nil, errors.New("empty attribute key")
-		} else if kv[1] == "" {
-			return nil, fmt.Errorf("empty attribute value for key %s", kv[0])
+		} else if v == "" {
+			return nil, fmt.Errorf("empty attribute value for key %s", k)
 		}
 
-		attrs[i].SetKey(kv[0])
-		attrs[i].SetValue(kv[1])
+		attrs[i].SetKey(k)
+		attrs[i].SetValue(v)
 	}
 
 	if !disableFilename {

--- a/cmd/neofs-cli/modules/object/range.go
+++ b/cmd/neofs-cli/modules/object/range.go
@@ -194,16 +194,16 @@ func getRangeList(cmd *cobra.Command) ([]*object.Range, error) {
 	vs := strings.Split(v, ",")
 	rs := make([]*object.Range, len(vs))
 	for i := range vs {
-		r := strings.Split(vs[i], rangeSep)
-		if len(r) != 2 {
+		offString, lenString, found := strings.Cut(vs[i], rangeSep)
+		if !found {
 			return nil, fmt.Errorf("invalid range specifier: %s", vs[i])
 		}
 
-		offset, err := strconv.ParseUint(r[0], 10, 64)
+		offset, err := strconv.ParseUint(offString, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid '%s' range offset specifier: %w", vs[i], err)
 		}
-		length, err := strconv.ParseUint(r[1], 10, 64)
+		length, err := strconv.ParseUint(lenString, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid '%s' range length specifier: %w", vs[i], err)
 		}

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -82,12 +82,12 @@ func ParseXHeaders(cmd *cobra.Command) []string {
 	xs := make([]string, 0, 2*len(xHeaders))
 
 	for i := range xHeaders {
-		kv := strings.SplitN(xHeaders[i], "=", 2)
-		if len(kv) != 2 {
+		k, v, found := strings.Cut(xHeaders[i], "=")
+		if !found {
 			panic(fmt.Errorf("invalid X-Header format: %s", xHeaders[i]))
 		}
 
-		xs = append(xs, kv[0], kv[1])
+		xs = append(xs, k, v)
 	}
 
 	return xs

--- a/cmd/neofs-cli/modules/util/acl.go
+++ b/cmd/neofs-cli/modules/util/acl.go
@@ -238,21 +238,22 @@ func parseEACLRecord(args []string) (eacl.Record, error) {
 	var targets []eacl.Target
 
 	for i := range args {
-		ss := strings.SplitN(args[i], ":", 2)
+		prefix, arg, hasArg := strings.Cut(args[i], ":")
+		prefix = strings.ToLower(prefix)
 
-		switch prefix := strings.ToLower(ss[0]); prefix {
+		switch prefix {
 		case "req", "obj": // filters
-			if len(ss) != 2 {
+			if !hasArg {
 				return eacl.Record{}, fmt.Errorf("invalid filter or target: %s", args[i])
 			}
 
-			key, value, op, err := parseKVWithOp(ss[1])
+			key, value, op, err := parseKVWithOp(arg)
 			if err != nil {
-				return eacl.Record{}, fmt.Errorf("invalid filter key-value pair %s: %w", ss[1], err)
+				return eacl.Record{}, fmt.Errorf("invalid filter key-value pair %s: %w", arg, err)
 			}
 
 			typ := eacl.HeaderFromRequest
-			if ss[0] == "obj" {
+			if prefix == "obj" {
 				typ = eacl.HeaderFromObject
 			}
 
@@ -270,18 +271,18 @@ func parseEACLRecord(args []string) (eacl.Record, error) {
 				accounts []user.ID
 			)
 
-			if len(ss) != 2 {
+			if !hasArg {
 				return eacl.Record{}, fmt.Errorf("invalid address: %s", args[i])
 			}
 
-			accounts, err = parseAccountList(ss[1])
+			accounts, err = parseAccountList(arg)
 			if err != nil {
 				return eacl.Record{}, err
 			}
 
 			targets = append(targets, eacl.NewTargetByAccounts(accounts))
 		default:
-			return eacl.Record{}, fmt.Errorf("invalid prefix: %s", ss[0])
+			return eacl.Record{}, fmt.Errorf("invalid prefix: %s", prefix)
 		}
 	}
 

--- a/cmd/neofs-node/config/test/config.go
+++ b/cmd/neofs-node/config/test/config.go
@@ -72,14 +72,14 @@ func loadEnv(path string) {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		pair := strings.SplitN(scanner.Text(), "=", 2)
-		if len(pair) != 2 {
+		envVar, value, found := strings.Cut(scanner.Text(), "=")
+		if !found {
 			continue
 		}
 
-		pair[1] = strings.Trim(pair[1], `"`)
+		value = strings.Trim(value, `"`)
 
-		err = os.Setenv(pair[0], pair[1])
+		err = os.Setenv(envVar, value)
 		if err != nil {
 			panic("can't set environment variable")
 		}

--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -122,19 +122,19 @@ func stringifyAddress(addr oid.Address) string {
 }
 
 func addressFromString(s string) (*oid.Address, error) {
-	ss := strings.SplitN(s, ".", 2)
-	if len(ss) != 2 {
+	objString, cnrString, found := strings.Cut(s, ".")
+	if !found {
 		return nil, errors.New("invalid address")
 	}
 
 	var obj oid.ID
-	if err := obj.DecodeString(ss[0]); err != nil {
-		return nil, fmt.Errorf("decode object ID from string %q: %w", ss[0], err)
+	if err := obj.DecodeString(objString); err != nil {
+		return nil, fmt.Errorf("decode object ID from string %q: %w", objString, err)
 	}
 
 	var cnr cid.ID
-	if err := cnr.DecodeString(ss[1]); err != nil {
-		return nil, fmt.Errorf("decode container ID from string %q: %w", ss[1], err)
+	if err := cnr.DecodeString(cnrString); err != nil {
+		return nil, fmt.Errorf("decode container ID from string %q: %w", cnrString, err)
 	}
 
 	var addr oid.Address

--- a/pkg/util/attributes/parser.go
+++ b/pkg/util/attributes/parser.go
@@ -19,29 +19,29 @@ func ReadNodeAttributes(dst *netmap.NodeInfo, attrs []string) error {
 	for i := range attrs {
 		line := replaceEscaping(attrs[i], false) // replaced escaped symbols with non-printable symbols
 
-		words := strings.Split(line, keyValueSeparator)
-		if len(words) != 2 {
+		key, value, found := strings.Cut(line, keyValueSeparator)
+		if !found {
 			return errors.New("missing attribute key and/or value")
 		}
 
-		_, ok := cache[words[0]]
+		_, ok := cache[key]
 		if ok {
-			return fmt.Errorf("duplicated keys %s", words[0])
+			return fmt.Errorf("duplicated keys %s", key)
 		}
 
-		cache[words[0]] = struct{}{}
+		cache[key] = struct{}{}
 
 		// replace non-printable symbols with escaped symbols without escape character
-		words[0] = replaceEscaping(words[0], true)
-		words[1] = replaceEscaping(words[1], true)
+		key = replaceEscaping(key, true)
+		value = replaceEscaping(value, true)
 
-		if words[0] == "" {
+		if key == "" {
 			return errors.New("empty key")
-		} else if words[1] == "" {
+		} else if value == "" {
 			return errors.New("empty value")
 		}
 
-		dst.SetAttribute(words[0], words[1])
+		dst.SetAttribute(key, value)
 	}
 
 	return nil


### PR DESCRIPTION
It's more efficient (no slice allocation) and more friendly for this case.