### PR TITLE
engine: sort EC objects properly when evacuating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for NeoFS Node
 - Payment deadlock on IR side (#3842)
 - Wrong shard ID entry in FSTree descriptor (#3849, #3861)
 - Shard evacuation replicate for EC parts (#3854)
+- Suboptimal shard selection for EC parts during data evacuation (#3870)
 
 ### Changed
 - SN returns unsigned responses to requests with API >= `v2.22` (#3785)

--- a/pkg/local_object_storage/engine/evacuate.go
+++ b/pkg/local_object_storage/engine/evacuate.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/nspcc-dev/hrw/v2"
+	iec "github.com/nspcc-dev/neofs-node/internal/ec"
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
@@ -89,8 +90,10 @@ mainLoop:
 			// TODO (@fyrchik): #1731 parallelize the loop
 		loop:
 			for i := range lst {
-				addr := lst[i].Address
-				addrHash := hrwOIDWrapper(addr.Object())
+				var (
+					addr     = lst[i].Address
+					addrHash hrwOIDWrapper
+				)
 
 				obj, err := sh.Get(addr, false)
 				if err != nil {
@@ -100,6 +103,11 @@ mainLoop:
 					return count, err
 				}
 
+				if iec.ObjectWithAttributes(*obj) {
+					addrHash = hrwOIDWrapper(obj.GetParentID())
+				} else {
+					addrHash = hrwOIDWrapper(addr.Object())
+				}
 				hrw.Sort(shards, addrHash)
 				for j := range shards {
 					if _, ok := shardMap[shards[j].ID().String()]; ok {


### PR DESCRIPTION
Refs. 476652be8e6902c192241cfa95dda06c19f6ca90, put/get/evacuate should be in sync wrt this.