### PR TITLE
cli: fallback to v1 session in object search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog for NeoFS Node
 - Garbage double-counting in metrics (#3933)
 - Panic in session token storage epoch parsing (#3941)
 - Compressed object GET failure in some cases (#3936)
-- Support v2 session tokens in cli object search (#3955)
+- Support v2 session tokens in cli object search (#3955, #3962)
 
 ### Changed
 - `object search` CLI command is now the same as `object searchv2` (#3931)

--- a/cmd/neofs-cli/modules/object/search.go
+++ b/cmd/neofs-cli/modules/object/search.go
@@ -162,17 +162,6 @@ func searchV2(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	stV2, err := getVerifiedSessionV2(cmd, sessionv2.VerbObjectSearch, pk, cnr)
-	if err != nil {
-		return err
-	}
-	var st *session.Object
-	if stV2 == nil {
-		st, err = getVerifiedSession(cmd, session.VerbObjectSearch, pk, cnr)
-		if err != nil {
-			return err
-		}
-	}
 
 	ctx, cancel := commonflags.GetCommandContext(cmd)
 	defer cancel()
@@ -191,10 +180,21 @@ func searchV2(cmd *cobra.Command, _ []string) error {
 	if bt != nil {
 		opts.WithBearerToken(*bt)
 	}
+	stV2 := tryReadSessionV2(cmd)
 	if stV2 != nil {
+		err = verifySessionV2(cmd, stV2, sessionv2.VerbObjectSearch, pk, cnr)
+		if err != nil {
+			return err
+		}
 		opts.WithSessionTokenV2(*stV2)
-	} else if st != nil {
-		opts.WithSessionToken(*st)
+	} else {
+		st, err := getVerifiedSession(cmd, session.VerbObjectSearch, pk, cnr)
+		if err != nil {
+			return err
+		}
+		if st != nil {
+			opts.WithSessionToken(*st)
+		}
 	}
 	res, cursor, err := cli.SearchObjects(ctx, cnr, fs, searchAttributesFlag.v, searchCursorFlag.v, neofsecdsa.Signer(*pk), opts)
 	if err != nil && !errors.Is(err, apistatus.ErrIncomplete) {

--- a/cmd/neofs-cli/modules/object/util.go
+++ b/cmd/neofs-cli/modules/object/util.go
@@ -200,11 +200,11 @@ func getSession(cmd *cobra.Command) (*session.Object, error) {
 //	*internal.PayloadRangePrm
 //	*internal.HashPayloadRangesPrm
 func _readVerifiedSession(cmd *cobra.Command, dst SessionPrm, key *ecdsa.PrivateKey, cnr cid.ID, obj *oid.ID) error {
-	isV2, err := tryReadSessionV2(cmd, dst, key, cnr)
-	if err != nil {
-		return fmt.Errorf("v2 session validation failed: %w", err)
-	}
-	if isV2 {
+	if tokV2 := tryReadSessionV2(cmd); tokV2 != nil {
+		err := attachVerifiedSessionV2(cmd, tokV2, dst, key, cnr)
+		if err != nil {
+			return fmt.Errorf("v2 session validation failed: %w", err)
+		}
 		common.PrintVerbose(cmd, "Using V2 session token")
 		return nil
 	}

--- a/cmd/neofs-cli/modules/object/util_session_v2.go
+++ b/cmd/neofs-cli/modules/object/util_session_v2.go
@@ -37,40 +37,35 @@ func getSessionV2(cmd *cobra.Command) (*session.Token, error) {
 	return &tok, nil
 }
 
-func getVerifiedSessionV2(cmd *cobra.Command, cmdVerb session.Verb, key *ecdsa.PrivateKey, cnr cid.ID) (*session.Token, error) {
-	tok, err := getSessionV2(cmd)
-	if err != nil || tok == nil {
-		return tok, err
-	}
-
+func verifySessionV2(cmd *cobra.Command, tok *session.Token, cmdVerb session.Verb, key *ecdsa.PrivateKey, cnr cid.ID) error {
 	common.PrintVerbose(cmd, "Validating V2 session token...")
 
 	if err := tok.Validate(noopNNSResolver{}); err != nil {
-		return nil, fmt.Errorf("invalid V2 session token: %w", err)
+		return fmt.Errorf("invalid V2 session token: %w", err)
 	}
 
 	if !tok.AssertVerb(cmdVerb, cnr) {
-		return nil, fmt.Errorf("v2 session token does not authorize %v for container %s", cmdVerb, cnr)
+		return fmt.Errorf("v2 session token does not authorize %v for container %s", cmdVerb, cnr)
 	}
 
 	signer := user.NewAutoIDSigner(*key)
 	if tok.Issuer() != signer.UserID() {
-		return nil, fmt.Errorf("v2 session token issuer %v does not match provided key/wallet %s", tok.Issuer(), signer.UserID())
+		return fmt.Errorf("v2 session token issuer %v does not match provided key/wallet %s", tok.Issuer(), signer.UserID())
 	}
 
 	if err := icrypto.AuthenticateTokenV2(tok, nil); err != nil {
 		// CLI has no tool to verify N3 signature, so check is delegated to the server
 		var errScheme icrypto.ErrUnsupportedScheme
 		if !errors.As(err, &errScheme) || neofscrypto.Scheme(errScheme) != neofscrypto.N3 {
-			return nil, fmt.Errorf("verify session token signature: %w", err)
+			return fmt.Errorf("verify session token signature: %w", err)
 		}
 	}
 
 	common.PrintVerbose(cmd, "V2 session token validated successfully")
-	return tok, nil
+	return nil
 }
 
-func _readVerifiedSessionV2(cmd *cobra.Command, dst SessionPrm, key *ecdsa.PrivateKey, cnr cid.ID) error {
+func attachVerifiedSessionV2(cmd *cobra.Command, tok *session.Token, dst SessionPrm, key *ecdsa.PrivateKey, cnr cid.ID) error {
 	var cmdVerb session.Verb
 
 	switch dst.(type) {
@@ -88,8 +83,8 @@ func _readVerifiedSessionV2(cmd *cobra.Command, dst SessionPrm, key *ecdsa.Priva
 		cmdVerb = session.VerbObjectRangeHash
 	}
 
-	tok, err := getVerifiedSessionV2(cmd, cmdVerb, key, cnr)
-	if err != nil || tok == nil {
+	err := verifySessionV2(cmd, tok, cmdVerb, key, cnr)
+	if err != nil {
 		return err
 	}
 
@@ -99,24 +94,16 @@ func _readVerifiedSessionV2(cmd *cobra.Command, dst SessionPrm, key *ecdsa.Priva
 	return nil
 }
 
-func tryReadSessionV2(cmd *cobra.Command, dst SessionPrm, key *ecdsa.PrivateKey, cnr cid.ID) (bool, error) {
+func tryReadSessionV2(cmd *cobra.Command) *session.Token {
 	path, _ := cmd.Flags().GetString(commonflags.SessionToken)
 	if path == "" {
-		return false, nil
+		return nil
 	}
 
 	tok, err := getSessionV2(cmd)
 	if err != nil {
-		return false, nil
+		common.PrintVerbose(cmd, "Failed to read V2 session: %v", err)
+		return nil
 	}
-	if tok == nil {
-		return false, nil
-	}
-
-	err = _readVerifiedSessionV2(cmd, dst, key, cnr)
-	if err != nil {
-		return true, err
-	}
-
-	return true, nil
+	return tok
 }


### PR DESCRIPTION
https://rest.fs.neo.org/Aku38wpn2xEqfEPxmwyAa7N3VnAkMV8PEVkpLqwKM1z3/5201-1776711165/index.html#suites/fb2643933f3d9d19313b2e8b63c64bcd/c296519ce2c8b980/.