### PR TITLE
object/get: make internal payload-only GETs conditional on eACL recheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog for NeoFS Node
 - SN panic on start without Control service (#4017)
 - Incorrect protobuf scanning (#4013)
 - Data race in RANGE response buffer (#4013)
-- Incorrect access denial during EACL rechecks for payload-only GET (#4024)
+- Incorrect access denial during EACL rechecks for payload-only GET (#4024, #4029)
 
 ### Changed
 - Optimized EC GET request execution (#3996)

--- a/pkg/services/object/get/exec.go
+++ b/pkg/services/object/get/exec.go
@@ -75,6 +75,7 @@ type execCtx struct {
 	submitLocalRangeStreamFn SubmitDataStreamFunc
 
 	payloadOnly bool
+	recheckEACL bool
 	legacyRange bool
 
 	// collectOnly keeps one fetched stream and skips writing/assembly.
@@ -117,6 +118,12 @@ func withPayloadRange(r *object.Range) execOption {
 func withPayloadOnly(v bool) execOption {
 	return func(c *execCtx) {
 		c.payloadOnly = v
+	}
+}
+
+func withEACLRecheck(v bool) execOption {
+	return func(c *execCtx) {
+		c.recheckEACL = v
 	}
 }
 
@@ -354,6 +361,7 @@ func (exec *execCtx) copyChild(id oid.ID, rng *object.Range, withHdr bool) bool 
 	exec.statusError = exec.svc.get(exec.context(), p.commonPrm,
 		withPayloadRange(rng),
 		withPayloadOnly(exec.payloadOnly),
+		withEACLRecheck(exec.recheckEACL),
 		withLegacyRange(exec.legacyRange),
 		withLogger(log),
 	)

--- a/pkg/services/object/get/get.go
+++ b/pkg/services/object/get/get.go
@@ -49,7 +49,7 @@ func (s *Service) Get(ctx context.Context, prm Prm) error {
 	if prm.common.LocalOnly() &&
 		len(prm.container.PlacementPolicy().ECRules()) == 0 && // EC breaks TTL requirements currently.
 		len(prm.container.PlacementPolicy().Replicas()) != 0 {
-		opts := []execOption{withPayloadRange(prm.rng), withPayloadOnly(prm.payloadOnly)}
+		opts := []execOption{withPayloadRange(prm.rng), withPayloadOnly(prm.payloadOnly), withEACLRecheck(prm.recheckEACL)}
 		if prm.rng == nil && !prm.payloadOnly {
 			opts = append(opts, withLocalGetBuffer(prm.localGetBuffer, prm.submitLocalGetStreamFn))
 		}
@@ -71,6 +71,7 @@ func (s *Service) Get(ctx context.Context, prm Prm) error {
 			withPayloadRange(prm.rng),
 			withPayloadOnly(prm.payloadOnly),
 			withGetTransportFunc(prm.transportFn),
+			withEACLRecheck(prm.recheckEACL),
 		}
 		if prm.rng == nil && !prm.payloadOnly {
 			opts = append(opts, withLocalGetBuffer(prm.localGetBuffer, prm.submitLocalGetStreamFn))
@@ -88,7 +89,7 @@ func (s *Service) Get(ctx context.Context, prm Prm) error {
 		for i := range ecRules {
 			repRules[i] = uint(ecRules[i].DataPartNum + ecRules[i].ParityPartNum)
 		}
-		return s.get(ctx, prm.commonPrm, withPreSortedContainerNodes(ecNodeLists, repRules), withPayloadRange(prm.rng), withPayloadOnly(prm.payloadOnly)).err
+		return s.get(ctx, prm.commonPrm, withPreSortedContainerNodes(ecNodeLists, repRules), withPayloadRange(prm.rng), withPayloadOnly(prm.payloadOnly), withEACLRecheck(prm.recheckEACL)).err
 	}
 
 	if prm.rng != nil {

--- a/pkg/services/object/get/prm.go
+++ b/pkg/services/object/get/prm.go
@@ -27,6 +27,7 @@ type Prm struct {
 
 	rng         *object.Range
 	payloadOnly bool
+	recheckEACL bool
 
 	localGetBuffer         []byte
 	submitLocalGetStreamFn SubmitStreamFunc
@@ -127,6 +128,12 @@ func (p *Prm) SetRange(rng *object.Range) {
 // MarkPayloadOnly requests payload without an object header.
 func (p *Prm) MarkPayloadOnly() {
 	p.payloadOnly = true
+}
+
+// RequireEACLRecheck marks request as requiring object header on internal
+// full-GETs so eACL can be rechecked against header fields when needed.
+func (p *Prm) RequireEACLRecheck() {
+	p.recheckEACL = true
 }
 
 // SetChunkWriter sets target component to write the object payload range.

--- a/pkg/services/object/get/util.go
+++ b/pkg/services/object/get/util.go
@@ -369,6 +369,9 @@ func (c *clientWrapper) get(exec *execCtx, key *ecdsa.PrivateKey) (*object.Objec
 	if exec.isRaw() {
 		opts.MarkRaw()
 	}
+	if exec.payloadOnly && exec.ctxRange() == nil && !exec.recheckEACL {
+		opts.MarkPayloadOnly()
+	}
 
 	hdr, rdr, err := c.client.ObjectGetInit(exec.context(), addr.Container(), id, user.NewAutoIDSigner(*key), opts)
 	if err != nil {

--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -1218,6 +1218,9 @@ func convertGetPrm(signer ecdsa.PrivateKey, cnr container.Container, req *protoo
 	if body.GetPayloadOnly() {
 		p.MarkPayloadOnly()
 	}
+	if stream.recheckEACL {
+		p.RequireEACLRecheck()
+	}
 	if cp.LocalOnly() {
 		return p, nil
 	}


### PR DESCRIPTION
Closes #4028.