### PR TITLE
sn/policer: add "clean" cycle flag to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 - `neofs-cli container policy check` command (#3790)
 - `neofs-adm mainchain update-contract` command (#3799)
+- `policer_consistency_state` SN metric that means all SN's objects correspond placement policies (#3795)
 
 ### Fixed
 - Unclosed compressed FSTree files (#3802)

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -61,3 +61,7 @@ func (c *cfg) setHealthStatus(st control.HealthStatus) {
 func (c *cfg) HealthStatus() control.HealthStatus {
 	return control.HealthStatus(c.healthStatus.Load())
 }
+
+func (c *cfg) SetPolicerConsistency(consistent bool) {
+	c.metricsCollector.SetPolicerConsistencyState(consistent)
+}

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -204,6 +204,7 @@ func initObjectService(c *cfg) {
 	c.policer = policer.New(neofsecdsa.Signer(c.key.PrivateKey),
 		policer.WithLogger(c.log),
 		policer.WithLocalStorage(ls),
+		policer.WithMetrics(c),
 		policer.WithRemoteHeader(
 			headsvc.NewRemoteHeader(keyStorage, clientConstructor),
 		),

--- a/pkg/metrics/state.go
+++ b/pkg/metrics/state.go
@@ -5,7 +5,8 @@ import "github.com/prometheus/client_golang/prometheus"
 const stateSubsystem = "state"
 
 type stateMetrics struct {
-	healthCheck prometheus.Gauge
+	healthCheck             prometheus.Gauge
+	policerConsistencyState prometheus.Gauge
 }
 
 func newStateMetrics() stateMetrics {
@@ -16,13 +17,28 @@ func newStateMetrics() stateMetrics {
 			Name:      "health",
 			Help:      "Current Node state",
 		}),
+		policerConsistencyState: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: storageNodeNameSpace,
+			Subsystem: stateSubsystem,
+			Name:      "policer_consistency_state",
+			Help:      "Current Policer's consistency state. 0 for inconsistent/unknown state; 1 for synchronized",
+		}),
 	}
 }
 
 func (m stateMetrics) register() {
 	prometheus.MustRegister(m.healthCheck)
+	prometheus.MustRegister(m.policerConsistencyState)
 }
 
 func (m stateMetrics) SetHealth(s int32) {
 	m.healthCheck.Set(float64(s))
+}
+
+func (m stateMetrics) SetPolicerConsistencyState(consistent bool) {
+	if consistent {
+		m.policerConsistencyState.Set(1)
+	} else {
+		m.policerConsistencyState.Set(0)
+	}
 }

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -325,6 +325,9 @@ func (p *Policer) processNodes(ctx context.Context, plc *processPlacementContext
 	}
 
 	if shortage > 0 {
+		p.metrics.SetPolicerConsistency(false)
+		p.hadToReplicate.Store(true)
+
 		p.log.Debug("shortage of object copies detected",
 			zap.Stringer("object", plc.object.Address),
 			zap.Uint32("shortage", shortage),

--- a/pkg/services/policer/ec.go
+++ b/pkg/services/policer/ec.go
@@ -295,6 +295,9 @@ headNextPart:
 		return
 	}
 
+	p.metrics.SetPolicerConsistency(false)
+	p.hadToReplicate.Store(true)
+
 	if parentHdr.GetID().IsZero() {
 		// can only happen for 1/1 rule: local part is never HEADed in for-loop above and remote one is unreachable
 		hdr, err := p.localStorage.Head(parentAddr, false)


### PR DESCRIPTION
If policer passes all the placement checks for every object SN stores, mention it in SN's metrics. Closes #3795.