### PR TITLE
node: skip TTL=1 request signatures over inter-node mTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for NeoFS Node
 - SN no longer adds origin signature to EC requests sent to remote nodes with API >= v2.25 (#4118)
 - SN now allocates less to handle ranged GET requests (#4115)
 - SN responds with server's API version only if it is older than client (#4110)
+- SNs no longer sign TTL=1 requests over mutually authenticated inter-node connections (#4100)
 
 ### Removed
 - Session token storage migration (#4124)

--- a/cmd/neofs-node/config.go
+++ b/cmd/neofs-node/config.go
@@ -406,7 +406,12 @@ func initCfg(appCfg *config.Config) *cfg {
 	minConnTimeout := appCfg.APIClient.MinConnectionTime
 	pingInterval := appCfg.APIClient.PingInterval
 	pingTimeout := appCfg.APIClient.PingTimeout
-	getClientCertificate := clientCertificateProvider(appCfg.GRPC)
+	getClientCertificate := clientCertificateProvider(appCfg.GRPC, key.PublicKey().Bytes())
+	// Validate the certificate before serving requests so that it is trusted by peer SNs.
+	if getClientCertificate != nil {
+		_, err = getClientCertificate(nil)
+		fatalOnErr(err)
+	}
 	newClientCache := func(scope string) *cache.Clients {
 		return cache.NewClients(c.log.With(zap.String("scope", scope)), &buffers, streamTimeout,
 			minConnTimeout, pingInterval, pingTimeout, neofsecdsa.Signer(key.PrivateKey), getClientCertificate)

--- a/cmd/neofs-node/grpc.go
+++ b/cmd/neofs-node/grpc.go
@@ -19,7 +19,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/netutil"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
 )
@@ -196,7 +195,7 @@ func buildSingleGRPCServer(c *cfg, sc grpcconfig.GRPC, maxRecvMsgSizeOpt grpc.Se
 		}
 
 		// read certificate from disk on each handshake to pick up renewals automatically.
-		creds := credentials.NewTLS(&tls.Config{
+		creds := trustedPeerTLSCredentials(&tls.Config{
 			GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
 				cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 				if err != nil {

--- a/cmd/neofs-node/mtls.go
+++ b/cmd/neofs-node/mtls.go
@@ -1,13 +1,47 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"net"
 
 	grpcconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/grpc"
+	"github.com/nspcc-dev/neofs-node/pkg/network/peerauth"
+	"google.golang.org/grpc/credentials"
 )
 
-func clientCertificateProvider(cfgs []grpcconfig.GRPC) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+type trustedPeerCredentials struct {
+	credentials.TransportCredentials
+}
+
+func trustedPeerTLSCredentials(config *tls.Config) credentials.TransportCredentials {
+	return trustedPeerCredentials{TransportCredentials: credentials.NewTLS(config)}
+}
+
+func (x trustedPeerCredentials) Clone() credentials.TransportCredentials {
+	return trustedPeerCredentials{TransportCredentials: x.TransportCredentials.Clone()}
+}
+
+func (x trustedPeerCredentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, authInfo, err := x.TransportCredentials.ServerHandshake(conn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tlsInfo, ok := authInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.PeerCertificates) == 0 {
+		return conn, authInfo, nil
+	}
+	trustedInfo, err := peerauth.NewAuthInfo(tlsInfo)
+	if err != nil {
+		return conn, authInfo, nil
+	}
+	return conn, trustedInfo, nil
+}
+
+func clientCertificateProvider(cfgs []grpcconfig.GRPC, expectedPublicKey []byte) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 	for i := range cfgs {
 		if !cfgs[i].TLS.Enabled {
 			continue
@@ -19,9 +53,23 @@ func clientCertificateProvider(cfgs []grpcconfig.GRPC) func(*tls.CertificateRequ
 			if err != nil {
 				return nil, fmt.Errorf("reload TLS client certificate: %w", err)
 			}
+			if err := verifyTLSCertificatePublicKey(&cert, expectedPublicKey); err != nil {
+				return nil, err
+			}
 			return &cert, nil
 		}
 	}
 
+	return nil
+}
+
+func verifyTLSCertificatePublicKey(cert *tls.Certificate, expected []byte) error {
+	pub, err := peerauth.CertificatePublicKeyFromRaw(cert.Certificate)
+	if err != nil {
+		return fmt.Errorf("parse TLS client certificate public key: %w", err)
+	}
+	if !bytes.Equal(pub, expected) {
+		return errors.New("TLS client certificate public key differs from node public key")
+	}
 	return nil
 }

--- a/cmd/neofs-node/mtls_test.go
+++ b/cmd/neofs-node/mtls_test.go
@@ -1,14 +1,25 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	grpcconfig "github.com/nspcc-dev/neofs-node/cmd/neofs-node/config/grpc"
+	"github.com/nspcc-dev/neofs-node/pkg/network/peerauth"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
 )
 
 func TestClientCertificateProvider(t *testing.T) {
-	require.Nil(t, clientCertificateProvider(nil))
+	require.Nil(t, clientCertificateProvider(nil, nil))
 
 	provider := clientCertificateProvider([]grpcconfig.GRPC{{
 		TLS: grpcconfig.TLS{
@@ -16,7 +27,7 @@ func TestClientCertificateProvider(t *testing.T) {
 			Certificate: "missing-certificate",
 			Key:         "missing-key",
 		},
-	}})
+	}}, nil)
 	require.NotNil(t, provider)
 	_, err := provider(nil)
 	require.ErrorContains(t, err, "reload TLS client certificate")
@@ -24,7 +35,71 @@ func TestClientCertificateProvider(t *testing.T) {
 	provider = clientCertificateProvider([]grpcconfig.GRPC{
 		{TLS: grpcconfig.TLS{Enabled: false, Certificate: "ignored-certificate", Key: "ignored-key"}},
 		{TLS: grpcconfig.TLS{Enabled: true, Certificate: "client-certificate", Key: "client-key"}},
-	})
+	}, nil)
 	_, err = provider(nil)
 	require.ErrorContains(t, err, "client-certificate")
+}
+
+func TestTrustedPeerTLSCredentials(t *testing.T) {
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverCert := testTLSCertificate(t, serverKey)
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientCert := testTLSCertificate(t, clientKey)
+
+	serverConn, clientConn := net.Pipe()
+	serverCreds := trustedPeerTLSCredentials(&tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{serverCert.Raw}, PrivateKey: serverKey}},
+		ClientAuth:   tls.RequestClientCert,
+		NextProtos:   []string{"h2"},
+	})
+	serverResult := make(chan credentials.AuthInfo, 1)
+	serverErr := make(chan error, 1)
+	go func() {
+		_, info, err := serverCreds.ServerHandshake(serverConn)
+		if err == nil {
+			serverResult <- info
+		}
+		serverErr <- err
+	}()
+
+	clientTLSConn := tls.Client(clientConn, &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{{Certificate: [][]byte{clientCert.Raw}, PrivateKey: clientKey}},
+		NextProtos:         []string{"h2"},
+	})
+	require.NoError(t, clientTLSConn.Handshake())
+	require.NoError(t, <-serverErr)
+	_ = clientConn.Close()
+	info := <-serverResult
+	authInfo, ok := info.(peerauth.AuthInfo)
+	require.True(t, ok)
+	require.Equal(t, (*keys.PublicKey)(&clientKey.PublicKey), authInfo.PublicKey)
+}
+
+func TestVerifyTLSCertificatePublicKey(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	cert := testTLSCertificate(t, key)
+	pub, err := peerauth.CertificatePublicKey(cert)
+	require.NoError(t, err)
+
+	tlsCert := &tls.Certificate{Certificate: [][]byte{cert.Raw}}
+	require.NoError(t, verifyTLSCertificatePublicKey(tlsCert, pub.Bytes()))
+	require.ErrorContains(t, verifyTLSCertificatePublicKey(tlsCert, []byte("other key")), "differs from node public key")
+	require.ErrorContains(t, verifyTLSCertificatePublicKey(new(tls.Certificate), pub.Bytes()), "parse TLS client certificate public key")
+}
+
+func testTLSCertificate(t *testing.T, key *ecdsa.PrivateKey) *x509.Certificate {
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
 }

--- a/cmd/neofs-node/object.go
+++ b/cmd/neofs-node/object.go
@@ -400,6 +400,10 @@ type reputationClient struct {
 	cons *reputationClientConstructor
 }
 
+func (c *reputationClient) IsMutuallyAuthenticated() bool {
+	return clientcore.IsMutuallyAuthenticated(c.MultiAddressClient)
+}
+
 func (c *reputationClient) submitResult(err error) {
 	currEpoch := c.cons.netState.CurrentEpoch()
 	sat := err == nil

--- a/config/example/node.yaml
+++ b/config/example/node.yaml
@@ -46,6 +46,7 @@ grpc:
     conn_limit: 1  # connection limits; exceeding connection will not be declined, just blocked before active number decreases or client timeouts
     tls:
       enabled: true  # use TLS for a gRPC connection (min version is TLS 1.2)
+      # For inter-node mTLS, certificate public key must match the node key announced in the network map.
       certificate: /path/to/cert  # path to TLS certificate
       key: /path/to/key  # path to TLS key
 

--- a/internal/crypto/requests.go
+++ b/internal/crypto/requests.go
@@ -62,8 +62,7 @@ func requestNeedsSignature[B neofscrypto.ProtoMessage](ctx context.Context, req 
 	if meta == nil || meta.GetTtl() != 1 {
 		return true
 	}
-	key, err := peerauth.PeerPublicKey(ctx)
-	return err != nil || key == nil
+	return !peerauth.IsTrustedPeer(ctx)
 }
 
 // GetRequestAuthor returns ID of the request author along with public key from

--- a/internal/crypto/requests_test.go
+++ b/internal/crypto/requests_test.go
@@ -8,10 +8,12 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"math/big"
 	"math/rand/v2"
 	"testing"
 
 	icrypto "github.com/nspcc-dev/neofs-node/internal/crypto"
+	"github.com/nspcc-dev/neofs-node/pkg/network/peerauth"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
 	neofscryptotest "github.com/nspcc-dev/neofs-sdk-go/crypto/test"
@@ -36,11 +38,14 @@ func assertInvalidRequestSignatureError(t testing.TB, actual error, expected str
 func TestVerifyRequestSignaturesWithContext(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 	require.NoError(t, err)
-	ctx := peer.NewContext(context.Background(), &peer.Peer{
-		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
-			PeerCertificates: []*x509.Certificate{{PublicKey: &key.PublicKey}},
-		}},
-	})
+	cert := &x509.Certificate{SerialNumber: big.NewInt(1)}
+	der, err := x509.CreateCertificate(cryptorand.Reader, cert, cert, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+	info, err := peerauth.NewAuthInfo(credentials.TLSInfo{State: tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}})
+	require.NoError(t, err)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: info})
 	req := &protoobject.GetRequest{MetaHeader: &protosession.RequestMetaHeader{Ttl: 1}}
 
 	require.NoError(t, icrypto.VerifyRequestSignaturesWithContext(ctx, req))

