### PR TITLE
metabase: batch all regular state-modifying operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog for NeoFS Node
 - Optimized integer comparison in SearchV2 (#3938)
 - Optimized number of nodes for SEARCH in EC containers (#3940)
 - Optimized post-initial placement replication (#3923)
+- All regular state-modifying DB operations are batched now (was Put-only, #3942)
 
 ### Removed
 - `policer.max_workers` configuration (#3920)

--- a/pkg/local_object_storage/metabase/containers.go
+++ b/pkg/local_object_storage/metabase/containers.go
@@ -117,7 +117,7 @@ func (db *DB) DeleteContainer(cID cid.ID) error {
 		return ErrReadOnlyMode
 	}
 
-	return db.boltDB.Update(func(tx *bbolt.Tx) error {
+	return db.boltDB.Batch(func(tx *bbolt.Tx) error {
 		if err := tx.DeleteBucket(metaBucketKey(cID)); err != nil && !errors.Is(err, bolterrors.ErrBucketNotFound) {
 			return fmt.Errorf("metadata bucket cleanup: %w", err)
 		}

--- a/pkg/local_object_storage/metabase/delete.go
+++ b/pkg/local_object_storage/metabase/delete.go
@@ -51,7 +51,7 @@ func (db *DB) Delete(cnr cid.ID, addrs []oid.ID) (DeleteRes, error) {
 	var err error
 	var removed []RemovedObject
 
-	err = db.boltDB.Update(func(tx *bbolt.Tx) error {
+	err = db.boltDB.Batch(func(tx *bbolt.Tx) error {
 		var metaBucket = tx.Bucket(metaBucketKey(cnr))
 		if metaBucket == nil {
 			return nil

--- a/pkg/local_object_storage/metabase/inhume.go
+++ b/pkg/local_object_storage/metabase/inhume.go
@@ -39,7 +39,7 @@ func (db *DB) MarkGarbage(cnr cid.ID, addrs []oid.ID) (ContainerGarbageDiff, err
 		objsInCnr   = make([]oid.ID, 0, len(addrs))
 		counterDiff ContainerGarbageDiff
 	)
-	err = db.boltDB.Update(func(tx *bbolt.Tx) error {
+	err = db.boltDB.Batch(func(tx *bbolt.Tx) error {
 		metaBucket := tx.Bucket(metaBucketKey(cnr))
 		if metaBucket == nil {
 			return nil
@@ -131,7 +131,7 @@ func (db *DB) InhumeContainer(cID cid.ID) (CountersDiff, error) {
 		return res, ErrReadOnlyMode
 	}
 
-	err := db.boltDB.Update(func(tx *bbolt.Tx) error {
+	err := db.boltDB.Batch(func(tx *bbolt.Tx) error {
 		metaBkt, err := tx.CreateBucketIfNotExists(metaBucketKey(cID))
 		if err != nil {
 			return fmt.Errorf("create meta bucket: %w", err)


### PR DESCRIPTION
GC and Policer can modify the DB concurrently to Put, while some (container-level) operations are pretty rare, Policer will call MarkGarbage per object and this can add serious pressure to the DB affecting Put flows. None of these operations require any urgency, justifying a separate transaction, so use Batch() for them.