### PR TITLE
Fix/fstree compressed objects buffered reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - SearchV2 method returning zero result instead of "bad request" error for incorrect numeric filters (#3934)
 - Garbage double-counting in metrics (#3933)
 - Panic in session token storage epoch parsing (#3941)
+- Compressed object GET failure in some cases (#3936)
 
 ### Changed
 - `object search` CLI command is now the same as `object searchv2` (#3931)

--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -555,10 +555,7 @@ func (t *FSTree) GetRangeStream(addr oid.Address, off uint64, ln uint64) (io.Rea
 		}
 	}
 
-	return struct {
-		io.Reader
-		io.Closer
-	}{
+	return readerCloser{
 		Reader: io.LimitReader(stream, int64(ln)),
 		Closer: stream,
 	}, nil

--- a/pkg/local_object_storage/blobstor/fstree/getstream_test.go
+++ b/pkg/local_object_storage/blobstor/fstree/getstream_test.go
@@ -86,6 +86,24 @@ func TestGetStream(t *testing.T) {
 				testStream(t, size)
 			})
 		}
+
+		t.Run("uncompressed object overflows buffer", func(t *testing.T) {
+			testData := make([]byte, 2*iobject.NonPayloadFieldsBufferLength+1)
+
+			addr := oidtest.Address()
+			require.NoError(t, tree.Put(addr, testData))
+
+			buff := make([]byte, 2*iobject.NonPayloadFieldsBufferLength)
+			n, reader, err := tree.ReadObject(addr, buff)
+			require.NoError(t, err)
+			require.EqualValues(t, len(buff), n)
+
+			require.NotNil(t, reader)
+			additionallyRead, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, testData, append(buff, additionallyRead...))
+			require.NoError(t, reader.Close())
+		})
 	})
 
 	t.Run("specific combined object", func(t *testing.T) {

--- a/pkg/local_object_storage/blobstor/fstree/head.go
+++ b/pkg/local_object_storage/blobstor/fstree/head.go
@@ -85,7 +85,18 @@ func (t *FSTree) ReadObject(addr oid.Address, buf []byte) (int, io.ReadCloser, e
 		stream = nopReadCloser{}
 	}
 
-	return copy(buf, initial), stream, nil
+	n := copy(buf, initial)
+	if len(initial) > n {
+		// data was pre-read according to the provided buffer, but its
+		// uncompressed form does not fit the buffer, reslice it, and do not
+		// lose any payload
+		return n, readerCloser{
+			Reader: io.MultiReader(bytes.NewReader(initial[n:]), stream),
+			Closer: stream,
+		}, nil
+	}
+
+	return n, stream, nil
 }
 
 // getObjectStream reads an object from the storage by address as a stream.

--- a/pkg/local_object_storage/blobstor/fstree/util.go
+++ b/pkg/local_object_storage/blobstor/fstree/util.go
@@ -4,6 +4,10 @@ import (
 	"io"
 )
 
+type readerCloser struct {
+	io.Reader
+	io.Closer
+}
 type readerTwoClosers struct {
 	io.ReadCloser
 	baseCloser io.Closer


### PR DESCRIPTION
Previously, if a compressed object fits pre-read buffer fully, but its uncompressed form overflows it, a broken object with lost payload was returned.
Closes #3936.