### PR TITLE
ir/adm: use deleteNode method to forcefully drop node

### DIFF
--- a/cmd/neofs-adm/internal/modules/fschain/remove_node.go
+++ b/cmd/neofs-adm/internal/modules/fschain/remove_node.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/smartcontract/callflag"
 	"github.com/nspcc-dev/neo-go/pkg/vm/emit"
-	"github.com/nspcc-dev/neofs-contract/rpc/netmap"
 	"github.com/nspcc-dev/neofs-contract/rpc/nns"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -45,8 +44,8 @@ func removeNodesCmd(cmd *cobra.Command, args []string) error {
 
 	bw := io.NewBufBinWriter()
 	for i := range nodeKeys {
-		emit.AppCall(bw.BinWriter, nmHash, "updateStateIR", callflag.All,
-			netmap.NodeStateOffline, nodeKeys[i].Bytes())
+		emit.AppCall(bw.BinWriter, nmHash, "deleteNode", callflag.All,
+			nodeKeys[i].Bytes())
 	}
 
 	if err := emitNewEpochCall(bw, wCtx, nmHash); err != nil {

--- a/pkg/innerring/network.go
+++ b/pkg/innerring/network.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neofs-contract/rpc/netmap"
 	netmapcore "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	"go.uber.org/zap"
 )
@@ -101,9 +100,9 @@ func (s *Server) RequestNotary(method string, args ...[]byte) (util.Uint256, err
 
 		hash, err = s.netmapClient.Morph().NotaryInvoke(context.TODO(),
 			s.netmapClient.ContractAddress(), false, 0, 1, nil,
-			"updateStateIR", netmap.NodeStateOffline, nodePubKey.Bytes())
+			"deleteNode", nodePubKey.Bytes())
 		if err != nil {
-			s.log.Warn("external request: can't invoke updateSateIR method in netmap",
+			s.log.Warn("external request: can't invoke deleteNode method in netmap",
 				zap.String("node pub key", nodePubKey.String()),
 				zap.Error(err))
 		}


### PR DESCRIPTION
updateStateIR is gone in contracts since https://github.com/nspcc-dev/neofs-contract/pull/556 (0.26.0 changeset), so it no longer works. Fixes test failure:

    2025-12-12T13:37:24.776Z	warn	innerring/network.go:106	external request: can't invoke updateSateIR method in netmap	{"node pub key": "ed92cf9dde91bf35d7d806130ce7c22cbdb639dbb59e77b0fb87287359cbf88dcb6d7faf4cf86b4c1a928b74601dbda357445ffd0baa36a29bc16be0cc5b737f", "error": "chain/client: contract execution finished with state FAULT; exception: at instruction 76 (SYSCALL): System.Contract.Call failed: method not found: updateStateIR/2"}