### PR TITLE
node/object/put: forbid new pre-2.18 objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changelog for NeoFS Node
 - SN now ignores `copies_number` field of `object.PutRequest.Body.Init` message (#3830)
 - Policer starts from a random offset (#3879)
 - SN now determines request API version from original request meta header (#3897)
+- 2.18 is the minimum supported version for new objects (#3869)
 
 ### Removed
 - `node.persistent_sessions.path` config option from SN config (#3846)

--- a/pkg/core/object/ec_test.go
+++ b/pkg/core/object/ec_test.go
@@ -208,12 +208,12 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 					obj.SetParent(&parent)
 					tc.corruptPart(obj)
 				})
-				require.EqualError(t, v.Validate(&cp, false), tc.err)
+				require.EqualError(t, v.Validate(&cp, false, true), tc.err)
 				return
 			}
 
 			cp := corruptPart(t, tc.corruptPart)
-			require.EqualError(t, v.Validate(&cp, false), tc.err)
+			require.EqualError(t, v.Validate(&cp, false, true), tc.err)
 		})
 	}
 
@@ -224,17 +224,17 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 			obj.SetPayload(nil)
 			obj.AssociateDeleted(oidtest.ID())
 		})
-		require.EqualError(t, v.Validate(&cp, false), "mix of EC (__NEOFS__EC_RULE_IDX) and non-EC (__NEOFS__ASSOCIATE) attributes")
+		require.EqualError(t, v.Validate(&cp, false, true), "mix of EC (__NEOFS__EC_RULE_IDX) and non-EC (__NEOFS__ASSOCIATE) attributes")
 	})
 
 	t.Run("blank", func(t *testing.T) {
 		for i := range ecParts {
-			require.EqualError(t, v.Validate(&ecParts[i], true), "blank object with EC attributes")
+			require.EqualError(t, v.Validate(&ecParts[i], true, true), "blank object with EC attributes")
 		}
 
 		obj := blankValidObject(creator)
 		obj.SetContainerID(cnrID)
-		require.NoError(t, v.Validate(obj, true))
+		require.NoError(t, v.Validate(obj, true, true))
 	})
 
 	t.Run("non-EC container", func(t *testing.T) {
@@ -247,7 +247,7 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 			obj.SetContainerID(cnr)
 		})
 
-		require.EqualError(t, v.Validate(&cp, false), "object with EC attributes __NEOFS__EC_RULE_IDX in container without EC rules")
+		require.EqualError(t, v.Validate(&cp, false, true), "object with EC attributes __NEOFS__EC_RULE_IDX in container without EC rules")
 	})
 
 	t.Run("split", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 
 		require.NoError(t, linker.SetVerificationFields(creator))
 
-		require.NoError(t, v.Validate(&linker, false))
+		require.NoError(t, v.Validate(&linker, false, true))
 
 		for i := range splitParts {
 			parts, err := iec.Encode(irule, splitParts[i].Payload())
@@ -331,7 +331,7 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				require.NoError(t, v.Validate(&ecPart, false))
+				require.NoError(t, v.Validate(&ecPart, false, true))
 			}
 		}
 	})
@@ -345,11 +345,11 @@ func TestFormatValidator_Validate_EC(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.NoError(t, v.Validate(&obj, false))
+			require.NoError(t, v.Validate(&obj, false, true))
 		}
 	})
 
 	for i := range ecParts {
-		require.NoError(t, v.Validate(&ecParts[i], false))
+		require.NoError(t, v.Validate(&ecParts[i], false, true))
 	}
 }

