### PR TITLE
put: fix panic on local write failure log

### DIFF
--- a/pkg/services/object/put/distributed.go
+++ b/pkg/services/object/put/distributed.go
@@ -540,8 +540,7 @@ func (t *distributedTarget) distributeObjectWithMeta(obj object.Object, encObj e
 
 		err = t.writeObjectLocally(obj, encObj)
 		if err != nil {
-			err = fmt.Errorf("write object locally: %w", err)
-			svcutil.LogServiceError(l, "PUT", nil, err)
+			svcutil.LogServiceError(l, "PUT", slices.Values([]string{"local"}), err)
 		}
 	} else {
 		err = placementFn(obj, encObj)


### PR DESCRIPTION
Regression from 6d306486f3549c443003541d602745f340e61671:

    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf07580]

    goroutine 74173 [running]:
    slices.AppendSeq[...](...)
    	slices/iter.go:51
    slices.Collect[...](...)
    	slices/iter.go:60
    github.com/nspcc-dev/neofs-node/pkg/services/object/util.LogServiceError(0xc003438500, {0x13ea04f, 0x3}, 0x0, {0x1661c20, 0xc005871700})
    	github.com/nspcc-dev/neofs-node/pkg/services/object/util/log.go:13 +0x100
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*distributedTarget).distributeObjectWithMeta(_, {{0x69, 0xc7, 0xf4, 0x97, 0xe9, 0xf2, 0x44, 0xa4, 0x5, ...}, ...}, ...)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/distributed.go:544 +0x31a
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*distributedTarget).distributeObject(_, {{0x69, 0xc7, 0xf4, 0x97, 0xe9, 0xf2, 0x44, 0xa4, 0x5, ...}, ...}, ...)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/distributed.go:531 +0x1b2
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*distributedTarget).saveObject(_, {{0x69, 0xc7, 0xf4, 0x97, 0xe9, 0xf2, 0x44, 0xa4, 0x5, ...}, ...}, ...)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/distributed.go:182 +0x165
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*distributedTarget).Close(0xc000cba8c0)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/distributed.go:169 +0x307
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*validatingTarget).Close(0xc0035baa00?)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/validation.go:155 +0x93
    github.com/nspcc-dev/neofs-node/pkg/services/object/put.(*Streamer).Close(0xc001eb30e0)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/put/streamer.go:303 +0x4b
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*putStream).close(0x1661540?)
    	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:410 +0x4e
    github.com/nspcc-dev/neofs-node/pkg/services/object.(*Server).Put(0xc0000f2dd0, {0x167cad0, 0xc005482910})
    	github.com/nspcc-dev/neofs-node/pkg/services/object/server.go:441 +0x6fa
    github.com/nspcc-dev/neofs-sdk-go/proto/object._ObjectService_Put_Handler({0x13c2fc0?, 0xc0000f2dd0}, {0x16771f8, 0xc0035ba900})
    	github.com/nspcc-dev/neofs-sdk-go@v1.0.0-rc.18.0.20260417090255-d6b86c01a5af/proto/object/service_grpc.pb.go:725 +0xd8
    google.golang.org/grpc.(*Server).processStreamingRPC(0xc0003cbd48, {0x1672570, 0xc002e26390}, 0xc0018af1e0, 0xc00148c0c0, 0x215c5e0, 0x0)
    	google.golang.org/grpc@v1.79.3/server.go:1715 +0x1172
    google.golang.org/grpc.(*Server).handleStream(0xc0003cbd48, {0x1672fd8, 0xc0008b4b60}, 0xc0018af1e0)
    	google.golang.org/grpc@v1.79.3/server.go:1859 +0xb85
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
    	google.golang.org/grpc@v1.79.3/server.go:1064 +0x7f
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 386
    	google.golang.org/grpc@v1.79.3/server.go:1075 +0x11d