### PR TITLE
Add flush write-cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 - `neofs-lens meta resync` command (#3849)
 - `policer.boost_multiplier` SN config option (#3855)
+- `neofs-lens storage flush-write-caches` command (#3872)
 
 ### Fixed
 - Resending the header after chunks have already been sent in object service `Get` handler (#3833)

--- a/cmd/neofs-lens/internal/storage/get.go
+++ b/cmd/neofs-lens/internal/storage/get.go
@@ -31,7 +31,7 @@ func getFunc(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid address argument: %w", err)
 	}
 
-	storage, err := openEngine()
+	storage, err := openEngine(true)
 	if err != nil {
 		return err
 	}

--- a/cmd/neofs-lens/internal/storage/list.go
+++ b/cmd/neofs-lens/internal/storage/list.go
@@ -27,7 +27,7 @@ func listFunc(cmd *cobra.Command, _ []string) error {
 	// other targets can be supported
 	w := cmd.OutOrStderr()
 
-	storage, err := openEngine()
+	storage, err := openEngine(true)
 	if err != nil {
 		return err
 	}

--- a/cmd/neofs-lens/internal/storage/root.go
+++ b/cmd/neofs-lens/internal/storage/root.go
@@ -35,6 +35,7 @@ func init() {
 		storageListObjsCMD,
 		storageStatusObjCMD,
 		storageSanityCMD,
+		wcFlushCMD,
 	)
 }
 
@@ -50,7 +51,7 @@ func (e epochState) CurrentEpoch() uint64 {
 	return 0
 }
 
-func openEngine() (*engine.StorageEngine, error) {
+func openEngine(readOnly bool) (*engine.StorageEngine, error) {
 	appCfg, err := config.New(config.WithConfigFile(vConfig))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config file: %w", err)
@@ -125,8 +126,12 @@ func openEngine() (*engine.StorageEngine, error) {
 		shardsWithMeta = append(shardsWithMeta, sh)
 	}
 
+	shardMode := mode.ReadWrite
+	if readOnly {
+		shardMode = mode.ReadOnly
+	}
 	for _, optsWithMeta := range shardsWithMeta {
-		_, err := ls.AddShard(append(optsWithMeta.shOpts, shard.WithMode(mode.ReadOnly))...)
+		_, err := ls.AddShard(append(optsWithMeta.shOpts, shard.WithMode(shardMode))...)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/neofs-lens/internal/storage/status.go
+++ b/cmd/neofs-lens/internal/storage/status.go
@@ -29,7 +29,7 @@ func statusObject(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid address argument: %w", err)
 	}
 
-	storage, err := openEngine()
+	storage, err := openEngine(true)
 	if err != nil {
 		return err
 	}

--- a/cmd/neofs-lens/internal/storage/write_cache_flush.go
+++ b/cmd/neofs-lens/internal/storage/write_cache_flush.go
@@ -1,0 +1,28 @@
+package storage
+
+import (
+	common "github.com/nspcc-dev/neofs-node/cmd/neofs-lens/internal"
+	"github.com/spf13/cobra"
+)
+
+var wcFlushCMD = &cobra.Command{
+	Use:   "flush-write-caches",
+	Short: "Flush write-caches",
+	Long:  `Flush all write-caches from config. This will push all objects from write-caches to the corresponding blobstors.`,
+	Args:  cobra.NoArgs,
+	RunE:  wcFlushFunc,
+}
+
+func init() {
+	common.AddConfigFileFlag(wcFlushCMD, &vConfig)
+}
+
+func wcFlushFunc(_ *cobra.Command, _ []string) error {
+	storage, err := openEngine(false)
+	if err != nil {
+		return err
+	}
+	defer storage.Close()
+
+	return storage.FlushWriteCaches()
+}

--- a/pkg/local_object_storage/engine/writecache.go
+++ b/pkg/local_object_storage/engine/writecache.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"fmt"
+
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 )
 
@@ -15,4 +17,15 @@ func (e *StorageEngine) FlushWriteCache(id *shard.ID) error {
 	}
 
 	return sh.FlushWriteCache(false)
+}
+
+// FlushWriteCaches flushes write-cache on all shards.
+func (e *StorageEngine) FlushWriteCaches() error {
+	for _, sh := range e.unsortedShards() {
+		err := sh.FlushWriteCache(false)
+		if err != nil {
+			return fmt.Errorf("flush write-cache for shard %s: %w", sh.ID(), err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Closes #3827.

Implemented for storage. I don't really see a use for `lens write-cache flush`. In case of necessity, it is possible to specify a configuration for a specific shard if we want to flush only a specific write cache. 