--- a/pkg/core/client/client.go
+++ b/pkg/core/client/client.go
@@ -56,3 +56,10 @@ type MultiAddressClient interface {
 	// this client (min(server, client) effectively).
 	APIVersion() *protorefs.Version
 }
+
+// IsMutuallyAuthenticated reports whether all connections of c use mutual TLS.
+// Clients that do not expose this property are treated as unauthenticated.
+func IsMutuallyAuthenticated(c any) bool {
+	x, ok := c.(interface{ IsMutuallyAuthenticated() bool })
+	return ok && x.IsMutuallyAuthenticated()
+}

--- a/pkg/network/cache/clients.go
+++ b/pkg/network/cache/clients.go
@@ -272,6 +272,9 @@ func (x *Clients) initConnection(ctx context.Context, pub []byte, uri string) (*
 		_ = grpcConn.Close()
 		return res, nil, fmt.Errorf("init NeoFS API client from gRPC client conn: %w", err)
 	}
+	if res.mtls.Load() {
+		res.SkipSignatureForLocalRequests()
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, x.streamMsgTimeout)
 	defer cancel()

--- a/pkg/network/cache/clients.go
+++ b/pkg/network/cache/clients.go
@@ -14,6 +14,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
@@ -153,7 +154,7 @@ func (x *Clients) syncWithNetmapSN(ctx context.Context, sn netmap.NodeInfo) erro
 	conns.mtx.Lock()
 	defer conns.mtx.Unlock()
 
