### PR TITLE
sn: Fix Control service start panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for NeoFS Node
 - Possibility to set eACL in the same RPC that creates new container (#4006)
 
 ### Fixed
+- SN panic on start without Control service (#4017)
 
 ### Changed
 - Optimized EC GET request execution (#3996)

--- a/cmd/neofs-node/main.go
+++ b/cmd/neofs-node/main.go
@@ -150,13 +150,15 @@ func initApp(c *cfg) {
 
 	c.workers = append(c.workers, newWorkerFromFunc(c.configWatcher))
 
-	c.control.MarkReady(
-		c.cfgObject.cfgLocalStorage.localStorage,
-		c.netMapSource,
-		c.cnrSrc,
-		c.replicator,
-		c,
-	)
+	if c.control != nil {
+		c.control.MarkReady(
+			c.cfgObject.cfgLocalStorage.localStorage,
+			c.netMapSource,
+			c.cnrSrc,
+			c.replicator,
+			c,
+		)
+	}
 }
 
 func runAndLog(c *cfg, name string, logSuccess bool, starter func(*cfg)) {


### PR DESCRIPTION
caught this case while testing SN locally w/o needs in Control service. Usually it's enabled