### PR TITLE
morph: make client retry if fallback transaction was accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for NeoFS Node
 - Potential payload overflow on getting full object from combined FSTree file (#3801)
 
 ### Changed
+- SN retries notary requests if `insufficient amount of gas` error appears (#3739)
 
 ### Removed
 

--- a/pkg/morph/client/static.go
+++ b/pkg/morph/client/static.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -202,7 +203,8 @@ func (s StaticClient) execWithBackoff(invokeFunc func() error) error {
 	return backoff.RetryNotify(func() error {
 		err := invokeFunc()
 		if err != nil {
-			if errors.Is(err, neorpc.ErrMempoolCapReached) {
+			if errors.Is(err, neorpc.ErrMempoolCapReached) ||
+				strings.Contains(err.Error(), "insufficient amount of gas") {
 				return err
 			}
 			return backoff.Permanent(err)


### PR DESCRIPTION
If complex notary invocation flow failed, retry transaction sending the same way it is done for `ErrMempoolCapReached` problems. Contract storages (and, therefore, GAS payments) may change b/w SN's test invocations and real transaction acceptance tries, and it is normal. In particular, it fixes #3739.