### PR TITLE
crypto: skip owner/session mismatch check for pre-2.18 objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Node
 ### Fixed
 - Policer removes redundant local shard copies that could remain on disk forever (#3908)
 - Treat only HALTed main transactions as successfully executed, retry the rest (#3868)
+- `different object owner and session issuer` for stored objects (#3929)
 
 ### Changed
 

--- a/internal/crypto/object.go
+++ b/internal/crypto/object.go
@@ -58,7 +58,7 @@ func AuthenticateObject(obj object.Object, fsChain HistoricN3ScriptRunner, ecPar
 		if err := AuthenticateToken(sessionToken, fsChain); err != nil {
 			return fmt.Errorf("session token: %w", err)
 		}
-		if sessionToken.Issuer() != obj.Owner() {
+		if sessionToken.Issuer() != obj.Owner() && version.OwnerSignatureMatchRequired(obj.Version()) {
 			return errors.New("different object owner and session issuer")
 		}
 	}

--- a/internal/crypto/object_test.go
+++ b/internal/crypto/object_test.go
@@ -100,6 +100,10 @@ func TestAuthenticateObject(t *testing.T) {
 		} {
 			t.Run(tc.scheme.String(), func(t *testing.T) {
 				require.EqualError(t, icrypto.AuthenticateObject(tc.object, nil, false, nil), "owner mismatches signature")
+				t.Run("before v2.18", func(t *testing.T) {
+					tc.object.SetVersion(&oldVersion)
+					require.NoError(t, icrypto.AuthenticateObject(tc.object, nil, false, nil))
+				})
 			})
 		}
 	})
@@ -157,6 +161,10 @@ func TestAuthenticateObject(t *testing.T) {
 			} {
 				t.Run(tc.scheme.String(), func(t *testing.T) {
 					require.EqualError(t, icrypto.AuthenticateObject(tc.object, nil, false, nil), "different object owner and session issuer")
+					t.Run("before v2.18", func(t *testing.T) {
+						tc.object.SetVersion(&oldVersion)
+						require.NoError(t, icrypto.AuthenticateObject(tc.object, nil, false, nil))
+					})
 				})
 			}
 		})
@@ -207,6 +215,8 @@ var (
 	wrongOwnerObjectECDSASHA512        object.Object
 	wrongOwnerObjectECDSARFC6979       object.Object
 	wrongOwnerObjectECDSAWalletConnect object.Object
+
+	oldVersion = version.New(2, 17)
 )
 
 func getUnsignedObject() object.Object {

--- a/pkg/core/version/version.go
+++ b/pkg/core/version/version.go
@@ -31,7 +31,7 @@ func ValidNewObject(v *version.Version) bool {
 }
 
 // OwnerSignatureMatchRequired returns true if an object with the given version
-// must have the owner matching the signature's public key. Objects below version
+// must have the owner matching the authentication data. Objects below version
 // 2.18 may have a mismatching owner due to a bug that allowed creating such
 // objects, so they should not be rejected.
 func OwnerSignatureMatchRequired(v *version.Version) bool {


### PR DESCRIPTION
Closes #3919.