### PR TITLE
session/v2: drop `nonce` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Changelog for NeoFS Node
 
 ### Updated
 - `github.com/nspcc-dev/neofs-contract` module to `v0.26.0` (#3670, #3746, #3733, #3780, #3782)
-- `github.com/nspcc-dev/neofs-sdk-go` module to `v1.0.0-rc.16.0.20260127152410-12dbac67e506` (#3711, #3750, #3733, #3775, #3772, #3787, #3784, #3671)
+- `github.com/nspcc-dev/neofs-sdk-go` module to `v1.0.0-rc.16.0.20260202120027-3768714e73a0` (#3711, #3750, #3733, #3775, #3772, #3787, #3784, #3671, #3796)
 - `github.com/nspcc-dev/locode-db` module to `v0.8.2` (#3729)
 - `github.com/nspcc-dev/neo-go` module to `v0.116.0` (#3733, #3769, #3779)
 

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -374,7 +374,6 @@ func CreateSessionV2(ctx context.Context, cmd *cobra.Command, dst SessionPrm, cl
 
 	currentTime := time.Now()
 	tok.SetVersion(sessionv2.TokenCurrentVersion)
-	tok.SetNonce(sessionv2.RandomNonce())
 	// allow 10s clock skew, because time isn't synchronous over the network
 	tok.SetIat(currentTime.Add(-10 * time.Second))
 	tok.SetNbf(currentTime)

--- a/cmd/neofs-cli/modules/session/create_v2.go
+++ b/cmd/neofs-cli/modules/session/create_v2.go
@@ -123,7 +123,6 @@ func createSessionV2(cmd *cobra.Command, _ []string) error {
 	signer := user.NewAutoIDSigner(*privKey)
 
 	tokV2.SetVersion(session.TokenCurrentVersion)
-	tokV2.SetNonce(session.RandomNonce())
 	tokV2.SetNbf(currentTime)
 	// allow 10s clock skew, because time isn't synchronous over the network
 	tokV2.SetIat(currentTime.Add(-10 * time.Second))

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.116.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.26.0
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260127152410-12dbac67e506
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260202120027-3768714e73a0
 	github.com/nspcc-dev/tzhash v1.8.3
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.26.0 h1:HoYsJN3shTB8uHZn/FP1Ce2N6mnG5lpDKQXvEvzsAQA=
 github.com/nspcc-dev/neofs-contract v0.26.0/go.mod h1:pevVF9OWdEN5bweKxOu6ryZv9muCEtS1ppzYM4RfBIo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260127152410-12dbac67e506 h1:aQPJ2OnJyVsYYom3nXYt1TlP4zcLa+2ypMXEGC5wkIY=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260127152410-12dbac67e506/go.mod h1:IrM1JG/klBtecZEApIf8USgLonNcarv32R1O0dj4kQI=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260202120027-3768714e73a0 h1:2GfzhHnFyt8jUWGolmA+73hT1rebjs9+k4fDmx+0nWI=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.16.0.20260202120027-3768714e73a0/go.mod h1:IrM1JG/klBtecZEApIf8USgLonNcarv32R1O0dj4kQI=
 github.com/nspcc-dev/rfc6979 v0.2.4 h1:NBgsdCjhLpEPJZqmC9rciMZDcSY297po2smeaRjw57k=
 github.com/nspcc-dev/rfc6979 v0.2.4/go.mod h1:86ylDw6Kss+P6v4QAJqo1Sp3mC0/Zr9G97xSjQ9TuFg=
 github.com/nspcc-dev/tzhash v1.8.3 h1:EWJMOL/ppdqNBvkKjHECljusopcsNu4i4kH8KctTv10=

--- a/pkg/services/container/server_test.go
+++ b/pkg/services/container/server_test.go
@@ -741,7 +741,6 @@ func TestService_TokenV2(t *testing.T) {
 		t.Helper()
 		var tok sessionv2.Token
 		tok.SetVersion(sessionv2.TokenCurrentVersion)
-		tok.SetNonce(sessionv2.RandomNonce())
 
 		now := time.Now()
 		tok.SetIat(now)

--- a/pkg/services/container/service_internal_test.go
+++ b/pkg/services/container/service_internal_test.go
@@ -105,7 +105,6 @@ func BenchmarkSessionTokenV2Verification(b *testing.B) {
 
 	var tok sessionv2.Token
 	tok.SetVersion(sessionv2.TokenCurrentVersion)
-	tok.SetNonce(sessionv2.RandomNonce())
 
 	ctx, err := sessionv2.NewContext(anyCnr, []sessionv2.Verb{anyVerbV2})
 	require.NoError(b, err)

--- a/pkg/services/object/acl/v2/service_internal_test.go
+++ b/pkg/services/object/acl/v2/service_internal_test.go
@@ -126,7 +126,6 @@ func BenchmarkSessionTokenV2Verification(b *testing.B) {
 
 	var tok sessionv2.Token
 	tok.SetVersion(sessionv2.TokenCurrentVersion)
-	tok.SetNonce(sessionv2.RandomNonce())
 
 	ctx, err := sessionv2.NewContext(anyCnr, []sessionv2.Verb{anyVerbV2})
 	require.NoError(b, err)

--- a/pkg/services/object/put/service_test.go
+++ b/pkg/services/object/put/service_test.go
@@ -1449,7 +1449,6 @@ func checkAndCutECPartsForRule(t *testing.T, ruleIdx int, rule iec.Rule, nodeObj
 func newSessionTokenV2(t *testing.T, cnrID cid.ID, owner user.Signer, nodes []mockNodeSession, verbs []sessionv2.Verb) *sessionv2.Token {
 	var sessionTokenV2 sessionv2.Token
 	sessionTokenV2.SetVersion(sessionv2.TokenCurrentVersion)
-	sessionTokenV2.SetNonce(sessionv2.RandomNonce())
 
 	currentTime := time.Now()
 	sessionTokenV2.SetIat(currentTime)


### PR DESCRIPTION
Refs https://github.com/nspcc-dev/neofs-sdk-go/pull/775.