### PR TITLE
cli: adjust clock adjustment to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Unclosed compressed FSTree files (#3802)
 - Potential payload overflow on getting full object from combined FSTree file (#3801)
+- Too high nbf/iat token defaults in CLI for testnet/mainnet (#3819)
 
 ### Changed
 - SN retries notary requests if `insufficient amount of gas` error appears (#3739)

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -372,12 +372,16 @@ func CreateSessionV2(ctx context.Context, cmd *cobra.Command, dst SessionPrm, cl
 	var tok sessionv2.Token
 	signer := user.NewAutoIDSigner(*key)
 
-	currentTime := time.Now()
+	var (
+		currentTime = time.Now()
+		expTime     = currentTime.Add(defaultTokenExp)
+		// allow 30s clock skew, because time isn't synchronous over the network
+		nbfTime = currentTime.Add(-30 * time.Second)
+	)
 	tok.SetVersion(sessionv2.TokenCurrentVersion)
-	// allow 10s clock skew, because time isn't synchronous over the network
-	tok.SetIat(currentTime.Add(-10 * time.Second))
-	tok.SetNbf(currentTime)
-	tok.SetExp(currentTime.Add(defaultTokenExp))
+	tok.SetIat(nbfTime)
+	tok.SetNbf(nbfTime)
+	tok.SetExp(expTime)
 	tok.SetFinal(true)
 	err := tok.SetSubjects(subjects)
 	if err != nil {

--- a/cmd/neofs-cli/modules/session/create_v2.go
+++ b/cmd/neofs-cli/modules/session/create_v2.go
@@ -106,8 +106,12 @@ func createSessionV2(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	currentTime := time.Now()
-	var expTime time.Time
+	var (
+		currentTime = time.Now()
+		expTime     time.Time
+		// allow 30s clock skew, because time isn't synchronous over the network
+		nbfTime = currentTime.Add(-30 * time.Second)
+	)
 	if exp, _ := cmd.Flags().GetUint64(commonflags.ExpireAt); exp == 0 {
 		lifetime, _ := cmd.Flags().GetUint64(commonflags.Lifetime)
 		lifetimeDuration := time.Duration(lifetime) * time.Second
@@ -123,9 +127,8 @@ func createSessionV2(cmd *cobra.Command, _ []string) error {
 	signer := user.NewAutoIDSigner(*privKey)
 
 	tokV2.SetVersion(session.TokenCurrentVersion)
-	tokV2.SetNbf(currentTime)
-	// allow 10s clock skew, because time isn't synchronous over the network
-	tokV2.SetIat(currentTime.Add(-10 * time.Second))
+	tokV2.SetNbf(nbfTime)
+	tokV2.SetIat(nbfTime)
 	tokV2.SetExp(expTime)
 
 	final, _ := cmd.Flags().GetBool(v2FinalFlag)


### PR DESCRIPTION
We have 20s max block time, this happens pretty often in practice:

Error: rpc error: deleting 1C1DCs3dkEuULKFTcnCFWh8X6dZvfLFVAXUgYe9EvfX object: remove object via client: status: code = 1028 message = malformed request: V2 token is invalid at 2026-02-13 08:56:53 +0000 UTC, token iat 2026-02-13 08:56:53 +0000 UTC, nbf 2026-02-13 08:57:03 +0000 UTC, exp 2026-02-13 18:57:03 +0000 UTC