### PR TITLE
network: write URIs into network map info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changelog for NeoFS Node
 - Optimized netmap caching in node (#3966)
 - Store in metabase associated object ID in bytes instead of Base58 (#3971)
 - Optimized local RANGE request execution (#3967)
+- SN pushes URI-style endpoints to netmap instead of multiaddr (#3982)
 
 ### Removed
 - `policer.max_workers` configuration (#3920)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for NeoFS Node
 
 ### Changed
 - SN requests network map only when it has been changed (#4121)
+- SN pushes URI-style endpoints to netmap instead of multiaddr (#3982)
 
 ### Removed
 
@@ -20,6 +21,10 @@ Changelog for NeoFS Node
 To change an FSTree layout depth, configure the new `blobstor.depth` and set
 `blobstor.allow_depth_change` to `true`, then restart the storage node. After
 the node logs that reshaping has completed, the flag can be removed.
+
+Network maps with 0.56.0 nodes can differ from previous ones because of
+address conversion from multiaddr. Multiaddr is still accepted by IR and SN,
+but this support will be removed in the next release.
 
 ## [0.56.0] - 2026-09-01 - Nabdo
 

--- a/pkg/network/group.go
+++ b/pkg/network/group.go
@@ -116,7 +116,7 @@ func WriteToNodeInfo(g AddressGroup, ni *netmap.NodeInfo) {
 
 	for addr := range slices.Values(g) {
 		ni.SetNetworkEndpoints()
-		addrs = append(addrs, addr.String())
+		addrs = append(addrs, addr.URIAddr())
 	}
 
 	ni.SetNetworkEndpoints(addrs...)

--- a/pkg/network/group.go
+++ b/pkg/network/group.go
@@ -126,7 +126,7 @@ func WriteToNodeInfo(g AddressGroup, ni *netmap.NodeInfo) {
 
 	for addr := range slices.Values(g) {
 		ni.SetNetworkEndpoints()
-		addrs = append(addrs, addr.String())
+		addrs = append(addrs, addr.URIAddr())
 	}
 
 	ni.SetNetworkEndpoints(addrs...)


### PR DESCRIPTION
Which allows to avoid parsing when using them. Blocked by #3981.