### PR TITLE
blockchain: enable session iterator expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 ### Fixed
 
 ### Changed
+- Session iterator expansion is enabled for internal SN RPC (#3695)
 
 ### Removed
 

--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -200,7 +200,9 @@ func New(cfg *config.Consensus, wallet *config.Wallet, errChan chan<- error, log
 	cfgBaseApp.P2PNotary.UnlockWallet = neowallet
 	cfgBaseApp.RPC.StartWhenSynchronized = true
 	cfgBaseApp.RPC.MaxGasInvoke = fixedn.Fixed8FromInt64(int64(cfg.RPC.MaxGasInvoke))
+	cfgBaseApp.RPC.MaxIteratorResultItems = 100
 	cfgBaseApp.RPC.SessionEnabled = true
+	cfgBaseApp.RPC.SessionExpansionEnabled = true
 	cfgBaseApp.P2P.Addresses = cfg.P2P.Listen
 	cfgBaseApp.P2P.DialTimeout = cfg.P2P.DialTimeout
 	cfgBaseApp.P2P.ProtoTickInterval = cfg.P2P.ProtoTickInterval


### PR DESCRIPTION
It's more effective (one request less), especially for SNs using this embedded CN RPC. This feature was introduced in NeoGo 0.109.0 and it requires at least the same client version, but we have it everywhere already.

What do you think, @AnnaShaleva?