### PR TITLE
sn/storage: Fix payload overflow in combined `FSTree.Get()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 
 ### Fixed
 - Unclosed compressed FSTree files (#3802)
+- Potential payload overflow on getting full object from combined FSTree file (#3801)
 
 ### Changed
 

--- a/pkg/local_object_storage/blobstor/fstree/head.go
+++ b/pkg/local_object_storage/blobstor/fstree/head.go
@@ -81,6 +81,15 @@ func (t *FSTree) extractHeaderAndStream(id oid.ID, f *os.File) (*object.Object, 
 					return nil, f, fmt.Errorf("read up to size: %w", err)
 				}
 			}
+
+			f := io.ReadCloser(f)
+			if buffered := uint32(size - offset); l > buffered {
+				f = struct {
+					io.Reader
+					io.Closer
+				}{Reader: io.LimitReader(f, int64(l-buffered)), Closer: f}
+			}
+
 			return t.readHeaderAndPayload(f, buf[offset:size])
 		}
 


### PR DESCRIPTION
i did not try to reproduce this on a cluster. For example, it might show up with https://github.com/nspcc-dev/neofs-node/blob/58f146c6f709967d7d413aefb54f6865abc81869/pkg/local_object_storage/writecache/flush.go#L224