### PR TITLE
sidechain: change pooling time to 1s

### DIFF
--- a/pkg/innerring/internal/blockchain/blockchain.go
+++ b/pkg/innerring/internal/blockchain/blockchain.go
@@ -359,7 +359,7 @@ func (x *Blockchain) Run(ctx context.Context) (err error) {
 	go x.netServer.Start()
 
 	// await synchronization with the network
-	t := time.NewTicker(x.core.GetConfig().TimePerBlock)
+	t := time.NewTicker(time.Second)
 
 	for {
 		x.logger.Info("waiting for synchronization with the blockchain network...")

--- a/pkg/services/sidechain/sidechain.go
+++ b/pkg/services/sidechain/sidechain.go
@@ -110,7 +110,7 @@ func (s *SideChain) Run(ctx context.Context) error {
 	go s.core.Run()
 	go s.netServer.Start()
 
-	t := time.NewTicker(s.core.GetConfig().Genesis.TimePerBlock)
+	t := time.NewTicker(time.Second)
 
 	for {
 		s.logger.Info("waiting for synchronization with the blockchain network...")


### PR DESCRIPTION
In most cases meta chain will see fractions of seconds as a config, that is too small period that make logs full of:
```
info blockchain/blockchain.go:365 waiting for synchronization with the blockchain network... {"component": "metadata chain (IR)"}
info sidechain/sidechain.go:116 waiting for synchronization with the blockchain network... {"component": "metadata chain (SN)"}
```