### PR TITLE
netmap: drop unused InnerRingList method definition

### DIFF
--- a/pkg/morph/client/netmap/client.go
+++ b/pkg/morph/client/netmap/client.go
@@ -30,7 +30,6 @@ const (
 	lastEpochBlockMethod   = "lastEpochBlock"
 	epochBlockMethod       = "getEpochBlock"
 	epochBlockByTimeMethod = "getEpochBlockByTime"
-	innerRingListMethod    = "innerRingList"
 	newEpochMethod         = "newEpoch"
 	setConfigMethod        = "setConfig"
 	updateInnerRingMethod  = "updateInnerRing"


### PR DESCRIPTION
Unused since f33e949468ca310dc2f67e9c8470128cb6a66f51, this method is obsolete in contracts.