### PR TITLE
wc: do not produce logs when deleting a missing object

### DIFF
--- a/pkg/local_object_storage/writecache/flush.go
+++ b/pkg/local_object_storage/writecache/flush.go
@@ -237,7 +237,7 @@ func (c *cache) flushBatch(addrs []oid.Address) error {
 			c.log.Error("can't remove object from write-cache", zap.Error(err))
 		}
 	}
-	return err
+	return nil
 }
 
 func (c *cache) getObject(addr oid.Address) ([]byte, error) {


### PR DESCRIPTION
```
writecache/flush.go:155	can't flush objects	{"shard_id": "4YVJ1aJRfMw8mnWaqcUECj", "substorage": "write-cache", "worker": 12, "first_object": "Fz6GUm1oVtwKBnToZNEnhPUgGRU6SQ1aftUkbY4yGa3W/CihtqZKhvhKJY76XsRpywpUBwXtnzS1wHficeXKnwuSK", "error": "logical error: status: code = 2049 message = object not found"}
```