### PR TITLE
ir: do not wait for payment transaction acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for NeoFS Node
 - `owner mismatches signature` for stored objects (#3836)
 - SN does not retry resending failed transaction because of insufficient GAS in some cases (#3839)
 - Too early GET/HEAD/RANGE request failure on single SN dial failure (#3840)
+- Payment deadlock on IR side (#3842)
 
 ### Changed
 - SN returns unsigned responses to requests with API >= `v2.22` (#3785)

--- a/pkg/morph/client/balance/payment.go
+++ b/pkg/morph/client/balance/payment.go
@@ -17,7 +17,6 @@ func (c *Client) SettleContainerPayment(epoch uint64, cID cid.ID) error {
 	prm.SetArgs(cID[:])
 	prm.RequireAlphabetSignature()
 	prm.SetNonce(uint32(epoch))
-	prm.Await()
 
 	err := c.client.Invoke(prm)
 	if err != nil {


### PR DESCRIPTION
Closes #3842. There can be more containers than sender routines, and any problem with signatures leads to a payment deadlock that can be fixed with a full IR set restart only. A correct notary request is the maximum effort an IR node can do.