-	maps.DeleteFunc(conns.m, func(ma string, c *client.Client) bool {
+	maps.DeleteFunc(conns.m, func(ma string, c *endpointClient) bool {
 		if slices.Contains(as, ma) {
 			return false
 		}
@@ -181,12 +182,13 @@ func (x *Clients) syncWithNetmapSN(ctx context.Context, sn netmap.NodeInfo) erro
 		conns.m[ma] = c
 		x.log.Info("connection to new SN address in the new network map successfully initialized", zap.String("address", ma))
 	}
+	conns.updateMutualAuthenticationStatus()
 
 	return nil
 }
 
 func (x *Clients) initConnections(ctx context.Context, pub []byte, addrs iter.Seq[string]) (*connections, error) {
-	m := make(map[string]*client.Client)
+	m := make(map[string]*endpointClient)
 	l := x.log.With(zap.String("public key", hex.EncodeToString(pub)))
 	var ver *protorefs.Version
 
@@ -207,15 +209,18 @@ func (x *Clients) initConnections(ctx context.Context, pub []byte, addrs iter.Se
 		m[s] = c
 	}
 	var hexKey = hex.EncodeToString(pub)
-	return &connections{
-		log:        x.log.With(zap.String("SN public key", hexKey)),
-		nodeID:     hexKey,
-		m:          m,
-		apiVersion: ver,
-	}, nil
+	res := &connections{
+		log:                  x.log.With(zap.String("SN public key", hexKey)),
+		nodeID:               hexKey,
+		hasClientCertificate: x.getClientCertificate != nil,
+		m:                    m,
+		apiVersion:           ver,
+	}
+	res.updateMutualAuthenticationStatus()
+	return res, nil
 }
 
-func (x *Clients) initConnection(ctx context.Context, pub []byte, uri string) (*client.Client, *protorefs.Version, error) {
+func (x *Clients) initConnection(ctx context.Context, pub []byte, uri string) (*endpointClient, *protorefs.Version, error) {
 	// FIXME: pending removal in #3982.
 	var a network.Address
 	if err := a.FromString(uri); err != nil {
@@ -226,13 +231,24 @@ func (x *Clients) initConnection(ctx context.Context, pub []byte, uri string) (*
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse URI: %w", err)
 	}
+	res := &endpointClient{withTLS: withTLS}
 	var transportCreds credentials.TransportCredentials
 	if withTLS {
 		expectedKey, err := keys.NewPublicKeyFromBytes(pub, elliptic.P256())
 		if err != nil {
 			return nil, nil, fmt.Errorf("parse node public key: %w", err)
 		}
-		transportCreds = credentials.NewTLS(newNodeTLSConfig((*ecdsa.PublicKey)(expectedKey), x.getClientCertificate))
+		getClientCertificate := x.getClientCertificate
+		if getClientCertificate != nil {
+			getClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				cert, err := x.getClientCertificate(info)
+				if err == nil && cert != nil {
+					res.mtls.Store(true)
+				}
+				return cert, err
+			}
+		}
+		transportCreds = credentials.NewTLS(newNodeTLSConfig((*ecdsa.PublicKey)(expectedKey), getClientCertificate))
 	} else {
 		transportCreds = insecure.NewCredentials()
 	}
@@ -251,7 +267,7 @@ func (x *Clients) initConnection(ctx context.Context, pub []byte, uri string) (*
 	if err != nil { // should never happen
 		return nil, nil, fmt.Errorf("init gRPC client conn: %w", err)
 	}
-	res, err := client.NewGRPC(ctx, grpcConn, x.signBufPool, x.streamMsgTimeout)
+	res.Client, err = client.NewGRPC(ctx, grpcConn, x.signBufPool, x.streamMsgTimeout)
 	if err != nil {
 		_ = grpcConn.Close()
 		return res, nil, fmt.Errorf("init NeoFS API client from gRPC client conn: %w", err)
@@ -309,12 +325,40 @@ func newNodeTLSConfig(expectedKey *ecdsa.PublicKey, getClientCertificate func(*t
 }
 
 type connections struct {
-	log    *zap.Logger
-	nodeID string
+	log                  *zap.Logger
+	nodeID               string
+	hasClientCertificate bool
 
-	mtx        sync.RWMutex
-	m          map[string]*client.Client // keys are multiaddrs
-	apiVersion *protorefs.Version
+	mtx                   sync.RWMutex
+	m                     map[string]*endpointClient // keys are multiaddrs
+	mutuallyAuthenticated atomic.Bool
+	apiVersion            *protorefs.Version
+}
+
+type endpointClient struct {
+	*client.Client
+	withTLS bool
+	mtls    atomic.Bool
+}
+
+func (x *connections) IsMutuallyAuthenticated() bool {
+	return x.mutuallyAuthenticated.Load()
+}
+
+// updateMutualAuthenticationStatus recalculates the connection group's status.
+// x.mtx must be locked by the caller.
+func (x *connections) updateMutualAuthenticationStatus() {
+	if !x.hasClientCertificate || len(x.m) == 0 {
+		x.mutuallyAuthenticated.Store(false)
+		return
+	}
+	for _, c := range x.m {
+		if !c.withTLS || !c.mtls.Load() {
+			x.mutuallyAuthenticated.Store(false)
+			return
+		}
+	}
+	x.mutuallyAuthenticated.Store(true)
 }
 
 func (x *connections) closeAll() {
@@ -329,7 +373,11 @@ func (x *connections) closeAll() {
 
 func (x *connections) all(f func(ma string, c *client.Client) bool) {
 	x.mtx.RLock()
-	maps.All(x.m)(f)
+	for ma, c := range x.m {
+		if !f(ma, c.Client) {
+			break
+		}
+	}
 	x.mtx.RUnlock()
 }
 

--- a/pkg/network/cache/clients_internal_test.go
+++ b/pkg/network/cache/clients_internal_test.go
@@ -34,6 +34,7 @@ func TestNodeTLSConfig(t *testing.T) {
 	t.Run("matching self-signed certificate", func(t *testing.T) {
 		cfg := newNodeTLSConfig(&expectedKey.PublicKey, nil)
 		require.True(t, cfg.InsecureSkipVerify)
+		require.Empty(t, cfg.ServerName)
 		require.NoError(t, cfg.VerifyConnection(tls.ConnectionState{
 			PeerCertificates: []*x509.Certificate{newSelfSignedCertificate(t, expectedKey)},
 		}))
@@ -44,6 +45,7 @@ func TestNodeTLSConfig(t *testing.T) {
 		cfg := newNodeTLSConfig(&expectedKey.PublicKey, func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return expected, nil
 		})
+		require.Empty(t, cfg.ServerName)
 		actual, err := cfg.GetClientCertificate(nil)
 		require.NoError(t, err)
 		require.Same(t, expected, actual)
@@ -88,6 +90,38 @@ func TestNodeTLSConfig(t *testing.T) {
 func TestInvalidTLSPublicKey(t *testing.T) {
 	_, _, err := new(Clients).initConnection(context.Background(), []byte("invalid"), "/dns4/example.com/tcp/443/tls")
 	require.ErrorContains(t, err, "parse node public key")
+}
+
+func TestConnectionsIsMutuallyAuthenticated(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		hasClientCertificate bool
+		endpoints            []string
+		peerRequestedCert    bool
+		expected             bool
+	}{
+		{name: "single TLS endpoint", hasClientCertificate: true, endpoints: []string{"/dns4/example.com/tcp/443/tls"}, peerRequestedCert: true, expected: true},
+		{name: "multiple TLS endpoints", hasClientCertificate: true, endpoints: []string{"/dns4/one.example.com/tcp/443/tls", "/dns4/two.example.com/tcp/443/tls"}, peerRequestedCert: true, expected: true},
+		{name: "server did not request certificate", hasClientCertificate: true, endpoints: []string{"/dns4/example.com/tcp/443/tls"}},
+		{name: "no client certificate", endpoints: []string{"/dns4/example.com/tcp/443/tls"}},
+		{name: "plain endpoint", hasClientCertificate: true, endpoints: []string{"/dns4/example.com/tcp/8080"}},
+		{name: "mixed endpoints", hasClientCertificate: true, endpoints: []string{"/dns4/example.com/tcp/443/tls", "/dns4/example.com/tcp/8080"}},
+		{name: "empty endpoints", hasClientCertificate: true},
+		{name: "invalid endpoint", hasClientCertificate: true, endpoints: []string{"invalid"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conns := &connections{
+				hasClientCertificate: tc.hasClientCertificate,
+				m:                    make(map[string]*endpointClient, len(tc.endpoints)),
+			}
+			for i := range tc.endpoints {
+				conns.m[tc.endpoints[i]] = &endpointClient{withTLS: tc.endpoints[i] != "/dns4/example.com/tcp/8080"}
+				conns.m[tc.endpoints[i]].mtls.Store(tc.peerRequestedCert)
+			}
+			conns.updateMutualAuthenticationStatus()
+			require.Equal(t, tc.expected, conns.IsMutuallyAuthenticated())
+		})
+	}
 }
 
 func newSelfSignedCertificate(t *testing.T, key crypto.Signer) *x509.Certificate {

--- a/pkg/network/peerauth/peerauth.go
+++ b/pkg/network/peerauth/peerauth.go
@@ -12,6 +12,43 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
+// AuthInfo is TLS authentication information for a peer with a supported
+// public key. It is set once during the TLS handshake.
+type AuthInfo struct {
+	credentials.TLSInfo
+	PublicKey *keys.PublicKey
+}
+
+// AuthType implements [credentials.AuthInfo].
+func (AuthInfo) AuthType() string { return "tls" }
+
+// NewAuthInfo returns authentication information for a TLS peer certificate.
+func NewAuthInfo(info credentials.TLSInfo) (AuthInfo, error) {
+	if len(info.State.PeerCertificates) == 0 {
+		return AuthInfo{}, fmt.Errorf("missing TLS peer certificate")
+	}
+	key, err := CertificatePublicKey(info.State.PeerCertificates[0])
+	if err != nil {
+		return AuthInfo{}, err
+	}
+	return AuthInfo{TLSInfo: info, PublicKey: key}, nil
+}
+
+// IsTrustedPeer reports whether ctx was authenticated during the TLS handshake.
+func IsTrustedPeer(ctx context.Context) bool {
+	_, ok := authenticatedPeerInfo(ctx)
+	return ok
+}
+
+func authenticatedPeerInfo(ctx context.Context) (AuthInfo, bool) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return AuthInfo{}, false
+	}
+	info, ok := p.AuthInfo.(AuthInfo)
+	return info, ok
+}
+
 // CertificatePublicKey returns the P-256 public key from cert.
 func CertificatePublicKey(cert *x509.Certificate) (*keys.PublicKey, error) {
 	pub, ok := cert.PublicKey.(*ecdsa.PublicKey)
@@ -24,23 +61,29 @@ func CertificatePublicKey(cert *x509.Certificate) (*keys.PublicKey, error) {
 	return (*keys.PublicKey)(pub), nil
 }
 
+// CertificatePublicKeyFromRaw returns the P-256 public key from the first TLS
+// certificate in a handshake chain.
+func CertificatePublicKeyFromRaw(rawCerts [][]byte) ([]byte, error) {
+	if len(rawCerts) == 0 {
+		return nil, fmt.Errorf("missing TLS peer certificate")
+	}
+	cert, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse TLS peer certificate: %w", err)
+	}
+	pub, err := CertificatePublicKey(cert)
+	if err != nil {
+		return nil, err
+	}
+	return pub.Bytes(), nil
+}
+
 // PeerPublicKey returns the public key authenticated by the TLS connection.
 // It returns nil when the request has no TLS client certificate.
 func PeerPublicKey(ctx context.Context) (*keys.PublicKey, error) {
-	p, ok := peer.FromContext(ctx)
+	info, ok := authenticatedPeerInfo(ctx)
 	if !ok {
 		return nil, nil
 	}
-	info, ok := p.AuthInfo.(credentials.TLSInfo)
-	if !ok {
-		return nil, nil
-	}
-	if len(info.State.PeerCertificates) == 0 {
-		return nil, nil
-	}
-	key, err := CertificatePublicKey(info.State.PeerCertificates[0])
-	if err != nil {
-		return nil, fmt.Errorf("invalid TLS peer certificate: %w", err)
-	}
-	return key, nil
+	return info.PublicKey, nil
 }

--- a/pkg/network/peerauth/peerauth_test.go
+++ b/pkg/network/peerauth/peerauth_test.go
@@ -50,11 +50,11 @@ func TestPeerPublicKey(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	cert := newCertificate(t, key)
-	ctx := peer.NewContext(context.Background(), &peer.Peer{
-		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
-			PeerCertificates: []*x509.Certificate{cert},
-		}},
-	})
+	info, err := NewAuthInfo(credentials.TLSInfo{State: tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+	}})
+	require.NoError(t, err)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: info})
 	pub, err = PeerPublicKey(ctx)
 	require.NoError(t, err)
 	require.Equal(t, (*keys.PublicKey)(&key.PublicKey), pub)

--- a/pkg/services/object/acl/v2/service_internal_test.go
+++ b/pkg/services/object/acl/v2/service_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	isessions "github.com/nspcc-dev/neofs-node/internal/sessions"
+	"github.com/nspcc-dev/neofs-node/pkg/network/peerauth"
 	"github.com/nspcc-dev/neofs-node/pkg/services/object/common"
 	"github.com/nspcc-dev/neofs-sdk-go/bearer"
 	"github.com/nspcc-dev/neofs-sdk-go/container"
@@ -186,11 +187,11 @@ func TestGetCredentialsFromPeerPublicKey(t *testing.T) {
 func TestGetRequestCredentialsUsesTLSAuthenticatedPeer(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	ctx := peer.NewContext(context.Background(), &peer.Peer{
-		AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{
-			PeerCertificates: []*x509.Certificate{{PublicKey: &key.PublicKey}},
-		}},
-	})
+	info, err := peerauth.NewAuthInfo(credentials.TLSInfo{State: tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{{PublicKey: &key.PublicKey}},
+	}})
+	require.NoError(t, err)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: info})
 	req := &protoobject.GetRequest{MetaHeader: &protosession.RequestMetaHeader{Ttl: 1}}
 
 	actualUser, actualPub, err := getRequestCredentials(ctx, req, common.RequestTokens{Session: new(sessionv2.Token)})

--- a/pkg/services/object/server.go
+++ b/pkg/services/object/server.go
@@ -827,7 +827,6 @@ func convertHeadPrm(signer ecdsa.PrivateKey, cnr container.Container, req *proto
 
 	p.SetTransportFunc(func(ctx context.Context, c clientcore.MultiAddressClient) (mem.BufferSlice, iprotobuf.BuffersSlice, error) {
 		if !updatedRequest {
-			updatedRequest = true
 			req = &protoobject.HeadRequest{
 				Body: req.Body,
 				MetaHeader: &protosession.RequestMetaHeader{
@@ -835,11 +834,14 @@ func convertHeadPrm(signer ecdsa.PrivateKey, cnr container.Container, req *proto
 					Ttl:     1,
 				},
 			}
-			var err error
-			req.VerifyHeader, err = neofscrypto.SignRequestWithBuffer(neofsecdsa.Signer(signer), req, nil)
-			if err != nil {
-				return nil, iprotobuf.BuffersSlice{}, err
+			if shouldSignOutgoingRequest(c, req) {
+				var err error
+				req.VerifyHeader, err = neofscrypto.SignRequestWithBuffer(neofsecdsa.Signer(signer), req, nil)
+				if err != nil {
+					return nil, iprotobuf.BuffersSlice{}, err
+				}
 			}
+			updatedRequest = true
 		}
 
 		var respBuf mem.BufferSlice
@@ -1406,8 +1408,6 @@ func convertGetPrm(signer ecdsa.PrivateKey, cnr container.Container, req *protoo
 
 	p.SetTransportFunc(func(ctx context.Context, c clientcore.MultiAddressClient) error {
 		if !updatedRequest {
-			updatedRequest = true
-
 			req = &protoobject.GetRequest{
 				Body: req.Body,
 				MetaHeader: &protosession.RequestMetaHeader{
@@ -1416,13 +1416,17 @@ func convertGetPrm(signer ecdsa.PrivateKey, cnr container.Container, req *protoo
 				},
 			}
 			if proxyCtx.suppressInit {
+				req.Body = proto.Clone(req.Body).(*protoobject.GetRequest_Body)
 				req.Body.PayloadOnly = false
 			}
-			var err error
-			req.VerifyHeader, err = neofscrypto.SignRequestWithBuffer(neofsecdsa.Signer(signer), req, nil)
-			if err != nil {
-				return err
+			if shouldSignOutgoingRequest(c, req) {
+				var err error
+				req.VerifyHeader, err = neofscrypto.SignRequestWithBuffer(neofsecdsa.Signer(signer), req, nil)
+				if err != nil {
+					return err
+				}
 			}
+			updatedRequest = true
 		}
 
 		return c.ForAnyGRPCConn(ctx, func(ctx context.Context, conn *grpc.ClientConn) error {
@@ -2110,10 +2114,8 @@ func (s *Server) ProcessSearch(ctx context.Context, req *protoobject.SearchV2Req
 				Ttl:     1,
 			},
 		}
-		if req.VerifyHeader, err = neofscrypto.SignRequestWithBuffer[*protoobject.SearchV2Request_Body](neofsecdsa.Signer(s.signer), req, nil); err != nil {
-			return nil, nil, fmt.Errorf("sign request: %w", err)
-		}
-
+		var onceResign sync.Once
+		var signingErr error
 		var optimizedNodes = (len(body.Filters) != 0) &&
 			slices.ContainsFunc(body.Filters, func(filt *protoobject.SearchFilter) bool {
 				return !strings.HasPrefix(filt.Key, "$Object:") && !strings.HasPrefix(filt.Key, "__NEOFS__")
@@ -2135,7 +2137,7 @@ func (s *Server) ProcessSearch(ctx context.Context, req *protoobject.SearchV2Req
 				return true
 			}
 			go func() {
-				set, more, err := s.searchOnRemoteNode(ctx, node, req)
+				set, more, err := s.searchOnRemoteNode(ctx, node, req, &onceResign, &signingErr)
 				resCh <- nodeSearchResult{set, more, err}
 			}()
 			return true
@@ -2189,17 +2191,32 @@ func (s *Server) ProcessSearch(ctx context.Context, req *protoobject.SearchV2Req
 	return res, newCursor, incomplete
 }
 
-func (s *Server) searchOnRemoteNode(ctx context.Context, node netmap.NodeInfo, req *protoobject.SearchV2Request) ([]client.SearchResultItem, bool, error) {
+func (s *Server) searchOnRemoteNode(ctx context.Context, node netmap.NodeInfo, req *protoobject.SearchV2Request, onceResign *sync.Once, signingErr *error) ([]client.SearchResultItem, bool, error) {
 	c, err := s.nodeClients.Get(ctx, node)
 	if err != nil {
 		return nil, false, fmt.Errorf("get node client: %w", err)
+	}
+
+	outReq := req
+	if shouldSignOutgoingRequest(c, req) {
+		onceResign.Do(func() {
+			req.VerifyHeader, *signingErr = neofscrypto.SignRequestWithBuffer[*protoobject.SearchV2Request_Body](neofsecdsa.Signer(s.signer), req, nil)
+		})
+		if *signingErr != nil {
+			return nil, false, fmt.Errorf("sign request: %w", *signingErr)
+		}
+	} else {
+		outReq = &protoobject.SearchV2Request{
+			Body:       req.Body,
+			MetaHeader: req.MetaHeader,
+		}
 	}
 
 	var items []client.SearchResultItem
 	var more bool
 	return items, more, c.ForAnyGRPCConn(ctx, func(ctx context.Context, conn *grpc.ClientConn) error {
 		var err error
-		items, more, err = searchOnRemoteAddress(ctx, conn, req)
+		items, more, err = searchOnRemoteAddress(ctx, conn, outReq)
 		return err // TODO: log error
 	})
 }
@@ -2393,6 +2410,11 @@ func chunkBoundsToSend(global, local, chunkLen int) (int, int) {
 
 func needSignGetResponse(req util.Request) bool {
 	return util.VersionLE(req, 2, 17)
+}
+
+func shouldSignOutgoingRequest(c any, req util.Request) bool {
+	meta := req.GetMetaHeader()
+	return meta == nil || meta.GetTtl() != 1 || !clientcore.IsMutuallyAuthenticated(c)
 }
 
 func checkHeaderProtobufAgainstID(buffers iprotobuf.BuffersSlice, id oid.ID, ordered bool) error {

--- a/pkg/services/object/server_internal_test.go
+++ b/pkg/services/object/server_internal_test.go
@@ -1,0 +1,27 @@
+package object
+
+import (
+	"testing"
+
+	protoobject "github.com/nspcc-dev/neofs-sdk-go/proto/object"
+	protosession "github.com/nspcc-dev/neofs-sdk-go/proto/session"
+	"github.com/stretchr/testify/require"
+)
+
+type mutuallyAuthenticatedClient bool
+
+func (x mutuallyAuthenticatedClient) IsMutuallyAuthenticated() bool {
+	return bool(x)
+}
+
+func TestShouldSignOutgoingRequest(t *testing.T) {
+	requestWithTTL := func(ttl uint32) *protoobject.GetRequest {
+		return &protoobject.GetRequest{MetaHeader: &protosession.RequestMetaHeader{Ttl: ttl}}
+	}
+
+	require.False(t, shouldSignOutgoingRequest(mutuallyAuthenticatedClient(true), requestWithTTL(1)))
+	require.True(t, shouldSignOutgoingRequest(mutuallyAuthenticatedClient(true), requestWithTTL(2)))
+	require.True(t, shouldSignOutgoingRequest(mutuallyAuthenticatedClient(true), new(protoobject.GetRequest)))
+	require.True(t, shouldSignOutgoingRequest(mutuallyAuthenticatedClient(false), requestWithTTL(1)))
+	require.True(t, shouldSignOutgoingRequest(struct{}{}, requestWithTTL(1)))
+}


### PR DESCRIPTION
Would it make sense to add an SDK option for unsigned requests?
Some inter-node TTL=1 paths still use SDK `ObjectHead/ObjectGetInit/ObjectRangeInit/ObjectPutInit`, which always sign requests. An opt-in parameter such as `DisableRequestSigning` could let the node skip signatures after it has confirmed mTLS, while keeping the SDK default safe.