--- a/pkg/core/object/fmt.go
+++ b/pkg/core/object/fmt.go
@@ -139,17 +139,22 @@ func NewFormatValidator(fsChain FSChain, netmapContract NetmapContract, containe
 //
 // Does not validate payload checksum and content.
 // If unprepared is true, only fields set by user are validated.
+// allowAllVersions defines whether the object version is checked.
 //
 // Returns nil error if the object has valid structure.
-func (v *FormatValidator) Validate(obj *object.Object, unprepared bool) error {
-	return v.validate(obj, unprepared, 0)
+func (v *FormatValidator) Validate(obj *object.Object, unprepared, allowAllVersions bool) error {
+	return v.validate(obj, unprepared, allowAllVersions, 0)
 }
 
 const maxObjectNestingLevel = 2
 
-func (v *FormatValidator) validate(obj *object.Object, unprepared bool, nestingLevel int) error {
+func (v *FormatValidator) validate(obj *object.Object, unprepared, allowAllVersions bool, nestingLevel int) error {
 	if obj == nil {
 		return errNilObject
+	}
+
+	if !allowAllVersions && !version.ValidNewObject(obj.Version()) {
+		return fmt.Errorf("invalid version for a non-replicated object: %s", obj.Version())
 	}
 
 	var expirationRequired bool
@@ -262,7 +267,7 @@ func (v *FormatValidator) validate(obj *object.Object, unprepared bool, nestingL
 
 		// it is possible to have a split of a split
 		prepared := firstSet || splitID != nil || isEC
-		return v.validate(par, !prepared, nestingLevel+1)
+		return v.validate(par, !prepared, allowAllVersions, nestingLevel+1)
 	}
 
 	return nil

--- a/pkg/core/object/fmt_test.go
+++ b/pkg/core/object/fmt_test.go
@@ -93,7 +93,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("nil input", func(t *testing.T) {
-		require.Error(t, v.Validate(nil, true))
+		require.Error(t, v.Validate(nil, true, true))
 	})
 
 	t.Run("storage group", func(t *testing.T) {
@@ -101,19 +101,19 @@ func TestFormatValidator_Validate(t *testing.T) {
 		obj.SetType(object.TypeStorageGroup) //nolint:staticcheck // Deprecated, but that's exactly the test.
 		obj.SetContainerID(cidtest.ID())
 
-		require.Error(t, v.Validate(obj, false))
-		require.Error(t, v.Validate(obj, true))
+		require.Error(t, v.Validate(obj, false, true))
+		require.Error(t, v.Validate(obj, true, true))
 	})
 
 	t.Run("invalid identifier", func(t *testing.T) {
 		t.Run("missing", func(t *testing.T) {
 			obj := smallECDSASHA512
 			obj.ResetID()
-			require.ErrorIs(t, v.Validate(&obj, false), errNilID)
+			require.ErrorIs(t, v.Validate(&obj, false, true), errNilID)
 		})
 		t.Run("wrong", func(t *testing.T) {
 			registerContainer(wrongIDECDSASHA512.GetContainerID())
-			require.EqualError(t, v.Validate(&wrongIDECDSASHA512, false), "could not validate header fields: invalid identifier: incorrect object identifier")
+			require.EqualError(t, v.Validate(&wrongIDECDSASHA512, false, true), "could not validate header fields: invalid identifier: incorrect object identifier")
 		})
 	})
 
@@ -121,14 +121,14 @@ func TestFormatValidator_Validate(t *testing.T) {
 		obj := new(object.Object)
 		obj.SetID(oidtest.ID())
 
-		require.ErrorIs(t, v.Validate(obj, true), errNilCID)
+		require.ErrorIs(t, v.Validate(obj, true, true), errNilCID)
 	})
 
 	t.Run("invalid signature", func(t *testing.T) {
 		t.Run("unsigned", func(t *testing.T) {
 			obj, _ := minUnsignedObject(t)
 			registerContainer(obj.GetContainerID())
-			require.EqualError(t, v.Validate(&obj, false), "authenticate: missing signature")
+			require.EqualError(t, v.Validate(&obj, false, true), "authenticate: missing signature")
 		})
 		t.Run("unsupported scheme", func(t *testing.T) {
 			obj, signer := minUnsignedObject(t)
@@ -140,7 +140,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 			registerContainer(obj.GetContainerID())
 
-			require.EqualError(t, v.Validate(&obj, false), "authenticate: unsupported scheme 4")
+			require.EqualError(t, v.Validate(&obj, false, true), "authenticate: unsupported scheme 4")
 		})
 		t.Run("wrong scheme", func(t *testing.T) {
 			obj, signer := minUnsignedObject(t)
@@ -152,7 +152,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 			registerContainer(obj.GetContainerID())
 
-			require.EqualError(t, v.Validate(&obj, false), "authenticate: scheme ECDSA_RFC6979_SHA256_WALLET_CONNECT: signature mismatch")
+			require.EqualError(t, v.Validate(&obj, false, true), "authenticate: scheme ECDSA_RFC6979_SHA256_WALLET_CONNECT: signature mismatch")
 		})
 		t.Run("invalid public key", func(t *testing.T) {
 			obj, signer := minUnsignedObject(t)
@@ -180,7 +180,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 					registerContainer(obj.GetContainerID())
 
-					require.EqualError(t, v.Validate(&obj, false), "authenticate: scheme ECDSA_SHA512: decode public key: "+tc.err)
+					require.EqualError(t, v.Validate(&obj, false, true), "authenticate: scheme ECDSA_SHA512: decode public key: "+tc.err)
 				})
 			}
 		})
@@ -202,7 +202,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 						cp[i]++
 						newSig := neofscrypto.NewSignatureFromRawKey(sig.Scheme(), sig.PublicKeyBytes(), cp)
 						tc.object.SetSignature(&newSig)
-						require.EqualError(t, v.Validate(&tc.object, false), fmt.Sprintf("authenticate: scheme %s: signature mismatch", tc.scheme))
+						require.EqualError(t, v.Validate(&tc.object, false, true), fmt.Sprintf("authenticate: scheme %s: signature mismatch", tc.scheme))
 					}
 				})
 			}
