### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/pkg/local_object_storage/shard/control.go
+++ b/pkg/local_object_storage/shard/control.go
@@ -3,6 +3,7 @@ package shard
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/core/version"
@@ -249,15 +250,15 @@ func (s *Shard) resyncObjectHandler(addr oid.Address, data []byte) error {
 }
 
 func oidsToString(ids []oid.ID) string {
-	var res string
+	var res strings.Builder
 	for i, id := range ids {
-		res += id.String()
+		res.WriteString(id.String())
 		if i != len(ids)-1 {
-			res += ", "
+			res.WriteString(", ")
 		}
 	}
 
-	return res
+	return res.String()
 }
 
 // Close releases all Shard's components.

--- a/pkg/network/group.go
+++ b/pkg/network/group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 )
@@ -19,13 +20,13 @@ type AddressGroup []Address
 //
 // The result is order-dependent.
 func StringifyGroup(x AddressGroup) string {
-	var s string
+	var s strings.Builder
 
 	for addr := range slices.Values(x) {
-		s += addr.String()
+		s.WriteString(addr.String())
 	}
 
-	return s
+	return s.String()
 }
 
 // Len returns number of addresses in AddressGroup.


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)