### PR TITLE
node: simplify IR key fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for NeoFS Node
 - All regular state-modifying DB operations are batched now (was Put-only, #3942)
 - Optimized metabase object checks for container-level GC marks (#3953)
 - Rejected metabase PUT requests into GC-marked containers (#3953)
+- Improved IR list caching in SN (#3954)
 
 ### Removed
 - `policer.max_workers` configuration (#3920)

--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/core/container"
 	"github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	cntClient "github.com/nspcc-dev/neofs-node/pkg/morph/client/container"
-	putsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/put"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	sdkcontainer "github.com/nspcc-dev/neofs-sdk-go/container"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -410,77 +409,62 @@ func (s *ttlContainerLister) reset() {
 	s.inner.reset()
 }
 
-type cachedIRFetcher struct {
-	tc ttlNetCache[struct{}, [][]byte]
-}
+type cachedIRFetcher singleValueTTLCache[[][]byte]
 
-func newCachedIRFetcher(f interface{ InnerRingKeys() ([][]byte, error) }) *cachedIRFetcher {
-	const (
-		irFetcherCacheSize = 1 // we intend to store only one value
-
-		// Without the cache in the testnet we can see several hundred simultaneous
-		// requests (neofs-node #1278), so limiting the request rate solves the issue.
-		//
-		// Exact request rate doesn't really matter because Inner Ring list update
-		// happens extremely rare, but there is no FS chain events for that as
-		// for now (neofs-contract v0.15.0 notary disabled env) to monitor it.
-		irFetcherCacheTTL = 30 * time.Second
-	)
-
-	irFetcherCache := newNetworkTTLCache(irFetcherCacheSize, irFetcherCacheTTL,
-		func(key struct{}) ([][]byte, error) {
-			return f.InnerRingKeys()
-		},
-	)
-
-	return &cachedIRFetcher{tc: irFetcherCache}
+func newCachedIRFetcher(f func() ([][]byte, error)) *cachedIRFetcher {
+	return &cachedIRFetcher{
+		src: f,
+	}
 }
 
 // InnerRingKeys returns cached list of Inner Ring keys. If keys are missing in
 // the cache or expired, then it returns keys from FS chain and updates
 // the cache.
-func (f *cachedIRFetcher) InnerRingKeys() ([][]byte, error) {
-	val, err := f.tc.get(struct{}{})
-	if err != nil {
-		return nil, err
-	}
-
-	return val, nil
+func (f *cachedIRFetcher) InnerRingKeys() [][]byte {
+	return (*singleValueTTLCache[[][]byte])(f).Value()
 }
 
-type ttlMaxObjectSizeCache struct {
-	mtx         sync.RWMutex
-	lastUpdated time.Time
-	lastSize    uint64
-	src         putsvc.MaxSizeSource
+type ttlMaxObjectSizeCache singleValueTTLCache[uint64]
+
+func (c *ttlMaxObjectSizeCache) MaxObjectSize() uint64 {
+	return (*singleValueTTLCache[uint64])(c).Value()
 }
 
-func newCachedMaxObjectSizeSource(src putsvc.MaxSizeSource) putsvc.MaxSizeSource {
+func newCachedMaxObjectSizeSource(src func() (uint64, error)) *ttlMaxObjectSizeCache {
 	return &ttlMaxObjectSizeCache{
 		src: src,
 	}
 }
 
-func (c *ttlMaxObjectSizeCache) MaxObjectSize() uint64 {
+type singleValueTTLCache[T any] struct {
+	mtx         sync.RWMutex
+	lastUpdated time.Time
+	lastValue   T
+	src         func() (T, error)
+}
+
+func (c *singleValueTTLCache[T]) Value() T {
 	const ttl = time.Second * 30
 
 	c.mtx.RLock()
 	prevUpdated := c.lastUpdated
-	size := c.lastSize
+	value := c.lastValue
 	c.mtx.RUnlock()
 
 	if time.Since(prevUpdated) < ttl {
-		return size
+		return value
 	}
 
 	c.mtx.Lock()
-	size = c.lastSize
 	if !c.lastUpdated.After(prevUpdated) {
-		size = c.src.MaxObjectSize()
-		c.lastSize = size
-		c.lastUpdated = time.Now()
+		value, err := c.src()
+		if err == nil {
+			c.lastValue = value
+			c.lastUpdated = time.Now()
+		}
 	}
+	value = c.lastValue
 	c.mtx.Unlock()
 
-	return size
+	return value
 }

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -91,7 +91,7 @@ func (r putPostInitialPlacementReplicator) HandlePostPlacement(obj *object.Objec
 	}
 }
 
-func (c *cfg) MaxObjectSize() uint64 {
+func (c *cfg) MaxObjectSize() (uint64, error) {
 	sz, err := c.nCli.MaxObjectSize()
 	if err != nil {
 		c.log.Error("could not get max object size value",
@@ -99,7 +99,7 @@ func (c *cfg) MaxObjectSize() uint64 {
 		)
 	}
 
-	return sz
+	return sz, err
 }
 
 func (s *objectSvc) Put(ctx context.Context) (*putsvc.Streamer, error) {
@@ -145,13 +145,15 @@ func (i *delNetInfo) LocalNodeID() user.ID {
 }
 
 type innerRingFetcherWithNotary struct {
+	cfg     *cfg
 	fschain *morphClient.Client
 }
 
 func (fn *innerRingFetcherWithNotary) InnerRingKeys() ([][]byte, error) {
 	keys, err := fn.fschain.NeoFSAlphabetList()
 	if err != nil {
-		return nil, fmt.Errorf("can't get inner ring keys from alphabet role: %w", err)
+		fn.cfg.log.Error("can't get inner ring key list", zap.Error(err))
+		return nil, fmt.Errorf("can't get inner ring key list: %w", err)
 	}
 
 	result := make([][]byte, 0, len(keys))
@@ -208,6 +210,7 @@ func initObjectService(c *cfg) {
 	}
 
 	irFetcher := &innerRingFetcherWithNotary{
+		cfg:     c,
 		fschain: c.cfgMorph.client,
 	}
 
@@ -267,7 +270,7 @@ func initObjectService(c *cfg) {
 		putsvc.WithKeyStorage(keyStorage),
 		putsvc.WithClientConstructor(putConstructor),
 		putsvc.WithContainerClient(c.cCli),
-		putsvc.WithMaxSizeSource(newCachedMaxObjectSizeSource(c)),
+		putsvc.WithMaxSizeSource(newCachedMaxObjectSizeSource(c.MaxObjectSize)),
 		putsvc.WithObjectStorage(ls),
 		putsvc.WithContainerSource(c.cnrSrc),
 		putsvc.WithNetworkState(c.cfgNetmap.state),
@@ -308,7 +311,7 @@ func initObjectService(c *cfg) {
 
 	aclSvc := v2.New(fsChain,
 		v2.WithLogger(c.log),
-		v2.WithIRFetcher(newCachedIRFetcher(irFetcher)),
+		v2.WithIRFetcher(newCachedIRFetcher(irFetcher.InnerRingKeys)),
 		v2.WithNetmapper(netmapSourceWithNodes{
 			Source:         c.netMapSource,
 			fsChain:        fsChain,

--- a/pkg/services/object/acl/v2/classifier.go
+++ b/pkg/services/object/acl/v2/classifier.go
@@ -53,10 +53,7 @@ func (c senderClassifier) classify(idCnr cid.ID, cnrOwner, reqAuthor user.ID, re
 }
 
 func (c senderClassifier) isInnerRingKey(owner []byte) (bool, error) {
-	innerRingKeys, err := c.innerRing.InnerRingKeys()
-	if err != nil {
-		return false, err
-	}
+	innerRingKeys := c.innerRing.InnerRingKeys()
 
 	// if request owner key in the inner ring list, return RoleSystem
 	for i := range innerRingKeys {

--- a/pkg/services/object/acl/v2/classifier_test.go
+++ b/pkg/services/object/acl/v2/classifier_test.go
@@ -15,8 +15,8 @@ import (
 
 type nopIR struct{}
 
-func (nopIR) InnerRingKeys() ([][]byte, error) {
-	return nil, nil
+func (nopIR) InnerRingKeys() [][]byte {
+	return nil
 }
 
 type nopFSChain struct {

--- a/pkg/services/object/acl/v2/service_test.go
+++ b/pkg/services/object/acl/v2/service_test.go
@@ -47,8 +47,8 @@ func (x *mockFSChain) HasUserInNNS(string, util.Uint160) (bool, error) {
 type mockIR struct {
 }
 
-func (x *mockIR) InnerRingKeys() ([][]byte, error) {
-	return nil, nil
+func (x *mockIR) InnerRingKeys() [][]byte {
+	return nil
 }
 
 type mockTimeProvider struct{}

--- a/pkg/services/object/acl/v2/types.go
+++ b/pkg/services/object/acl/v2/types.go
@@ -24,5 +24,5 @@ type ACLChecker interface {
 type InnerRingFetcher interface {
 	// InnerRingKeys must return list of public keys of
 	// the actual inner ring.
-	InnerRingKeys() ([][]byte, error)
+	InnerRingKeys() [][]byte
 }


### PR DESCRIPTION
1. Returning old value from it is safe (similar to MaxObjectSize).
2. It doesn't need TTL cache, it's a single value. This removes exclusive lock as well (1.5% of overall mutex waits).