@@ -222,7 +222,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		registerContainer(obj.GetContainerID())
 
-		require.NoError(t, v.Validate(obj, false))
+		require.NoError(t, v.Validate(obj, false, true))
 	})
 
 	t.Run("incorrect session token", func(t *testing.T) {
@@ -236,14 +236,14 @@ func TestFormatValidator_Validate(t *testing.T) {
 			require.NoError(t, obj.SetIDWithSignature(signer))
 
 			obj.SetSignature(&neofscrypto.Signature{})
-			require.Error(t, v.Validate(obj, false))
+			require.Error(t, v.Validate(obj, false, true))
 		})
 
 		t.Run("wrong owner", func(t *testing.T) {
 			obj.SetOwner(user.ID{})
 
 			require.NoError(t, obj.SetIDWithSignature(signer))
-			require.Error(t, v.Validate(obj, false))
+			require.Error(t, v.Validate(obj, false, true))
 		})
 
 		t.Run("wrong signer", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 			wrongSigner := user.NewAutoIDSignerRFC6979(wrongOwner.PrivateKey)
 
 			require.NoError(t, obj.SetIDWithSignature(wrongSigner))
-			require.Error(t, v.Validate(obj, false))
+			require.Error(t, v.Validate(obj, false, true))
 		})
 
 		t.Run("signed not by issuer", func(t *testing.T) {
@@ -275,7 +275,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 			registerContainer(obj.GetContainerID())
 
-			err = v.Validate(obj, false)
+			err = v.Validate(obj, false, true)
 			require.EqualError(t, err, "authenticate: session token: issuer mismatches signature")
 		})
 	})
@@ -288,7 +288,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		registerContainer(obj.GetContainerID())
 
-		require.NoError(t, v.Validate(obj, false))
+		require.NoError(t, v.Validate(obj, false, true))
 	})
 
 	t.Run("expiration", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 		t.Run("invalid attribute value", func(t *testing.T) {
 			val := "text"
-			err := v.Validate(fn(val), false)
+			err := v.Validate(fn(val), false, true)
 			require.Error(t, err)
 		})
 
@@ -320,7 +320,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 			obj := fn(val)
 
 			t.Run("non-locked", func(t *testing.T) {
-				err := v.Validate(obj, false)
+				err := v.Validate(obj, false, true)
 				require.ErrorIs(t, err, errExpired)
 			})
 
@@ -333,14 +333,14 @@ func TestFormatValidator_Validate(t *testing.T) {
 				addr.SetObject(oID)
 				ls.m[addr] = true
 
-				err := v.Validate(obj, false)
+				err := v.Validate(obj, false, true)
 				require.NoError(t, err)
 			})
 		})
 
 		t.Run("alive object", func(t *testing.T) {
 			val := strconv.FormatUint(curEpoch, 10)
-			err := v.Validate(fn(val), true)
+			err := v.Validate(fn(val), true, true)
 			require.NoError(t, err)
 		})
 	})
