### PR TITLE
go.mod: update neofs-contracts to v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 - Too high nbf/iat token defaults in CLI for testnet/mainnet (#3819)
 - Repeated attempts to delete nonexistent objects (#3820)
 - Address change in configuration not triggering netmap update (#3828)
+- Billing for networks with 0.25.0 -> 0.26.0 migrated contracts (#3832)
 
 ### Changed
 - SN retries notary requests if `insufficient amount of gas` error appears (#3739)
@@ -24,6 +25,7 @@ Changelog for NeoFS Node
 
 ### Updated
 - NeoGo dependency to 0.117.0 (#3829)
+- neofs-contracts to 0.26.1 (#3832)
 
 ### Updating from v0.51.0
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/nspcc-dev/locode-db v0.8.2
 	github.com/nspcc-dev/neo-go v0.117.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
-	github.com/nspcc-dev/neofs-contract v0.26.0
+	github.com/nspcc-dev/neofs-contract v0.26.1
 	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.17
 	github.com/nspcc-dev/tzhash v1.8.3
 	github.com/panjf2000/ants/v2 v2.11.3

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20260121113504-979d1f4aada1 h1:k2
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20260121113504-979d1f4aada1/go.mod h1:X2spkE8hK/l08CYulOF19fpK5n3p2xO0L1GnJFIywQg=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK0EMGLvunXcFyq7fBURS/CsN4MH+4nlYiqn6pTwWAU=
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
-github.com/nspcc-dev/neofs-contract v0.26.0 h1:HoYsJN3shTB8uHZn/FP1Ce2N6mnG5lpDKQXvEvzsAQA=
-github.com/nspcc-dev/neofs-contract v0.26.0/go.mod h1:pevVF9OWdEN5bweKxOu6ryZv9muCEtS1ppzYM4RfBIo=
+github.com/nspcc-dev/neofs-contract v0.26.1 h1:7Ii7Q4L3au408LOsIWKiSgfnT1g8G9jo3W7381d41T8=
+github.com/nspcc-dev/neofs-contract v0.26.1/go.mod h1:pevVF9OWdEN5bweKxOu6ryZv9muCEtS1ppzYM4RfBIo=
 github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.17 h1:MahpltbItODvLsGIUsDuW9fz1MXmAi0c8dZNsK8Azqc=
 github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.17/go.mod h1:y2vNz9DVTqBkR7ctYb6taLnabWTtG7xtCHlGofEpKOM=
 github.com/nspcc-dev/rfc6979 v0.2.4 h1:NBgsdCjhLpEPJZqmC9rciMZDcSY297po2smeaRjw57k=


### PR DESCRIPTION
This fixes payments for networks that have been updated from 0.25.0 to 0.26.0 contracts version.