### PR TITLE
fstree: never copy to io.Discard unless dealing with compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for NeoFS Node
 ### Changed
 - Optimized EC GET request execution (#3996)
 - Optimized GET/HEAD/SEARCH request signing when forwarding by container node  (#4008)
+- Optimized ranged GET in FSTree (#4016)
 
 ### Removed
 

--- a/pkg/local_object_storage/blobstor/fstree/fstree.go
+++ b/pkg/local_object_storage/blobstor/fstree/fstree.go
@@ -579,7 +579,7 @@ func (t *FSTree) readPayloadRange(addr oid.Address, off, ln uint64, getHdrBuf fu
 	return pldLen, stream, nil
 }
 
-func (t *FSTree) shiftPayloadRangeStream(prefix []byte, pldLen uint64, pldFldOff int, stream io.ReadCloser, off, ln uint64) (io.ReadCloser, error) {
+func (t *FSTree) shiftPayloadRangeStream(prefix []byte, pldLen uint64, pldFldOff int, stream io.ReadSeekCloser, off, ln uint64) (io.ReadSeekCloser, error) {
 	if ln != 0 && (off >= pldLen || pldLen-off < ln) {
 		return nil, apistatus.ErrObjectOutOfRange
 	}
@@ -631,19 +631,16 @@ func (t *FSTree) shiftPayloadRangeStream(prefix []byte, pldLen uint64, pldFldOff
 	if off == 0 {
 		if ln == 0 { // full
 			if stream == nil {
-				return io.NopCloser(bytes.NewReader(prefix)), nil
+				return nopCloser(bytes.NewReader(prefix)), nil
 			}
 			if len(prefix) == 0 {
 				return stream, nil
 			}
-			return readerCloser{
-				Reader: io.MultiReader(bytes.NewReader(prefix), stream),
-				Closer: stream,
-			}, nil
+			return newPrefixedReadSeekCloser(prefix, stream), nil
 		}
 
 		if ln <= uint64(len(prefix)) {
-			return io.NopCloser(bytes.NewReader(prefix[:ln])), nil
+			return nopCloser(bytes.NewReader(prefix[:ln])), nil
 		}
 
 		// stream is non-nil here according to conditions above
@@ -656,15 +653,12 @@ func (t *FSTree) shiftPayloadRangeStream(prefix []byte, pldLen uint64, pldFldOff
 			return nil, err
 		}
 
-		return readerCloser{
-			Reader: io.LimitReader(io.MultiReader(bytes.NewReader(prefix), stream), int64(ln)),
-			Closer: stream,
-		}, nil
+		return newPrefixedReadSeekCloser(prefix, &limitedFileReader{ReadSeekCloser: stream, limit: int64(ln) - int64(len(prefix))}), nil
 	}
 
 	if stream == nil {
 		// range is within slice according to conditions above
-		return io.NopCloser(bytes.NewReader(prefix[off:][:ln])), nil
+		return nopCloser(bytes.NewReader(prefix[off:][:ln])), nil
 	}
 
 	if err := checkTooBigRange(off, ln); err != nil {
@@ -673,26 +667,16 @@ func (t *FSTree) shiftPayloadRangeStream(prefix []byte, pldLen uint64, pldFldOff
 
 	if off >= uint64(len(prefix)) {
 		if off > uint64(len(prefix)) {
-			var err error
-			if seeker, ok := stream.(io.Seeker); ok {
-				_, err = seeker.Seek(int64(off)-int64(len(prefix)), io.SeekCurrent)
-			} else {
-				_, err = io.CopyN(io.Discard, stream, int64(off)-int64(len(prefix)))
-			}
+			_, err := stream.Seek(int64(off)-int64(len(prefix)), io.SeekCurrent)
 			if err != nil {
 				return nil, fmt.Errorf("seek payload stream: %w", err)
 			}
 		}
-		return readerCloser{
-			Reader: io.LimitReader(stream, int64(ln)),
-			Closer: stream,
-		}, nil
+		return &limitedFileReader{ReadSeekCloser: stream, limit: int64(ln)}, nil
 	}
 
-	return readerCloser{
-		Reader: io.LimitReader(io.MultiReader(bytes.NewReader(prefix[off:]), stream), int64(ln)),
-		Closer: stream,
-	}, nil
+	prefix = prefix[off:]
+	return newPrefixedReadSeekCloser(prefix, &limitedFileReader{ReadSeekCloser: stream, limit: int64(ln) - int64(len(prefix))}), nil
 }
 
 // Type is fstree storage type used in logs and configuration.

--- a/pkg/local_object_storage/blobstor/fstree/head.go
+++ b/pkg/local_object_storage/blobstor/fstree/head.go
@@ -46,7 +46,7 @@ func (t *FSTree) ReadHeader(addr oid.Address, buf []byte) (int, error) {
 	return n, nil
 }
 
-func (t *FSTree) _readObject(addr oid.Address, buf []byte) ([]byte, io.ReadCloser, error) {
+func (t *FSTree) _readObject(addr oid.Address, buf []byte) ([]byte, io.ReadSeekCloser, error) {
 	if len(buf) < 2*objectwire.NonPayloadFieldsBufferLength {
 		return nil, nil, fmt.Errorf("too short buffer %d bytes", len(buf))
 	}
@@ -94,10 +94,7 @@ func (t *FSTree) ReadObject(addr oid.Address, buf []byte) (int, io.ReadCloser, e
 		// data was pre-read according to the provided buffer, but its
 		// uncompressed form does not fit the buffer, reslice it, and do not
 		// lose any payload
-		return n, readerCloser{
-			Reader: io.MultiReader(bytes.NewReader(initial[n:]), stream),
-			Closer: stream,
-		}, nil
+		return n, newPrefixedReadSeekCloser(initial[n:], stream), nil
 	}
 
 	return n, stream, nil
@@ -144,7 +141,7 @@ func (t *FSTree) extractHeaderAndStream(id oid.ID, f *os.File) (*object.Object, 
 	return t.readHeaderAndPayload(stream, initial)
 }
 
-func (t *FSTree) readHeader(id oid.ID, f *os.File, buf []byte) ([]byte, io.ReadCloser, error) {
+func (t *FSTree) readHeader(id oid.ID, f *os.File, buf []byte) ([]byte, io.ReadSeekCloser, error) {
 	n, err := io.ReadFull(f, buf[:objectwire.NonPayloadFieldsBufferLength])
 	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, f, err
@@ -172,15 +169,15 @@ func (t *FSTree) readHeader(id oid.ID, f *os.File, buf []byte) ([]byte, io.ReadC
 				}
 			}
 
-			f := io.ReadCloser(f)
+			rsc := io.ReadSeekCloser(f)
 			if buffered := uint32(size - offset); l > buffered {
-				f = struct {
-					io.Reader
-					io.Closer
-				}{Reader: io.LimitReader(f, int64(l-buffered)), Closer: f}
+				rsc = &limitedFileReader{
+					ReadSeekCloser: f,
+					limit:          int64(l - buffered),
+				}
 			}
 
-			return buf[offset:size], f, nil
+			return buf[offset:size], rsc, nil
 		}
 
 		offset += int(l)
@@ -214,7 +211,7 @@ func (t *FSTree) readHeader(id oid.ID, f *os.File, buf []byte) ([]byte, io.ReadC
 
 // readHeaderAndPayload reads an object header from the file and returns reader for payload.
 // This function takes ownership of the io.ReadCloser and will close it if it does not return it.
-func (t *FSTree) readHeaderAndPayload(f io.ReadCloser, initial []byte) (*object.Object, io.ReadSeekCloser, error) {
+func (t *FSTree) readHeaderAndPayload(f io.ReadSeekCloser, initial []byte) (*object.Object, io.ReadSeekCloser, error) {
 	initial, reader, err := t.preprocessStreamHead(f, initial)
 	if err != nil {
 		return nil, nil, err
@@ -231,10 +228,7 @@ func (t *FSTree) readHeaderAndPayload(f io.ReadCloser, initial []byte) (*object.
 
 		obj.SetPayload(nil)
 
-		return &obj, &payloadReader{
-			Reader: bytes.NewReader(pld),
-			close:  func() error { return nil },
-		}, nil
+		return &obj, nopCloser(bytes.NewReader(pld)), nil
 	}
 
 	obj, payloadPrefix, err := objectwire.ExtractHeaderAndPayload(initial)
@@ -243,13 +237,10 @@ func (t *FSTree) readHeaderAndPayload(f io.ReadCloser, initial []byte) (*object.
 		return nil, nil, fmt.Errorf("extract header and payload: %w", err)
 	}
 
-	return obj, &payloadReader{
-		Reader: io.MultiReader(bytes.NewReader(payloadPrefix), reader),
-		close:  reader.Close,
-	}, nil
+	return obj, newPrefixedReadSeekCloser(payloadPrefix, reader), nil
 }
 
-func (t *FSTree) preprocessStreamHead(f io.ReadCloser, initial []byte) ([]byte, io.ReadCloser, error) {
+func (t *FSTree) preprocessStreamHead(f io.ReadSeekCloser, initial []byte) ([]byte, io.ReadSeekCloser, error) {
 	var err error
 	if len(initial) < objectwire.NonPayloadFieldsBufferLength {
 		_ = f.Close()
@@ -267,9 +258,9 @@ func (t *FSTree) preprocessStreamHead(f io.ReadCloser, initial []byte) ([]byte, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("zstd decoder: %w", err)
 		}
-		reader = readerTwoClosers{
-			ReadCloser: decoder.IOReadCloser(),
-			baseCloser: f,
+		reader = compressedReader{
+			Decoder:    decoder,
+			fileCloser: f,
 		}
 
 		buf := make([]byte, objectwire.NonPayloadFieldsBufferLength)
@@ -284,25 +275,14 @@ func (t *FSTree) preprocessStreamHead(f io.ReadCloser, initial []byte) ([]byte, 
 	return initial, reader, nil
 }
 
-type payloadReader struct {
-	io.Reader
-	close func() error
+type nopCloserRS struct {
+	io.ReadSeeker
 }
 
-func (p *payloadReader) Close() error {
-	return p.close()
+func (n nopCloserRS) Close() error {
+	return nil
 }
 
-// Seek implements io.Seeker interface for payloadReader.
-// If the Reader does not support seeking, it will discard the data until the offset
-// is reached, but only if whence is io.SeekStart. If whence is not io.SeekStart,
-// it returns an error indicating that seeking is not supported.
-func (p *payloadReader) Seek(offset int64, whence int) (int64, error) {
-	if seeker, ok := p.Reader.(io.Seeker); ok {
-		return seeker.Seek(offset, whence)
-	}
-	if whence == io.SeekStart {
-		return io.CopyN(io.Discard, p.Reader, offset)
-	}
-	return 0, errors.New("payload reader does not support seeking")
+func nopCloser(rs io.ReadSeeker) io.ReadSeekCloser {
+	return nopCloserRS{ReadSeeker: rs}
 }

--- a/pkg/local_object_storage/blobstor/fstree/util.go
+++ b/pkg/local_object_storage/blobstor/fstree/util.go
@@ -1,28 +1,39 @@
 package fstree
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math"
+
+	"github.com/klauspost/compress/zstd"
 )
 
-type readerCloser struct {
-	io.Reader
-	io.Closer
-}
-type readerTwoClosers struct {
-	io.ReadCloser
-	baseCloser io.Closer
+type compressedReader struct {
+	*zstd.Decoder
+	fileCloser io.Closer
 }
 
-func (x readerTwoClosers) Close() error {
-	x.ReadCloser.Close()
-	return x.baseCloser.Close()
+func (x compressedReader) Close() error {
+	x.Decoder.Close()
+	return x.fileCloser.Close()
+}
+
+// Seek supports SeekCurrent and positive offsets only, allowing to skip some data.
+func (x compressedReader) Seek(offset int64, whence int) (int64, error) {
+	if whence != io.SeekCurrent || offset < 0 {
+		panic("wrong compressed reader seek")
+	}
+	_, err := io.CopyN(io.Discard, x.Decoder, offset)
+
+	return 0, err
 }
 
 type nopReadCloser struct{}
 
 func (nopReadCloser) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (nopReadCloser) Seek(int64, int) (int64, error) { return 0, io.EOF }
 
 func (nopReadCloser) Close() error { return nil }
 
@@ -31,4 +42,80 @@ func checkTooBigRange(off, ln uint64) error {
 		return fmt.Errorf("range overflowing int64 is not supported by this server: off=%d,len=%d", off, ln)
 	}
 	return nil
+}
+
+type prefixedReadSeekCloser struct {
+	prefix *bytes.Reader
+	rest   io.ReadSeekCloser
+}
+
+func newPrefixedReadSeekCloser(prefix []byte, f io.ReadSeekCloser) *prefixedReadSeekCloser {
+	return &prefixedReadSeekCloser{prefix: bytes.NewReader(prefix), rest: f}
+}
+
+func (p *prefixedReadSeekCloser) Read(b []byte) (int, error) {
+	var (
+		prefBytes = min(len(b), p.prefix.Len())
+		n         int
+	)
+
+	if prefBytes > 0 {
+		k, _ := p.prefix.Read(b[:prefBytes]) // io.EOF can't happen because of prefBytes and bytes.Reader can't have other errors.
+		n = k
+	}
+
+	k, err := p.rest.Read(b[prefBytes:])
+	n += k
+	return n, err
+}
+
+// Seek supports SeekCurrent and positive offsets only, allowing to skip some data.
+func (p *prefixedReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
+	if whence != io.SeekCurrent || offset < 0 {
+		panic("wrong prefixed reader seek")
+	}
+	var skipBytes = min(int64(p.prefix.Len()), offset)
+
+	_, err := p.prefix.Seek(skipBytes, whence)
+	if err != nil {
+		return 0, fmt.Errorf("seeking bytes: %w", err)
+	}
+
+	return p.rest.Seek(offset-skipBytes, whence)
+}
+
+func (p *prefixedReadSeekCloser) Close() error {
+	return p.rest.Close()
+}
+
+type limitedFileReader struct {
+	io.ReadSeekCloser
+	limit int64
+}
+
+func (l *limitedFileReader) Read(b []byte) (int, error) {
+	if l.limit <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(b)) > l.limit {
+		b = b[:int(l.limit)]
+	}
+	n, err := l.ReadSeekCloser.Read(b)
+	l.limit -= int64(n)
+	return n, err
+}
+
+// Seek supports SeekCurrent and positive offsets only, allowing to skip some data.
+func (l *limitedFileReader) Seek(offset int64, whence int) (int64, error) {
+	if whence != io.SeekCurrent || offset < 0 {
+		panic("wrong limited reader seek")
+	}
+	if offset > l.limit {
+		return 0, io.EOF
+	}
+	_, err := l.ReadSeekCloser.Seek(offset, whence)
+	if err == nil {
+		l.limit -= offset
+	}
+	return 0, err
 }


### PR DESCRIPTION
This suggests compression is harmful, so it better be dropped. But that's subject to some subsequent PR.