@@ -395,15 +395,15 @@ func TestFormatValidator_Validate(t *testing.T) {
 			}
 			t.Run("in key", func(t *testing.T) {
 				obj := objWithAttr("k\x00y", "value")
-				require.EqualError(t, v.Validate(obj, true), "invalid attributes: invalid attribute #1: invalid key: illegal zero byte")
+				require.EqualError(t, v.Validate(obj, true, true), "invalid attributes: invalid attribute #1: invalid key: illegal zero byte")
 				obj.SetID(oidtest.ID())
-				require.EqualError(t, v.Validate(obj, false), "invalid attributes: invalid attribute #1: invalid key: illegal zero byte")
+				require.EqualError(t, v.Validate(obj, false, true), "invalid attributes: invalid attribute #1: invalid key: illegal zero byte")
 			})
 			t.Run("in value", func(t *testing.T) {
 				obj := objWithAttr("key", "va\x00ue")
-				require.EqualError(t, v.Validate(obj, true), "invalid attributes: invalid attribute #1: invalid value: illegal zero byte")
+				require.EqualError(t, v.Validate(obj, true, true), "invalid attributes: invalid attribute #1: invalid value: illegal zero byte")
 				obj.SetID(oidtest.ID())
-				require.EqualError(t, v.Validate(obj, false), "invalid attributes: invalid attribute #1: invalid value: illegal zero byte")
+				require.EqualError(t, v.Validate(obj, false, true), "invalid attributes: invalid attribute #1: invalid value: illegal zero byte")
 			})
 		})
 	})
@@ -415,7 +415,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 			registerContainer(child.GetContainerID())
 
-			require.EqualError(t, v.Validate(&child, true), "max object nesting level 2 overflow")
+			require.EqualError(t, v.Validate(&child, true, true), "max object nesting level 2 overflow")
 		})
 
 		t.Run("nesting is ok", func(t *testing.T) {
@@ -424,7 +424,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 
 			registerContainer(child.GetContainerID())
 
-			require.NoError(t, v.Validate(&child, true))
+			require.NoError(t, v.Validate(&child, true, true))
 		})
 	})
 
@@ -437,7 +437,7 @@ func TestFormatValidator_Validate(t *testing.T) {
 		{scheme: neofscrypto.ECDSA_WALLETCONNECT, object: smallECDSAWalletConnect},
 	} {
 		t.Run(tc.scheme.String(), func(t *testing.T) {
-			require.NoError(t, v.Validate(&tc.object, false))
+			require.NoError(t, v.Validate(&tc.object, false, true))
 		})
 	}
 }
