### PR TITLE
ir/processors/netmap: drop one-time migration routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog for NeoFS Node
 - `node.persistent_sessions.path` config option from SN config (#3846)
 - Undocumented ability to fetch the latest contract release for adm update-contracts (#3850)
 - `storage.shards.resync_metabase` config option from SN config (#3849)
+- One-time netmap contract placement migration routine for v0.49.0+ releases (#3821)
 
 ### Updated
 - `github.com/nspcc-dev/neofs-sdk-go` module to `v1.0.0-rc.17.0.20260224112648-e6342b6bf094` (#3785, #3817, #3808)

--- a/pkg/innerring/processors/netmap/processor.go
+++ b/pkg/innerring/processors/netmap/processor.go
@@ -10,7 +10,6 @@ import (
 	nmClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
-	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
@@ -132,75 +131,6 @@ func New(p *Params) (*Processor, error) {
 		nodeValidator: p.NodeValidator,
 	}
 	processor.curMap.Store(curMap)
-
-	{ // 0.49.0 Container contract members fix
-		var (
-			migrationLog              = p.Log.With(zap.String("step", "0.49.0 Container contract migration"))
-			forceContainersListUpdate bool
-			cnrToCheck                cid.ID
-			nm                        *netmap.NetMap
-		)
-		ids, err := p.ContainerWrapper.List(nil)
-		if err != nil {
-			return nil, fmt.Errorf("0.49.0 Container contract migration: cannot list containers: %w", err)
-		}
-		if len(ids) != 0 {
-			nm, err = p.NetmapClient.NetMap()
-			if err != nil {
-				return nil, fmt.Errorf("0.49.0 Container contract migration: cannot fetch current network map: %w", err)
-			}
-		}
-	cnrsLoop:
-		for _, id := range ids {
-			cnr, err := p.ContainerWrapper.Get(id[:])
-			if err != nil {
-				migrationLog.Warn("cannot fetch container", zap.Stringer("cID", id), zap.Error(err))
-				continue
-			}
-
-			policy := cnr.PlacementPolicy()
-			vectors, err := nm.ContainerNodes(policy, id)
-			if err != nil {
-				migrationLog.Warn("cannot build node placement policy", zap.Stringer("cID", id), zap.Error(err))
-				continue
-			}
-
-			for _, vector := range vectors {
-				if len(vector) != 0 {
-					cnrToCheck = id
-					break cnrsLoop
-				}
-			}
-		}
-
-		if !cnrToCheck.IsZero() {
-			vectors, err := p.ContainerWrapper.Nodes(cnrToCheck)
-			if err != nil {
-				return nil, fmt.Errorf("0.49.0 Container contract migration: cannot fetch nodes for container %s: %w", cnrToCheck, err)
-			}
-
-			forceContainersListUpdate = true
-			for _, vector := range vectors {
-				if len(vector) != 0 {
-					forceContainersListUpdate = false
-					break
-				}
-			}
-
-			if forceContainersListUpdate {
-				migrationLog.Info("forcing Container contract list update")
-
-				err = processor.updatePlacementInContract(*nm, migrationLog)
-				if err != nil {
-					migrationLog.Error("can't update placements in Container contract", zap.Error(err))
-				} else {
-					migrationLog.Debug("updated placements in Container contract")
-				}
-			} else {
-				migrationLog.Info("no need to migrate container lists")
-			}
-		}
-	}
 
 	return processor, nil
 }


### PR DESCRIPTION
It made it for 3 release and should be OK to remove in v0.52.0 release. Closes #3821.