### PR TITLE
go.mod: upgrade SDK to fetch EACL improvement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/nspcc-dev/neo-go v0.120.0
 	github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea
 	github.com/nspcc-dev/neofs-contract v0.26.1
-	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260610124255-a2357941988d
+	github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260620083437-7b32188c31bc
 	github.com/nspcc-dev/tzhash v1.8.4
 	github.com/panjf2000/ants/v2 v2.11.5
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea h1:mK
 github.com/nspcc-dev/neofs-api-go/v2 v2.14.1-0.20240827150555-5ce597aa14ea/go.mod h1:YzhD4EZmC9Z/PNyd7ysC7WXgIgURc9uCG1UWDeV027Y=
 github.com/nspcc-dev/neofs-contract v0.26.1 h1:7Ii7Q4L3au408LOsIWKiSgfnT1g8G9jo3W7381d41T8=
 github.com/nspcc-dev/neofs-contract v0.26.1/go.mod h1:pevVF9OWdEN5bweKxOu6ryZv9muCEtS1ppzYM4RfBIo=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260610124255-a2357941988d h1:/cfZQeQ6XVLWSrT1eXY+d4xrkl+JqrguZNKY1AuoZdE=
-github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260610124255-a2357941988d/go.mod h1:KtAAolqjEdTNZ8T57FvpWsE/i9/Bpj6wuRPeUs/U85I=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260620083437-7b32188c31bc h1:ruGk2FkkSKYpQsvBbbcLBFiKff3C0A81dmHdxL5j8i8=
+github.com/nspcc-dev/neofs-sdk-go v1.0.0-rc.19.0.20260620083437-7b32188c31bc/go.mod h1:KtAAolqjEdTNZ8T57FvpWsE/i9/Bpj6wuRPeUs/U85I=
 github.com/nspcc-dev/rfc6979 v0.2.4 h1:NBgsdCjhLpEPJZqmC9rciMZDcSY297po2smeaRjw57k=
 github.com/nspcc-dev/rfc6979 v0.2.4/go.mod h1:86ylDw6Kss+P6v4QAJqo1Sp3mC0/Zr9G97xSjQ9TuFg=
 github.com/nspcc-dev/tzhash v1.8.4 h1:lvuPGWsqEo9dVEvo/kdNLKv/Cy0yxRs9z5hJp8VcBuo=

--- a/pkg/services/object/acl/acl.go
+++ b/pkg/services/object/acl/acl.go
@@ -195,13 +195,13 @@ func (c *Checker) CheckEACL(ctx context.Context, msg any, cnr cid.ID, obj oid.ID
 		vu.WithAccount(*sa)
 	}
 
-	action, matched, err := c.validator.CalculateAction(vu)
+	action, final, err := c.validator.CalculateAction(vu)
 
 	if err != nil {
 		return err
 	}
 
-	if !matched {
+	if !final {
 		return v2.ErrNotMatched
 	}
 

--- a/pkg/services/object/acl/eacl/v2/eacl_test.go
+++ b/pkg/services/object/acl/eacl/v2/eacl_test.go
@@ -133,7 +133,9 @@ func TestHeadRequest(t *testing.T) {
 
 	lStorage.err = errors.New("any error")
 
-	checkDefaultAction(t, validator, unit.WithHeaderSource(newSource(t)))
+	checkNonFinalAction(t, validator, unit.WithHeaderSource(newSource(t)))
+
+	lStorage.err = nil
 
 	r.SetAction(eacl.ActionAllow)
 
@@ -147,20 +149,27 @@ func TestHeadRequest(t *testing.T) {
 	table = eacl.ConstructTable([]eacl.Record{r, rID})
 
 	unit.WithEACLTable(&table)
-	checkDefaultAction(t, validator, unit.WithHeaderSource(newSource(t)))
+	checkAction(t, eacl.ActionDeny, validator, unit.WithHeaderSource(newSource(t)))
 }
 
 func checkAction(t *testing.T, expected eacl.Action, v *eacl.Validator, u *eacl.ValidationUnit) {
-	actual, fromRule, err := v.CalculateAction(u)
+	actual, final, err := v.CalculateAction(u)
 	require.NoError(t, err)
-	require.True(t, fromRule)
+	require.True(t, final)
 	require.Equal(t, expected, actual)
 }
 
 func checkDefaultAction(t *testing.T, v *eacl.Validator, u *eacl.ValidationUnit) {
-	actual, fromRule, err := v.CalculateAction(u)
+	actual, final, err := v.CalculateAction(u)
 	require.NoError(t, err)
-	require.False(t, fromRule)
+	require.True(t, final)
+	require.Equal(t, eacl.ActionAllow, actual)
+}
+
+func checkNonFinalAction(t *testing.T, v *eacl.Validator, u *eacl.ValidationUnit) {
+	actual, final, err := v.CalculateAction(u)
+	require.NoError(t, err)
+	require.False(t, final)
 	require.Equal(t, eacl.ActionAllow, actual)
 }
 


### PR DESCRIPTION
Follow https://github.com/nspcc-dev/neofs-sdk-go/pull/814, fix the test.