### PR TITLE
node: use a single node-to-node connection for everything

### DIFF
--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -155,10 +155,8 @@ type shared struct {
 	privateTokenStore sessionStorage
 	persistate        *state.PersistentStorage
 
-	clientCache    *cache.Clients
-	bgClientCache  *cache.Clients
-	putClientCache *cache.Clients
-	localAddr      network.AddressGroup
+	clientCache *cache.Clients
+	localAddr   network.AddressGroup
 
 	ownerIDFromKey user.ID // user ID calculated from key
 
@@ -425,9 +423,7 @@ func initCfg(appCfg *config.Config) *cfg {
 	c.shared = shared{
 		basics:            basicSharedConfig,
 		localAddr:         netAddr,
-		clientCache:       newClientCache("read"),
-		bgClientCache:     newClientCache("background"),
-		putClientCache:    newClientCache("put"),
+		clientCache:       newClientCache(""),
 		persistate:        persistate,
 		privateTokenStore: persistate,
 	}
@@ -464,9 +460,7 @@ func initCfg(appCfg *config.Config) *cfg {
 
 	c.veryLastClosers = make(map[string]func())
 
-	c.onShutdown(c.clientCache.CloseAll)    // clean up connections
-	c.onShutdown(c.bgClientCache.CloseAll)  // clean up connections
-	c.onShutdown(c.putClientCache.CloseAll) // clean up connections
+	c.onShutdown(c.clientCache.CloseAll) // clean up connections
 	c.onShutdown(func() { _ = c.persistate.Close() })
 
 	initPaymentChecker(c)

--- a/cmd/neofs-node/netmap.go
+++ b/cmd/neofs-node/netmap.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/nspcc-dev/neofs-node/pkg/morph/event"
 	netmapEvent "github.com/nspcc-dev/neofs-node/pkg/morph/event/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/network"
-	"github.com/nspcc-dev/neofs-node/pkg/network/cache"
 	"github.com/nspcc-dev/neofs-node/pkg/services/control"
 	netmapService "github.com/nspcc-dev/neofs-node/pkg/services/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
@@ -236,14 +234,9 @@ func initNetmapService(c *cfg) {
 
 		nodes := nm.Nodes()
 		local := slices.IndexFunc(nodes, func(node netmap.NodeInfo) bool { return c.IsLocalKey(node.PublicKey()) })
-		var wg sync.WaitGroup
+
 		l.Info("syncing SN connection caches with the new network map...")
-		for _, cl := range []*cache.Clients{c.clientCache, c.putClientCache, c.bgClientCache} {
-			wg.Go(func() {
-				cl.SyncWithNewNetmap(c.ctx, nodes, local)
-			})
-		}
-		wg.Wait()
+		c.clientCache.SyncWithNewNetmap(c.ctx, nodes, local)
 		l.Info("finished syncing SN connection caches with the new network map")
 	})
 }

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -187,12 +187,12 @@ func initObjectService(c *cfg) {
 	ls := c.cfgObject.cfgLocalStorage.localStorage
 	keyStorage := util.NewKeyStorage(&c.key.PrivateKey, c.privateTokenStore, c.cfgNetmap.state)
 
-	clientConstructor := &reputationClientConstructor{
+	repClientConstructor := &reputationClientConstructor{
 		log:              c.log,
 		nmSrc:            c.netMapSource,
 		netState:         c.cfgNetmap.state,
 		trustStorage:     c.cfgReputation.localTrustStorage,
-		basicConstructor: c.bgClientCache,
+		basicConstructor: c.clientCache,
 	}
 
 	coreConstructor := &coreClientConstructor{
@@ -201,14 +201,6 @@ func initObjectService(c *cfg) {
 		netState:         c.cfgNetmap.state,
 		trustStorage:     c.cfgReputation.localTrustStorage,
 		basicConstructor: c.clientCache,
-	}
-
-	putConstructor := &coreClientConstructor{
-		log:              c.log,
-		nmSrc:            c.netMapSource,
-		netState:         c.cfgNetmap.state,
-		trustStorage:     c.cfgReputation.localTrustStorage,
-		basicConstructor: c.putClientCache,
 	}
 
 	irFetcher := &innerRingFetcherWithNotary{
@@ -223,7 +215,7 @@ func initObjectService(c *cfg) {
 		),
 		replicator.WithLocalStorage(ls),
 		replicator.WithRemoteSender(
-			putsvc.NewRemoteSender(keyStorage, (*coreClientConstructor)(clientConstructor)),
+			putsvc.NewRemoteSender(keyStorage, (*coreClientConstructor)(repClientConstructor)),
 		),
 		replicator.WithLocalNodeKey(c),
 	)
@@ -233,7 +225,7 @@ func initObjectService(c *cfg) {
 		policer.WithLocalStorage(ls),
 		policer.WithMetrics(c),
 		policer.WithRemoteHeader(
-			headsvc.NewRemoteHeader(keyStorage, clientConstructor),
+			headsvc.NewRemoteHeader(keyStorage, repClientConstructor),
 		),
 		policer.WithHeadTimeout(c.appCfg.Policer.HeadTimeout),
 		policer.WithReplicator(c.replicator),
@@ -262,11 +254,11 @@ func initObjectService(c *cfg) {
 	c.cfgObject.placement = placementSvc
 
 	os := &objectSource{signer: neofsecdsa.SignerRFC6979(c.key.PrivateKey), get: sGet}
-	sPut := putsvc.NewService(&transport{clients: putConstructor}, c, c.metaService,
+	sPut := putsvc.NewService(&transport{clients: coreConstructor}, c, c.metaService,
 		initQuotas(c.cCli, c.cfgObject.quotasTTL),
 		c.containerPayments,
 		putsvc.WithKeyStorage(keyStorage),
-		putsvc.WithClientConstructor(putConstructor),
+		putsvc.WithClientConstructor(coreConstructor),
 		putsvc.WithContainerClient(c.cCli),
 		putsvc.WithMaxSizeSource(newCachedMaxObjectSizeSource(c.MaxObjectSize)),
 		putsvc.WithObjectStorage(ls),

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -96,7 +96,7 @@ func initReputationService(c *cfg) {
 		common.RemoteProviderPrm{
 			NetmapKeys:      c,
 			DeadEndProvider: daughterStorageWriterProvider,
-			ClientCache:     c.bgClientCache,
+			ClientCache:     c.clientCache,
 			WriterProvider: localreputation.NewRemoteProvider(
 				localreputation.RemoteProviderPrm{
 					Key: &c.key.PrivateKey,
@@ -111,7 +111,7 @@ func initReputationService(c *cfg) {
 		common.RemoteProviderPrm{
 			NetmapKeys:      c,
 			DeadEndProvider: consumerStorageWriterProvider,
-			ClientCache:     c.bgClientCache,
+			ClientCache:     c.clientCache,
 			WriterProvider: intermediatereputation.NewRemoteProvider(
 				intermediatereputation.RemoteProviderPrm{
 					Key: &c.key.PrivateKey,


### PR DESCRIPTION
Effectively reverts 597ed182694125cb62c9e515f58291416bac2b03 and dea97133d68a281e71536d49e5a7611dbd8a5794, mentioned problems either were solved some time ago in a different manner or were incorrectly interpreted in the first place. Currently we're all HTTP/2 with GRPC, this should be leveraged.