### PR TITLE
sn: do not respond with epoch in metaheader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog for NeoFS Node
 - RANGE requests now using the same forwarding scheme as GET (#4103)
 - PUT request forwarding no longer mangles meta headers (#4103)
 - SN spends less memory to handle range-only EC GET requests (#4102)
+- SN does not respond with server's epoch in response meta header (#4072)
 
 ### Removed
 - Compression support from FSTree (#4054)

--- a/cmd/neofs-node/accounting.go
+++ b/cmd/neofs-node/accounting.go
@@ -11,7 +11,7 @@ func initAccountingService(c *cfg) {
 		initMorphComponents(c)
 	}
 
-	server := accountingService.New(&c.key.PrivateKey, c.networkState, c.bCli)
+	server := accountingService.New(&c.key.PrivateKey, c.bCli)
 
 	c.cfgGRPC.registerService(func(srv *grpc.Server) {
 		protoaccounting.RegisterAccountingServiceServer(srv, server)

--- a/cmd/neofs-node/reputation.go
+++ b/cmd/neofs-node/reputation.go
@@ -259,7 +259,6 @@ type reputationServer struct {
 func (s *reputationServer) makeResponseMetaHeader(st *protostatus.Status) *protosession.ResponseMetaHeader {
 	return &protosession.ResponseMetaHeader{
 		Version: version.Current().ProtoMessage(),
-		Epoch:   s.networkState.CurrentEpoch(),
 		Status:  st,
 	}
 }

--- a/cmd/neofs-node/session.go
+++ b/cmd/neofs-node/session.go
@@ -25,7 +25,7 @@ func initSessionService(c *cfg) {
 		c.privateTokenStore.RemoveOldTokens(ev.(netmap.NewEpoch).EpochNumber())
 	})
 
-	server := sessionSvc.New(&c.key.PrivateKey, c, c.privateTokenStore)
+	server := sessionSvc.New(&c.key.PrivateKey, c.privateTokenStore)
 
 	c.cfgGRPC.registerService(func(srv *grpc.Server) {
 		protosession.RegisterSessionServiceServer(srv, server)

--- a/pkg/services/accounting/server.go
+++ b/pkg/services/accounting/server.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	icrypto "github.com/nspcc-dev/neofs-node/internal/crypto"
-	netmapcore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/services/util"
 	protoaccounting "github.com/nspcc-dev/neofs-sdk-go/proto/accounting"
 	protosession "github.com/nspcc-dev/neofs-sdk-go/proto/session"
@@ -29,7 +28,6 @@ type BalanceContract interface {
 type server struct {
 	protoaccounting.UnimplementedAccountingServiceServer
 	signer   *ecdsa.PrivateKey
-	net      netmapcore.State
 	contract BalanceContract
 }
 
@@ -38,10 +36,9 @@ type server struct {
 //
 // All response messages are signed using specified signer and have current
 // epoch in the meta header.
-func New(s *ecdsa.PrivateKey, net netmapcore.State, c BalanceContract) protoaccounting.AccountingServiceServer {
+func New(s *ecdsa.PrivateKey, c BalanceContract) protoaccounting.AccountingServiceServer {
 	return &server{
 		signer:   s,
-		net:      net,
 		contract: c,
 	}
 }
@@ -51,7 +48,6 @@ func (s *server) makeBalanceResponse(body *protoaccounting.BalanceResponse_Body,
 		Body: body,
 		MetaHeader: &protosession.ResponseMetaHeader{
 			Version: version.Current().ProtoMessage(),
-			Epoch:   s.net.CurrentEpoch(),
 			Status:  st,
 		},
 	}

--- a/pkg/services/container/server.go
+++ b/pkg/services/container/server.go
@@ -158,7 +158,6 @@ func New(s *ecdsa.PrivateKey, net netmapcore.State, fsChain FSChain, c Contract,
 func (s *Server) makeResponseMetaHeader(st *protostatus.Status) *protosession.ResponseMetaHeader {
 	return &protosession.ResponseMetaHeader{
 		Version: version.Current().ProtoMessage(),
-		Epoch:   s.net.CurrentEpoch(),
 		Status:  st,
 	}
 }

--- a/pkg/services/container/server_test.go
+++ b/pkg/services/container/server_test.go
@@ -514,7 +514,6 @@ func TestServer_SetExtendedACL_InvalidRequest(t *testing.T) {
 		require.True(t, proto.Equal(resp, &protocontainer.SetExtendedACLResponse{
 			MetaHeader: &protosession.ResponseMetaHeader{
 				Version: version.Current().ProtoMessage(),
-				Epoch:   currentEpoch,
 				Status: &protostatus.Status{
 					Code:    1024,
 					Message: "missing container ID in eACL table",
@@ -587,7 +586,6 @@ func TestService_SetExtendedACL_SessionIssuer(t *testing.T) {
 		require.True(t, proto.Equal(resp, &protocontainer.SetExtendedACLResponse{
 			MetaHeader: &protosession.ResponseMetaHeader{
 				Version: version.Current().ProtoMessage(),
-				Epoch:   currentEpoch,
 				Status:  st,
 			},
 		}), resp.GetMetaHeader().GetStatus())
@@ -675,7 +673,6 @@ func TestService_Delete_SessionIssuer(t *testing.T) {
 		require.True(t, proto.Equal(resp, &protocontainer.DeleteResponse{
 			MetaHeader: &protosession.ResponseMetaHeader{
 				Version: version.Current().ProtoMessage(),
-				Epoch:   currentEpoch,
 				Status:  st,
 			},
 		}), resp.GetMetaHeader().GetStatus())

--- a/pkg/services/netmap/server.go
+++ b/pkg/services/netmap/server.go
@@ -52,7 +52,6 @@ func currentProtoVersion() *refs.Version {
 func (s *server) makeResponseMetaHeader(st *protostatus.Status) *protosession.ResponseMetaHeader {
 	return &protosession.ResponseMetaHeader{
 		Version: currentProtoVersion(),
-		Epoch:   s.contract.CurrentEpoch(),
 		Status:  st,
 	}
 }

--- a/pkg/services/object/head_test.go
+++ b/pkg/services/object/head_test.go
@@ -10,7 +10,6 @@ import (
 	iec "github.com/nspcc-dev/neofs-node/internal/ec"
 	"github.com/nspcc-dev/neofs-node/internal/testutil"
 	clientcore "github.com/nspcc-dev/neofs-node/pkg/core/client"
-	netmapcore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	. "github.com/nspcc-dev/neofs-node/pkg/services/object"
 	getsvc "github.com/nspcc-dev/neofs-node/pkg/services/object/get"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/util"
@@ -62,7 +61,7 @@ func TestServer_Head_Local(t *testing.T) {
 
 	assertWithVersion := func(t *testing.T, ver version.Version) *protoobject.HeadResponse {
 		req := newLocalHeadRequest(t, ver, obj.Address(), signer)
-		return assertHeadRequestOK(t, srv, fsChain, req, *obj, false)
+		return assertHeadRequestOK(t, srv, req, *obj, false)
 	}
 
 	t.Run("EC part", func(t *testing.T) {
@@ -89,7 +88,7 @@ func TestServer_Head_Local(t *testing.T) {
 		req.MetaHeader.Ttl = 2 // to show it has no effect w/ EC X-headers
 		signHeadRequest(t, req, signer)
 
-		assertHeadRequestOK(t, srv, fsChain, req, partHdr, true)
+		assertHeadRequestOK(t, srv, req, partHdr, true)
 
 		handlerFSChain.ecRules = nil
 	})
@@ -165,7 +164,7 @@ func TestServer_Head_Remote(t *testing.T) {
 		req.MetaHeader.Ttl = 2
 		signHeadRequest(t, req, signer)
 
-		assertHeadRequestOK(t, srv, fsChain, req, *obj.CutPayload(), false)
+		assertHeadRequestOK(t, srv, req, *obj.CutPayload(), false)
 	})
 
 	t.Run("REP forwarded", func(t *testing.T) {
@@ -333,13 +332,12 @@ func callHead(t *testing.T, srv *Server, req *protoobject.HeadRequest) (*protoob
 	return protoobject.NewObjectServiceClient(c).Head(context.Background(), req)
 }
 
-func assertHeadRequestOK(t *testing.T, srv *Server, fsChain netmapcore.State, req *protoobject.HeadRequest, expObj object.Object, unsignedObject bool) *protoobject.HeadResponse {
+func assertHeadRequestOK(t *testing.T, srv *Server, req *protoobject.HeadRequest, expObj object.Object, unsignedObject bool) *protoobject.HeadResponse {
 	resp, err := callHead(t, srv, req)
 	require.NoError(t, err)
 
 	require.Equal(t, &protosession.ResponseMetaHeader{
 		Version: version.Current().ProtoMessage(),
-		Epoch:   fsChain.CurrentEpoch(),
 		Status:  nil, // for clarity
 	}, resp.MetaHeader)
 

--- a/pkg/services/object/proto.go
+++ b/pkg/services/object/proto.go
@@ -127,24 +127,12 @@ func (s *Server) signResponse(buf, body, metaHdr []byte) (int, error) {
 }
 
 func (s *Server) writeMetaHeaderToResponseBuffer(buf []byte) (int, int) {
-	epoch := s.fsChain.CurrentEpoch()
-
 	ln := len(currentVersionResponseMetaHeader)
-	if epoch > 0 {
-		ln += 1 + protowire.SizeVarint(epoch)
-	}
 
 	buf[0] = iprotobuf.TagBytes2
 	off := 1 + binary.PutUvarint(buf[1:], uint64(ln))
-
 	valOff := off
-
 	off += copy(buf[off:], currentVersionResponseMetaHeader)
-
-	if epoch > 0 {
-		buf[off] = iprotobuf.TagVarint2
-		off += 1 + binary.PutUvarint(buf[off+1:], epoch)
-	}
 
 	return valOff, off
 }

--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -249,7 +249,6 @@ func newCurrentProtoVersionMessage() *refs.Version {
 func (s *Server) makeResponseMetaHeader(st *protostatus.Status) *protosession.ResponseMetaHeader {
 	return &protosession.ResponseMetaHeader{
 		Version: newCurrentProtoVersionMessage(),
-		Epoch:   s.fsChain.CurrentEpoch(),
 		Status:  st,
 	}
 }

--- a/pkg/services/session/server.go
+++ b/pkg/services/session/server.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	icrypto "github.com/nspcc-dev/neofs-node/internal/crypto"
-	netmapcore "github.com/nspcc-dev/neofs-node/pkg/core/netmap"
 	"github.com/nspcc-dev/neofs-node/pkg/services/util"
 	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
 	neofsecdsa "github.com/nspcc-dev/neofs-sdk-go/crypto/ecdsa"
@@ -30,7 +29,6 @@ type KeyStorage interface {
 type server struct {
 	protosession.UnimplementedSessionServiceServer
 	signer *ecdsa.PrivateKey
-	net    netmapcore.State
 	keys   KeyStorage
 }
 
@@ -38,10 +36,9 @@ type server struct {
 //
 // All response messages are signed using specified signer and have current
 // epoch in the meta header.
-func New(s *ecdsa.PrivateKey, net netmapcore.State, ks KeyStorage) protosession.SessionServiceServer {
+func New(s *ecdsa.PrivateKey, ks KeyStorage) protosession.SessionServiceServer {
 	return &server{
 		signer: s,
-		net:    net,
 		keys:   ks,
 	}
 }
@@ -51,7 +48,6 @@ func (s *server) makeCreateResponse(body *protosession.CreateResponse_Body, st *
 		Body: body,
 		MetaHeader: &protosession.ResponseMetaHeader{
 			Version: version.Current().ProtoMessage(),
-			Epoch:   s.net.CurrentEpoch(),
 			Status:  st,
 		},
 	}


### PR DESCRIPTION
<s>This affects only
1. any REP objects;
2. EC parts;
3. EC full object with RANGE.
This does not affect case implemented in #3996 (Get service's Prm with `WithECTransport()` called). Refs #4071.</s>