### PR TITLE
FSTree buffered HEAD

### DIFF
--- a/pkg/local_object_storage/blobstor/fstree/bench_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/bench_test.go
@@ -18,6 +18,14 @@ func BenchmarkFSTree_Head(b *testing.B) {
 	}
 }
 
+func BenchmarkFSTree_ReadHeader(b *testing.B) {
+	for _, size := range payloadSizes {
+		b.Run(generateSizeLabel(size), func(b *testing.B) {
+			runReadBenchmark(b, "ReadHeader", size)
+		})
+	}
+}
+
 func BenchmarkFSTree_Get(b *testing.B) {
 	for _, size := range payloadSizes {
 		b.Run(generateSizeLabel(size), func(b *testing.B) {
@@ -59,6 +67,8 @@ func BenchmarkFSTree_GetStream(b *testing.B) {
 }
 
 func runReadBenchmark(b *testing.B, methodName string, payloadSize int) {
+	buf := make([]byte, 2*object.MaxHeaderLen)
+
 	testRead := func(fsTree *fstree.FSTree, addr oid.Address) {
 		var err error
 		switch methodName {
@@ -78,6 +88,8 @@ func runReadBenchmark(b *testing.B, methodName string, payloadSize int) {
 			if reader != nil {
 				require.NoError(b, reader.Close())
 			}
+		case "ReadHeader":
+			_, err = fsTree.ReadHeader(addr, buf)
 		}
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/local_object_storage/blobstor/fstree/head.go
+++ b/pkg/local_object_storage/blobstor/fstree/head.go
@@ -27,6 +27,47 @@ func (t *FSTree) Head(addr oid.Address) (*object.Object, error) {
 	return obj, nil
 }
 
+// ReadHeader reads first bytes of the referenced object's binary containing its
+// full header from t into buf. Returns number of bytes read.
+//
+// Read part may include payload prefix.
+//
+// If object is missing, ReadHeader returns [apistatus.ErrObjectNotFound].
+//
+// Passed buf must have 2*[object.MaxHeaderLen] bytes len at least.
+func (t *FSTree) ReadHeader(addr oid.Address, buf []byte) (int, error) {
+	if len(buf) < 2*object.MaxHeaderLen {
+		return 0, fmt.Errorf("too short buffer %d bytes", len(buf))
+	}
+
+	p := t.treePath(addr)
+
+	f, err := os.Open(p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, logicerr.Wrap(apistatus.ErrObjectNotFound)
+		}
+		return 0, fmt.Errorf("read file %q: %w", p, err)
+	}
+
+	initial, stream, err := t.readHeader(addr.Object(), f, buf)
+	if err != nil {
+		stream.Close()
+		return 0, err
+	}
+
+	initial, stream, err = t.preprocessStreamHead(stream, initial)
+	if stream != nil {
+		stream.Close()
+	}
+
+	if err != nil {
+		return 0, err
+	}
+
+	return copy(buf, initial), nil
+}
+
 // getObjectStream reads an object from the storage by address as a stream.
 // It returns the object with header only, and a reader for the payload.
 func (t *FSTree) getObjectStream(addr oid.Address) (*object.Object, io.ReadSeekCloser, error) {
@@ -58,17 +99,28 @@ func (t *FSTree) getObjectStream(addr oid.Address) (*object.Object, io.ReadSeekC
 // The caller is responsible for closing the returned io.ReadCloser if it is not nil.
 func (t *FSTree) extractHeaderAndStream(id oid.ID, f *os.File) (*object.Object, io.ReadSeekCloser, error) {
 	buf := make([]byte, 2*object.MaxHeaderLen)
+
+	initial, stream, err := t.readHeader(id, f, buf)
+	if err != nil {
+		stream.Close()
+		return nil, nil, err
+	}
+
+	return t.readHeaderAndPayload(stream, initial)
+}
+
+func (t *FSTree) readHeader(id oid.ID, f *os.File, buf []byte) ([]byte, io.ReadCloser, error) {
 	n, err := io.ReadFull(f, buf[:object.MaxHeaderLen])
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, f, err
 	}
 	if n < combinedDataOff {
-		return t.readHeaderAndPayload(f, buf[:n])
+		return buf[:n], f, nil
 	}
 
 	thisOID, l := parseCombinedPrefix(buf)
 	if thisOID == nil {
-		return t.readHeaderAndPayload(f, buf[:n])
+		return buf[:n], f, nil
 	}
 
 	offset := combinedDataOff
@@ -90,7 +142,7 @@ func (t *FSTree) extractHeaderAndStream(id oid.ID, f *os.File) (*object.Object, 
 				}{Reader: io.LimitReader(f, int64(l-buffered)), Closer: f}
 			}
 
-			return t.readHeaderAndPayload(f, buf[offset:size])
+			return buf[offset:size], f, nil
 		}
 
 		offset += int(l)
@@ -125,13 +177,12 @@ func (t *FSTree) extractHeaderAndStream(id oid.ID, f *os.File) (*object.Object, 
 // readHeaderAndPayload reads an object header from the file and returns reader for payload.
 // This function takes ownership of the io.ReadCloser and will close it if it does not return it.
 func (t *FSTree) readHeaderAndPayload(f io.ReadCloser, initial []byte) (*object.Object, io.ReadSeekCloser, error) {
-	var err error
-	if len(initial) < object.MaxHeaderLen {
-		_ = f.Close()
-		initial, err = t.Decompress(initial)
-		if err != nil {
-			return nil, nil, fmt.Errorf("decompress initial data: %w", err)
-		}
+	initial, reader, err := t.preprocessStreamHead(f, initial)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if reader == nil {
 		var obj object.Object
 		err = obj.Unmarshal(initial)
 		if err != nil {
@@ -148,13 +199,29 @@ func (t *FSTree) readHeaderAndPayload(f io.ReadCloser, initial []byte) (*object.
 		}, nil
 	}
 
-	return t.readUntilPayload(f, initial)
+	obj, payloadPrefix, err := objectwire.ExtractHeaderAndPayload(initial)
+	if err != nil {
+		_ = reader.Close()
+		return nil, nil, fmt.Errorf("extract header and payload: %w", err)
+	}
+
+	return obj, &payloadReader{
+		Reader: io.MultiReader(bytes.NewReader(payloadPrefix), reader),
+		close:  reader.Close,
+	}, nil
 }
 
-// readUntilPayload reads an object from the file until the payload field is reached
-// and returns the object along with a reader for the remaining data.
-// This function takes ownership of the io.ReadCloser and will close it if it does not return it.
-func (t *FSTree) readUntilPayload(f io.ReadCloser, initial []byte) (*object.Object, io.ReadSeekCloser, error) {
+func (t *FSTree) preprocessStreamHead(f io.ReadCloser, initial []byte) ([]byte, io.ReadCloser, error) {
+	var err error
+	if len(initial) < object.MaxHeaderLen {
+		_ = f.Close()
+		initial, err = t.Decompress(initial)
+		if err != nil {
+			return nil, nil, fmt.Errorf("decompress initial data: %w", err)
+		}
+		return initial, nil, nil
+	}
+
 	reader := f
 
 	if t.IsCompressed(initial) {
@@ -176,16 +243,7 @@ func (t *FSTree) readUntilPayload(f io.ReadCloser, initial []byte) (*object.Obje
 		initial = buf[:n]
 	}
 
-	obj, payloadPrefix, err := objectwire.ExtractHeaderAndPayload(initial)
-	if err != nil {
-		_ = reader.Close()
-		return nil, nil, fmt.Errorf("extract header and payload: %w", err)
-	}
-
-	return obj, &payloadReader{
-		Reader: io.MultiReader(bytes.NewReader(payloadPrefix), reader),
-		close:  reader.Close,
-	}, nil
+	return initial, reader, nil
 }
 
 type payloadReader struct {

--- a/pkg/local_object_storage/blobstor/fstree/head_bench_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/head_bench_test.go
@@ -2,6 +2,8 @@ package fstree_test
 
 import (
 	"testing"
+
+	"github.com/nspcc-dev/neofs-sdk-go/object"
 )
 
 func BenchmarkFSTree_HeadVsGet(b *testing.B) {
@@ -35,6 +37,18 @@ func runHeadVsGetBenchmark(b *testing.B, payloadSize int, compressed bool) {
 		b.ReportAllocs()
 		for b.Loop() {
 			_, err := fsTree.Head(addr)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("ReadHeader"+suffix, func(b *testing.B) {
+		buf := make([]byte, object.MaxHeaderLen*2)
+
+		b.ReportAllocs()
+		for b.Loop() {
+			_, err := fsTree.ReadHeader(addr, buf)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/local_object_storage/blobstor/fstree/head_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/head_test.go
@@ -1,10 +1,14 @@
 package fstree_test
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
+	iprotobuf "github.com/nspcc-dev/neofs-node/internal/protobuf"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/blobstor/fstree"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
@@ -33,6 +37,8 @@ func TestHeadStorage(t *testing.T) {
 		fullObj, err := fsTree.Get(obj.Address())
 		require.NoError(t, err)
 		require.Equal(t, obj, fullObj)
+
+		testReadHeaderOK(t, fsTree, *obj)
 	}
 
 	testCombinedObjects := func(t *testing.T, fsTree *fstree.FSTree, size int) {
@@ -60,6 +66,8 @@ func TestHeadStorage(t *testing.T) {
 			require.Len(t, attrs, 1)
 			require.Equal(t, fmt.Sprintf("key-%d", i), attrs[0].Key())
 			require.Equal(t, fmt.Sprintf("value-%d", i), attrs[0].Value())
+
+			testReadHeaderOK(t, fsTree, *objects[i])
 		}
 	}
 
@@ -78,6 +86,8 @@ func TestHeadStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, obj.CutPayload(), res)
 		require.Len(t, res.Attributes(), numAttrs)
+
+		testReadHeaderOK(t, fsTree, *obj)
 	})
 
 	t.Run("non-existent object", func(t *testing.T) {
@@ -86,6 +96,9 @@ func TestHeadStorage(t *testing.T) {
 
 		_, err := fsTree.Head(addr)
 		require.Error(t, err)
+
+		_, err = fsTree.ReadHeader(obj.Address(), make([]byte, object.MaxHeaderLen*2))
+		require.ErrorIs(t, err, apistatus.ErrObjectNotFound)
 	})
 
 	t.Run("different payload sizes", func(t *testing.T) {
@@ -118,4 +131,27 @@ func TestHeadStorage(t *testing.T) {
 			})
 		}
 	})
+}
+
+func testReadHeaderOK(t *testing.T, fst *fstree.FSTree, obj object.Object) {
+	buf := make([]byte, object.MaxHeaderLen*2)
+
+	n, err := fst.ReadHeader(obj.Address(), buf)
+	require.NoError(t, err)
+
+	_, tail, ok := bytes.Cut(buf[:n], obj.CutPayload().Marshal())
+	require.True(t, ok)
+
+	prefix := make([]byte, 1+binary.MaxVarintLen64)
+	prefix[0] = iprotobuf.TagBytes4 // payload field tag
+	prefix = prefix[:1+binary.PutUvarint(prefix[1:], uint64(len(obj.Payload())))]
+
+	if len(tail) < len(prefix) {
+		require.True(t, bytes.HasPrefix(prefix, tail))
+		return
+	}
+
+	tail, ok = bytes.CutPrefix(tail, prefix)
+	require.True(t, ok)
+	require.True(t, bytes.HasPrefix(obj.Payload(), tail))
 }


### PR DESCRIPTION
here's storage API i see for external buffer provision. Object service gonna pool response buffers and provide their subslices to to storage for reading. Buffer is closured in order to:
1. allocate it only when needed (object file is open)
2. not repick it (from shard to shard)