### PR TITLE
Optimize object-to-shard HRW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Changelog for NeoFS Node
 - Garbage marking scheme in metabase (#3753)
 - SN sorts shards identically when writing and reading EC parts (#3773)
 - SN puts EC parts concurrently now (#3777)
+- Optimized object-to-shard placement (#3794)
 
 ### Removed
 - Deprecated `fschain_autodeploy`, `without_mainnet`, `governance.disable`, `fee.main_chain` and `contracts` IR config options (#3716)

--- a/pkg/local_object_storage/engine/evacuate.go
+++ b/pkg/local_object_storage/engine/evacuate.go
@@ -100,7 +100,7 @@ mainLoop:
 		loop:
 			for i := range lst {
 				addr := lst[i].Address
-				addrHash := hrw.WrapBytes([]byte(addr.EncodeToString()))
+				addrHash := hrwOIDWrapper(addr.Object())
 
 				obj, err := sh.Get(addr, false)
 				if err != nil {

--- a/pkg/local_object_storage/engine/shards.go
+++ b/pkg/local_object_storage/engine/shards.go
@@ -192,7 +192,7 @@ func generateShardID() (*shard.ID, error) {
 func (e *StorageEngine) sortedShards(objAddr oid.Address) []shardWrapper {
 	shards := e.unsortedShards()
 
-	hrw.Sort(shards, hrw.WrapBytes([]byte(objAddr.EncodeToString())))
+	hrw.Sort(shards, hrwOIDWrapper(objAddr.Object()))
 
 	for i := range shards {
 		shards[i].shardIface = shards[i].Shard
@@ -258,4 +258,10 @@ func (e *StorageEngine) HandleNewEpoch(epoch uint64) {
 
 func (s shardWrapper) Hash() uint64 {
 	return binary.BigEndian.Uint64(*s.ID())
+}
+
+type hrwOIDWrapper oid.ID
+
+func (o hrwOIDWrapper) Hash() uint64 {
+	return binary.BigEndian.Uint64(o[:])
 }


### PR DESCRIPTION
This breaks sorting for already stored objects, but this shouldn't be a big problem, objects are going to be accessible anyway and optimizing access is a separate issue (it can be suboptimal because of other reasons, evacuations/shard addition/deletion/ro/etc).