### PR TITLE
tombstone/verify: don't dereference a nil header returned from ObjectSource

### DIFF
--- a/pkg/services/object/tombstone/verify.go
+++ b/pkg/services/object/tombstone/verify.go
@@ -75,6 +75,14 @@ func (v *Verifier) verifyMember(ctx context.Context, cnr cid.ID, member oid.ID) 
 
 		return fmt.Errorf("heading object: %w", err)
 	}
+	if header == nil {
+		// ObjectSource.Head contractually returns a non-nil header when
+		// err is nil, but the gRPC path under high load has been observed
+		// to return (nil, nil) in production (#3937) and dereferencing it
+		// a line below panics the whole node. Fail this one verification
+		// rather than the process.
+		return fmt.Errorf("heading object %s: source returned no header and no error", addr)
+	}
 
 	switch header.Type() {
 	case object.TypeLink, object.TypeTombstone, object.TypeLock:


### PR DESCRIPTION
## Summary

`Verifier.verifyMember` relies on `ObjectSource.Head` returning a non-nil `*object.Object` whenever it returns a nil error. In production under high load (#3937) a node panicked with:

```
panic: runtime error: invalid memory address or nil pointer dereference
    github.com/nspcc-dev/neofs-node/pkg/services/object/tombstone.(*Verifier).verifyMember
    pkg/services/object/tombstone/verify.go:79
```

Line 79 is the `switch header.Type()` immediately after the `Head` call returns, so some implementation on the gRPC path is racing back `(nil, nil)` for at least one request.

Fixes #3937.

## Change

Add a nil guard on `header` right after the error-handling block. If the source ever violates the contract, we fail this one verification with a descriptive error instead of panicking the whole node:

```go
if header == nil {
    return fmt.Errorf("heading object %s: source returned no header and no error", addr)
}
```

The contract is unchanged; this is pure defence. Any real "object exists but no header" response still flows through as before.

## Testing

- `go build ./...` passes.
- `go test ./pkg/services/object/tombstone/...` passes.
- Added a local regression with a mock `ObjectSource` that returns `(nil, nil)`: `verifyMember` now returns an error, previously it panicked.
