### PR TITLE
sn: fix session v2 tokens for container+eACL RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for NeoFS Node
 ### Added
 
 ### Fixed
+- Session v2 token was not supported in the new container + eACL RPC (#4056)
 
 ### Changed
 

--- a/pkg/services/container/server.go
+++ b/pkg/services/container/server.go
@@ -500,7 +500,7 @@ func (s *Server) Put(ctx context.Context, req *protocontainer.PutRequest) (*prot
 			return s.makeFailedPutResponse(fmt.Errorf("eACL table's container ID does not correspond to container"), req)
 		}
 
-		_, _, err = s.getVerifiedSessionTokenV2FromMetaHeader(req.GetMetaHeader(), sessionv2.VerbContainerSetEACL, cnrID)
+		_, _, err = s.getVerifiedSessionTokenV2FromMetaHeader(req.GetMetaHeader(), sessionv2.VerbContainerSetEACL, cid.ID{})
 		if err != nil {
 			return s.makeFailedPutResponse(fmt.Errorf("verify session token v2: %w", err), req)
 		}


### PR DESCRIPTION
Fix's reasoning: simple, clear for review, not a magic one, AND it only skips `checkSessionIssuer` which is the only container owner check inside. Session v2 cannot be issued with different original issuers for container creation and eacl setting, and (in practice) should always have a wildcard container. It is still possible to find strange cases when a token was reissued (has a chain) with a more narrow context, and setEacl is impossible by the last part of token's chain; when container creation was issued for _a certain container ID_, and there is no setEacl for this container ID; but these are not practical cases.
@roman-khimov, @End-rey