@@ -509,7 +509,7 @@ func TestLinkObjectSplitV2(t *testing.T) {
 	obj.SetFirstID(oidtest.ID())
 
 	t.Run("V1 split, first is set", func(t *testing.T) {
-		require.ErrorContains(t, v.Validate(obj, true), "first object ID is set")
+		require.ErrorContains(t, v.Validate(obj, true, true), "first object ID is set")
 	})
 
 	t.Run("V2 split", func(t *testing.T) {
@@ -519,7 +519,7 @@ func TestLinkObjectSplitV2(t *testing.T) {
 			obj.SetFirstID(oidtest.ID())
 			obj.SetType(object.TypeLink)
 
-			require.ErrorContains(t, v.Validate(obj, true), "incorrect link object's parent header")
+			require.ErrorContains(t, v.Validate(obj, true, true), "incorrect link object's parent header")
 		})
 
 		t.Run("middle child does not have previous object ID", func(t *testing.T) {
@@ -528,7 +528,52 @@ func TestLinkObjectSplitV2(t *testing.T) {
 			obj.SetFirstID(oidtest.ID())
 			obj.SetType(object.TypeRegular)
 
-			require.ErrorContains(t, v.Validate(obj, true), "middle part does not have previous object ID")
+			require.ErrorContains(t, v.Validate(obj, true, true), "middle part does not have previous object ID")
+		})
+	})
+}
+
+func TestVersion(t *testing.T) {
+	cnrID := cidtest.ID()
+
+	obj := objecttest.Object()
+	obj.ResetRelations()
+	obj.SetType(object.TypeRegular)
+	obj.CutPayload()
+	obj.SetContainerID(cnrID)
+
+	verifier := new(testSplitVerifier)
+
+	cnrs := newMockContainers()
+	cnrs.setContainer(cnrID, container.Container{})
+
+	v := NewFormatValidator(nil, nil, cnrs, WithSplitVerifier(verifier))
+
+	t.Run("Replication", func(t *testing.T) {
+		vers := version.New(2, 17)
+		obj.SetVersion(&vers)
+
+		require.NoError(t, v.Validate(&obj, true, true))
+	})
+
+	t.Run("PUT", func(t *testing.T) {
+		t.Run("2.18-", func(t *testing.T) {
+			vers := version.New(2, 17)
+			obj.SetVersion(&vers)
+
+			require.Error(t, v.Validate(&obj, true, false), "invalid version for a non-replicated object")
+		})
+
+		t.Run("2.18+", func(t *testing.T) {
+			vers := version.New(2, 18)
+			obj.SetVersion(&vers)
+
+			require.NoError(t, v.Validate(&obj, true, true))
+
+			vers = version.New(2, 100)
+			obj.SetVersion(&vers)
+
+			require.NoError(t, v.Validate(&obj, true, true))
 		})
 	})
 }

--- a/pkg/core/version/version.go
+++ b/pkg/core/version/version.go
@@ -22,6 +22,14 @@ func SysObjTargetShouldBeInHeader(v *version.Version) bool {
 		(v.Major() == latestSysObjTargetInPayloadMjr && v.Minor() > latestSysObjTargetInPayloadMnr)
 }
 
+// ValidNewObject checks if version is a correct for new objects in the system.
+func ValidNewObject(v *version.Version) bool {
+	// in practice this func was added to bypass error objects, `ValidNewObject`
+	// means the same version check but preventing new objects to be PUT;
+	// see https://github.com/nspcc-dev/neofs-node/issues/3869
+	return OwnerSignatureMatchRequired(v)
+}
+
 // OwnerSignatureMatchRequired returns true if an object with the given version
 // must have the owner matching the signature's public key. Objects below version
 // 2.18 may have a mismatching owner due to a bug that allowed creating such

--- a/pkg/services/object/put/local.go
+++ b/pkg/services/object/put/local.go
@@ -93,7 +93,7 @@ func (p *Service) ValidateAndStoreObjectLocally(obj object.Object) error {
 		}
 	}
 
-	if err := p.fmtValidator.Validate(&obj, false); err != nil {
+	if err := p.fmtValidator.Validate(&obj, false, true); err != nil {
 		return fmt.Errorf("validate object format: %w", err)
 	}
 

--- a/pkg/services/object/put/validation.go
+++ b/pkg/services/object/put/validation.go
@@ -109,7 +109,7 @@ func (t *validatingTarget) WriteHeader(obj *object.Object) error {
 		t.checksum = cs.Value()
 	}
 
-	if err := t.fmt.Validate(obj, t.unpreparedObject); err != nil {
+	if err := t.fmt.Validate(obj, t.unpreparedObject, false); err != nil {
 		return fmt.Errorf("(%T) could not validate object format: %w", t, err)
 	}
 


### PR DESCRIPTION
Replicated ones are exceptional for now. Closes #3869.