### PR TITLE
node: rework netmap cache into a ring buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog for NeoFS Node
 - `neofs-cli`, `neofs-node` do not allow searches based on homomorphic hash values (#3847)
 - Storage nodes do not calculate homomorphic hashes for objects (#3847)
 - Optimized GET/HEAD request forwarding (#3877)
+- Optimized netmap caching in node (#3966)
 
 ### Removed
 - `policer.max_workers` configuration (#3920)

--- a/cmd/neofs-node/cache.go
+++ b/cmd/neofs-node/cache.go
@@ -138,19 +138,19 @@ func (c *ttlNetCache[K, V]) reset() {
 
 // entity that provides LRU cache interface.
 type lruNetCache struct {
-	cache *lru.Cache[uint64, *netmapSDK.NetMap]
+	mtx     sync.RWMutex
+	netmaps []*netmapSDK.NetMap
+	size    int
 
 	netRdr netValueReader[uint64, *netmapSDK.NetMap]
 }
 
 // newNetworkLRUCache returns wrapper over netValueReader with LRU cache.
 func newNetworkLRUCache(sz int, netRdr netValueReader[uint64, *netmapSDK.NetMap]) *lruNetCache {
-	cache, err := lru.New[uint64, *netmapSDK.NetMap](sz)
-	fatalOnErr(err)
-
 	return &lruNetCache{
-		cache:  cache,
-		netRdr: netRdr,
+		netmaps: make([]*netmapSDK.NetMap, sz),
+		netRdr:  netRdr,
+		size:    sz,
 	}
 }
 
@@ -160,8 +160,13 @@ func newNetworkLRUCache(sz int, netRdr netValueReader[uint64, *netmapSDK.NetMap]
 //
 // returned value should not be modified.
 func (c *lruNetCache) get(key uint64) (*netmapSDK.NetMap, error) {
-	val, ok := c.cache.Get(key)
-	if ok {
+	var idx = int(key) % c.size
+
+	c.mtx.RLock()
+	var val = c.netmaps[idx]
+	c.mtx.RUnlock()
+
+	if val != nil && val.Epoch() == key {
 		return val, nil
 	}
 
@@ -172,14 +177,12 @@ func (c *lruNetCache) get(key uint64) (*netmapSDK.NetMap, error) {
 
 	if val != nil && len(val.Nodes()) != 0 {
 		// cache only non-empty netmap
-		c.cache.Add(key, val)
+		c.mtx.Lock()
+		c.netmaps[idx] = val
+		c.mtx.Unlock()
 	}
 
 	return val, nil
-}
-
-func (c *lruNetCache) reset() {
-	c.cache.Purge()
 }
 
 // wrapper over TTL cache of values read from the network
@@ -289,10 +292,6 @@ func (s *lruNetmapSource) getNetMapByEpoch(epoch uint64) (*netmapSDK.NetMap, err
 
 func (s *lruNetmapSource) Epoch() (uint64, error) {
 	return s.netState.CurrentEpoch(), nil
-}
-
-func (s *lruNetmapSource) reset() {
-	s.cache.reset()
 }
 
 // wrapper over TTL cache of values read from the network

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -188,9 +188,6 @@ func (s *shared) resetCaches() {
 	if s.containerListCache != nil {
 		s.containerListCache.reset()
 	}
-	if s.netmapCache != nil {
-		s.netmapCache.reset()
-	}
 }
 
 type cfg struct {


### PR DESCRIPTION
1. Netmaps never change and have no real TTL.
2. We usually request the latest or penultimate one.
3. Epochs change infrequently.
4. Old netmaps (>10) are unavailable from the contract.

So LRU cache (with tracking/locking) is not what we need here, a simple static ring buffer works fine.