### PR TITLE
object: fix panic on PUT error

### DIFF
--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -232,6 +232,9 @@ func (s *Server) makeResponseMetaHeader(st *protostatus.Status) *protosession.Re
 }
 
 func (s *Server) sendPutResponse(stream protoobject.ObjectService_PutServer, resp *protoobject.PutResponse, err error) error {
+	if resp == nil {
+		resp = new(protoobject.PutResponse)
+	}
 	if err != nil {
 		resp.MetaHeader = s.makeResponseMetaHeader(util.ToStatus(err))
 	}
@@ -241,7 +244,7 @@ func (s *Server) sendPutResponse(stream protoobject.ObjectService_PutServer, res
 }
 
 func (s *Server) sendStatusPutResponse(stream protoobject.ObjectService_PutServer, err error) error {
-	return s.sendPutResponse(stream, new(protoobject.PutResponse), err)
+	return s.sendPutResponse(stream, nil, err)
 }
 
 type putStream struct {


### PR DESCRIPTION
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf81297]

    goroutine 4070 [running]:
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).sendPutResponse(0xc001ed62c0, {0x15d6090, 0xc0023788b0}, 0x0, {0x15bb0a0?, 0xc0003588c0?})
    	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:236 +0x57
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).Put(0xc001ed62c0, {0x15d6090, 0xc0023788b0})
    	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:429 +0x6f0
    github.com/nspcc-dev/neofs-sdk-go/proto/object._ObjectService_Put_Handler({0x132df80?, 0xc001ed62c0}, {0x15d0fa8, 0xc00137d590})
    	github.com/nspcc-dev/neofs-sdk-go@v1.0.0-rc.16.0.20251118154818-9480da80f9ad/proto/object/service_grpc.pb.go:725 +0xd8
    google.golang.org/grpc.(*Server).processStreamingRPC(0xc00153e000, {0x15cbdb0, 0xc001699080}, 0xc000b2ce40, 0xc001e606c0, 0x205c060, 0x0)
    	google.golang.org/grpc@v1.75.1/server.go:1722 +0x12e8
    google.golang.org/grpc.(*Server).handleStream(0xc00153e000, {0x15ccc30, 0xc000370340}, 0xc000b2ce40)
    	google.golang.org/grpc@v1.75.1/server.go:1846 +0xb47
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
    	google.golang.org/grpc@v1.75.1/server.go:1061 +0x7f
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 257
    	google.golang.org/grpc@v1.75.1/server.go:1072 +0x11d

Regression of 85e0c6c1de519401e16ac854010d20b5e97b1627.