### PR TITLE
policer: balance local shard data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for NeoFS Node
 - SN requests network map only when it has been changed (#4121)
 - SN pushes URI-style endpoints to netmap instead of multiaddr (#3982)
 - Write-cache FSTree depth increased from 1 to 2 with online migration (#4175)
+- Policer balances data across local shards (#4170)
 
 ### Removed
 - GetRange object service method (#4167)

--- a/cmd/neofs-node/control.go
+++ b/cmd/neofs-node/control.go
@@ -83,3 +83,7 @@ func (c *cfg) IncPolicerObjectReplicated(isEC bool) {
 func (c *cfg) IncPolicerObjectDeleted(isEC bool) {
 	c.metricsCollector.IncPolicerObjectDeleted(isEC)
 }
+
+func (c *cfg) IncPolicerObjectRelocated() {
+	c.metricsCollector.IncPolicerObjectRelocated()
+}

--- a/pkg/local_object_storage/engine/delete.go
+++ b/pkg/local_object_storage/engine/delete.go
@@ -2,13 +2,11 @@ package engine
 
 import (
 	"context"
-	"slices"
 
 	meta "github.com/nspcc-dev/neofs-node/pkg/local_object_storage/metabase"
 	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"go.uber.org/zap"
 )
 
 // GarbageMark specifies why an object is marked for garbage collection.
@@ -39,61 +37,6 @@ func (e *StorageEngine) Delete(_ context.Context, addr oid.Address, mark Garbage
 	}
 	return e.processAddrDelete(addr, func(sh *shard.Shard, cnr cid.ID, addrs []oid.ID) error {
 		return sh.MarkGarbage(cnr, addrs, mark)
-	})
-}
-
-// DeleteRedundantCopies marks redundant object copies to be removed from all
-// listed shards except the most preferred one according to HRW ordering.
-//
-// Returns an error if executions are blocked (see BlockExecution) or if none of
-// the provided shards is found in the engine.
-func (e *StorageEngine) DeleteRedundantCopies(_ context.Context, addr oid.Address, shardIDs []string) error {
-	if e.metrics != nil {
-		defer elapsed(e.metrics.AddDeleteDuration)()
-	}
-
-	e.blockMtx.RLock()
-	defer e.blockMtx.RUnlock()
-
-	if e.blockErr != nil {
-		return e.blockErr
-	}
-
-	if len(shardIDs) < 2 {
-		return nil
-	}
-
-	var (
-		deleteShards []shardWrapper
-		keeperShard  string
-	)
-	for _, sh := range e.sortedShards(addr.Object()) {
-		var id = sh.ID().String()
-		if !slices.Contains(shardIDs, id) {
-			continue
-		}
-
-		if keeperShard == "" {
-			keeperShard = id
-			continue
-		}
-
-		deleteShards = append(deleteShards, sh)
-	}
-
-	if keeperShard == "" {
-		return errShardNotFound
-	}
-
-	if len(deleteShards) == 0 {
-		return nil
-	}
-
-	return e.processAddrDeleteOnShards(deleteShards, addr, func(sh *shard.Shard, cnr cid.ID, addrs []oid.ID) error {
-		e.log.Info("removing redundant local object copy",
-			zap.String("keeper_shard", keeperShard),
-			zap.Stringer("redundant_shard", sh.ID()))
-		return sh.MarkGarbage(cnr, addrs, GarbageMarkRedundant)
 	})
 }
 

--- a/pkg/local_object_storage/engine/optimize.go
+++ b/pkg/local_object_storage/engine/optimize.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"context"
+	"errors"
+
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"go.uber.org/zap"
+)
+
+// OptimizeShardLocation moves an object to its most preferred shard according
+// to HRW ordering and marks its copies on all other listed shards as redundant.
+//
+// The source copies are marked only after the object is known to exist on the
+// preferred shard. The operation therefore never removes the last local copy
+// when the destination cannot accept the object.
+//
+// It returns true if it copied the object to the preferred shard. It returns
+// false when the object was already there.
+//
+// Returns an error if executions are blocked (see BlockExecution), no listed
+// source shard contains the object, or optimization/marking fails.
+func (e *StorageEngine) OptimizeShardLocation(_ context.Context, addr oid.Address, shardIDs []string) (bool, error) {
+	e.blockMtx.RLock()
+	defer e.blockMtx.RUnlock()
+
+	if e.blockErr != nil {
+		return false, e.blockErr
+	}
+	if len(shardIDs) == 0 {
+		return false, errShardNotFound
+	}
+
+	shards := e.sortedShards(addr.Object())
+	if len(shards) == 0 {
+		return false, errShardNotFound
+	}
+
+	target := shards[0]
+	targetID := target.ID().String()
+	if len(shardIDs) == 1 && shardIDs[0] == targetID {
+		return false, nil
+	}
+
+	exists, err := target.Exists(addr, false)
+	if err != nil && !errors.Is(err, apistatus.ErrObjectNotFound) {
+		return false, err
+	}
+
+	moved := false
+	if !exists {
+		var (
+			obj           *object.Object
+			sourceShardID string
+		)
+		for _, sourceID := range shardIDs {
+			if sourceID == targetID {
+				continue
+			}
+
+			source := e.getShard(sourceID)
+			if source.Shard == nil {
+				continue
+			}
+
+			obj, err = source.Get(addr, false)
+			if err == nil {
+				sourceShardID = sourceID
+				break
+			}
+			if !errors.Is(err, apistatus.ErrObjectNotFound) {
+				return false, err
+			}
+		}
+		if obj == nil {
+			return false, apistatus.ObjectNotFound{}
+		}
+
+		err = e.putToShard(target, addr, obj, nil)
+		if err != nil && !errors.Is(err, errExists) {
+			return false, err
+		}
+		moved = err == nil
+		if moved {
+			e.log.Info("moved local object to preferred shard",
+				zap.Stringer("object", addr),
+				zap.String("source_shard", sourceShardID),
+				zap.String("target_shard", targetID))
+		}
+	}
+
+	for _, sourceID := range shardIDs {
+		if sourceID == targetID {
+			continue
+		}
+
+		source := e.getShard(sourceID)
+		if source.Shard == nil {
+			continue
+		}
+
+		if err = source.MarkGarbage(addr.Container(), []oid.ID{addr.Object()}, GarbageMarkRedundant); err != nil {
+			return false, err
+		}
+		e.log.Info("marked redundant local object copy",
+			zap.Stringer("object", addr),
+			zap.String("keeper_shard", targetID),
+			zap.String("redundant_shard", sourceID))
+	}
+
+	return moved, nil
+}

--- a/pkg/local_object_storage/engine/optimize_test.go
+++ b/pkg/local_object_storage/engine/optimize_test.go
@@ -1,0 +1,106 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard"
+	"github.com/nspcc-dev/neofs-node/pkg/local_object_storage/shard/mode"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageEngine_OptimizeShardLocation(t *testing.T) {
+	newEngine := func(t *testing.T, opts ...shard.Option) *StorageEngine {
+		var e *StorageEngine
+		if len(opts) == 0 {
+			e = testNewEngineWithShards(testNewShard(t, 1), testNewShard(t, 2))
+		} else {
+			e = testEngineFromShardOpts(t, 2, opts)
+		}
+		t.Cleanup(func() { _ = e.Close() })
+		return e
+	}
+
+	t.Run("moves to preferred shard", func(t *testing.T) {
+		e := newEngine(t, shard.WithGCRemoverSleepInterval(100*time.Millisecond))
+		obj := generateObjectWithCID(cidtest.ID())
+		addr := obj.Address()
+		shards := e.sortedShards(addr.Object())
+		target, source := shards[0], shards[1]
+
+		require.NoError(t, source.Put(obj, nil))
+		moved, err := e.OptimizeShardLocation(context.Background(), addr, []string{source.ID().String()})
+		require.NoError(t, err)
+		require.True(t, moved)
+
+		got, err := target.Get(addr, false)
+		require.NoError(t, err)
+		require.Equal(t, obj, got)
+
+		require.Eventually(t, func() bool {
+			_, err := source.Get(addr, false)
+			return errors.Is(err, apistatus.ErrObjectNotFound)
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("does not move when target already contains object", func(t *testing.T) {
+		e := newEngine(t)
+		obj := generateObjectWithCID(cidtest.ID())
+		addr := obj.Address()
+		shards := e.sortedShards(addr.Object())
+		target, source := shards[0], shards[1]
+
+		require.NoError(t, target.Put(obj, nil))
+		require.NoError(t, source.Put(obj, nil))
+		moved, err := e.OptimizeShardLocation(context.Background(), addr, []string{target.ID().String(), source.ID().String()})
+		require.NoError(t, err)
+		require.False(t, moved)
+	})
+
+	t.Run("does not move only target copy", func(t *testing.T) {
+		e := newEngine(t)
+		obj := generateObjectWithCID(cidtest.ID())
+		addr := obj.Address()
+		target := e.sortedShards(addr.Object())[0]
+
+		require.NoError(t, target.Put(obj, nil))
+		moved, err := e.OptimizeShardLocation(context.Background(), addr, []string{target.ID().String()})
+		require.NoError(t, err)
+		require.False(t, moved)
+	})
+
+	t.Run("keeps source when target is read-only", func(t *testing.T) {
+		e := newEngine(t)
+		obj := generateObjectWithCID(cidtest.ID())
+		addr := obj.Address()
+		shards := e.sortedShards(addr.Object())
+		target, source := shards[0], shards[1]
+
+		require.NoError(t, source.Put(obj, nil))
+		require.NoError(t, target.SetMode(mode.ReadOnly))
+		moved, err := e.OptimizeShardLocation(context.Background(), addr, []string{source.ID().String()})
+		require.False(t, moved)
+		require.ErrorIs(t, err, shard.ErrReadOnlyMode)
+
+		got, err := source.Get(addr, false)
+		require.NoError(t, err)
+		require.Equal(t, obj, got)
+	})
+
+	t.Run("fails when source is missing", func(t *testing.T) {
+		e := newEngine(t)
+		obj := generateObjectWithCID(cidtest.ID())
+		addr := obj.Address()
+		target := e.sortedShards(addr.Object())[0]
+
+		moved, err := e.OptimizeShardLocation(context.Background(), addr, []string{"missing"})
+		require.False(t, moved)
+		require.ErrorIs(t, err, apistatus.ErrObjectNotFound)
+		_, err = target.Get(addr, false)
+		require.ErrorIs(t, err, apistatus.ErrObjectNotFound)
+	})
+}

--- a/pkg/metrics/state.go
+++ b/pkg/metrics/state.go
@@ -96,6 +96,13 @@ func (m stateMetrics) IncPolicerObjectDeleted(isEC bool) {
 	m.incPolicerObjectCounter("deleted", isEC)
 }
 
+func (m stateMetrics) IncPolicerObjectRelocated() {
+	m.policerObjectCounter.With(prometheus.Labels{
+		policerActionLabel: "relocated",
+		policerModeLabel:   "physical",
+	}).Inc()
+}
+
 func (m stateMetrics) incPolicerObjectCounter(action string, isEC bool) {
 	mode := "replica"
 	if isEC {

--- a/pkg/services/policer/check.go
+++ b/pkg/services/policer/check.go
@@ -130,7 +130,7 @@ func (p *Policer) processObject(ctx context.Context, addrWithAttrs objectcore.Ad
 
 	if isEC {
 		if len(ecRules) > 0 {
-			p.processECPart(ctx, addr, selectNodesAddr.Object(), ecp, ecRules, nn[len(repRules):])
+			p.processECPart(ctx, addrWithAttrs, selectNodesAddr.Object(), ecp, ecRules, nn[len(repRules):])
 			return
 		}
 		p.log.Info("object with EC attributes in container without EC rules detected, deleting",
@@ -228,7 +228,7 @@ func (p *Policer) processObject(ctx context.Context, addrWithAttrs objectcore.Ad
 		return
 	}
 
-	p.dropRedundantLocalCopies(ctx, addrWithAttrs)
+	p.optimizeLocalShardLocation(ctx, addrWithAttrs)
 }
 
 type processPlacementContext struct {
@@ -377,11 +377,10 @@ func (p *Policer) dropRedundantLocalObject(ctx context.Context, addr oid.Address
 	err := p.localStorage.Delete(ctx, addr, engine.GarbageMarkRedundant)
 	if err == nil {
 		p.metrics.IncPolicerObjectDeleted(isEC)
+		return
 	}
-	if err != nil {
-		p.log.Warn("could not inhume mark redundant copy as garbage",
-			zap.Error(err))
-	}
+
+	p.log.Warn("could not inhume mark redundant copy as garbage", zap.Error(err))
 }
 
 func (p *Policer) deleteLocalObject(ctx context.Context, addr oid.Address, isEC bool) error {
@@ -392,8 +391,8 @@ func (p *Policer) deleteLocalObject(ctx context.Context, addr oid.Address, isEC 
 	return err
 }
 
-func (p *Policer) dropRedundantLocalCopies(ctx context.Context, obj objectcore.AddressWithAttributes) {
-	if len(obj.ShardIDs) < 2 {
+func (p *Policer) optimizeLocalShardLocation(ctx context.Context, obj objectcore.AddressWithAttributes) {
+	if len(obj.ShardIDs) == 0 {
 		return
 	}
 
@@ -403,12 +402,19 @@ func (p *Policer) dropRedundantLocalCopies(ctx context.Context, obj objectcore.A
 	default:
 	}
 
-	err := p.localStorage.DeleteRedundantCopies(ctx, obj.Address, obj.ShardIDs)
+	moved, err := p.localStorage.OptimizeShardLocation(ctx, obj.Address, obj.ShardIDs)
 	if err != nil {
-		p.log.Warn("could not mark redundant local shard copies as garbage",
+		p.log.Warn("could not optimize local object shard location",
 			zap.Stringer("object", obj.Address),
 			zap.Strings("shards", obj.ShardIDs),
 			zap.Error(err))
+		return
+	}
+	if moved {
+		p.metrics.IncPolicerObjectRelocated()
+		p.log.Info("optimized local object shard location",
+			zap.Stringer("object", obj.Address),
+			zap.Strings("shards", obj.ShardIDs))
 	}
 }
 

--- a/pkg/services/policer/ec.go
+++ b/pkg/services/policer/ec.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	iec "github.com/nspcc-dev/neofs-node/internal/ec"
+	objectcore "github.com/nspcc-dev/neofs-node/pkg/core/object"
 	"github.com/nspcc-dev/neofs-node/pkg/services/replicator"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
@@ -20,7 +21,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func (p *Policer) processECPart(ctx context.Context, addr oid.Address, parent oid.ID, pi iec.PartInfo, ecRules []iec.Rule, nodeLists [][]netmap.NodeInfo) {
+func (p *Policer) processECPart(ctx context.Context, obj objectcore.AddressWithAttributes, parent oid.ID, pi iec.PartInfo, ecRules []iec.Rule, nodeLists [][]netmap.NodeInfo) {
+	addr := obj.Address
 	if pi.RuleIndex >= len(ecRules) {
 		p.log.Warn("local object with invalid EC rule index detected, deleting",
 			zap.Stringer("object", addr), zap.Int("ruleIdx", pi.RuleIndex), zap.Int("totalRules", len(ecRules)))
@@ -43,10 +45,14 @@ func (p *Policer) processECPart(ctx context.Context, addr oid.Address, parent oi
 	}
 
 	p.checkECParts(ctx, addr.Container(), parent, rule, pi.RuleIndex, pi.Index, addr.Object())
-	p.processECPartByRule(ctx, rule, addr, pi.Index, nodeLists[pi.RuleIndex])
+	if p.processECPartByRule(ctx, rule, addr, pi.Index, nodeLists[pi.RuleIndex]) {
+		p.optimizeLocalShardLocation(ctx, obj)
+	}
 }
 
-func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr oid.Address, partIdx int, nodes []netmap.NodeInfo) {
+// processECPartByRule returns true if the local part has no confirmed
+// more-optimal remote holder and should have its local shard location optimized.
+func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr oid.Address, partIdx int, nodes []netmap.NodeInfo) bool {
 	var candidates []netmap.NodeInfo
 	var maintenance bool
 	headTimeout := time.Duration(-1)
@@ -57,7 +63,7 @@ func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr o
 				p.log.Debug("local node is optimal for EC part, hold",
 					zap.Stringer("cid", addr.Container()), zap.Stringer("partOID", addr.Object()),
 					zap.Stringer("rule", rule), zap.Int("partIdx", partIdx))
-				return
+				return true
 			}
 			break
 		}
@@ -76,7 +82,7 @@ func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr o
 				zap.Stringer("rule", rule), zap.Int("partIdx", partIdx),
 				zap.Strings("node", slices.Collect(nodes[i].NetworkEndpoints())))
 			p.dropRedundantLocalObject(ctx, addr, true)
-			return
+			return false
 		}
 
 		switch {
@@ -100,14 +106,14 @@ func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr o
 		p.log.Info("more optimal node for EC part is under maintenance, hold",
 			zap.Stringer("cid", addr.Container()), zap.Stringer("partOID", addr.Object()),
 			zap.Stringer("rule", rule), zap.Int("partIdx", partIdx))
-		return
+		return true
 	}
 
 	if len(candidates) == 0 {
 		p.log.Info("local node is suboptimal for EC part but now there are no other candidates, hold",
 			zap.Stringer("cid", addr.Container()), zap.Stringer("partOID", addr.Object()),
 			zap.Stringer("rule", rule), zap.Int("partIdx", partIdx))
-		return
+		return true
 	}
 
 	p.log.Info("local node is suboptimal for EC part, moving to more optimal node...",
@@ -122,12 +128,13 @@ func (p *Policer) processECPartByRule(ctx context.Context, rule iec.Rule, addr o
 			zap.Stringer("cid", addr.Container()), zap.Stringer("partOID", addr.Object()),
 			zap.Stringer("rule", rule), zap.Int("partIdx", partIdx), zap.Strings("newHolder", repRes.netAddresses))
 		p.dropRedundantLocalObject(ctx, addr, true)
-		return
+		return false
 	}
 
 	p.log.Info("failed to move EC part to more optimal node, hold",
 		zap.Stringer("cid", addr.Container()), zap.Stringer("partOID", addr.Object()),
 		zap.Stringer("rule", rule), zap.Int("partIdx", partIdx), zap.Int("candidateNum", len(candidates)))
+	return true
 }
 
 type singleReplication struct {

--- a/pkg/services/policer/policer.go
+++ b/pkg/services/policer/policer.go
@@ -29,7 +29,7 @@ type replicatorIface interface {
 type localStorage interface {
 	ListWithCursor(context.Context, uint32, *engine.Cursor, ...string) ([]objectcore.AddressWithAttributes, *engine.Cursor, error)
 	Delete(context.Context, oid.Address, engine.GarbageMark) error
-	DeleteRedundantCopies(context.Context, oid.Address, []string) error
+	OptimizeShardLocation(context.Context, oid.Address, []string) (bool, error)
 	Put(context.Context, *object.Object, []byte) error
 	Head(context.Context, oid.Address, bool) (*object.Object, error)
 	HeadECPart(context.Context, cid.ID, oid.ID, iec.PartInfo) (object.Object, error)
@@ -113,6 +113,8 @@ type (
 		IncPolicerObjectReplicated(isEC bool)
 		// IncPolicerObjectDeleted increments deleted objects counter.
 		IncPolicerObjectDeleted(isEC bool)
+		// IncPolicerObjectRelocated increments successfully moved physical objects counter.
+		IncPolicerObjectRelocated()
 	}
 )
 
@@ -146,6 +148,7 @@ func (nopMetricsCollector) IncPolicerCycleCount()           {}
 func (nopMetricsCollector) IncPolicerObjectProcessed(bool)  {}
 func (nopMetricsCollector) IncPolicerObjectReplicated(bool) {}
 func (nopMetricsCollector) IncPolicerObjectDeleted(bool)    {}
+func (nopMetricsCollector) IncPolicerObjectRelocated()      {}
 
 func defaultCfg() *cfg {
 	return &cfg{

--- a/pkg/services/policer/policer_test.go
+++ b/pkg/services/policer/policer_test.go
@@ -66,7 +66,7 @@ func (s *storageListerWithDelay) Delete(_ context.Context, _ oid.Address, _ engi
 	panic("do not call me")
 }
 
-func (s *storageListerWithDelay) DeleteRedundantCopies(_ context.Context, address oid.Address, _ []string) error {
+func (s *storageListerWithDelay) OptimizeShardLocation(_ context.Context, _ oid.Address, _ []string) (bool, error) {
 	panic("do not call me")
 }
 
@@ -956,6 +956,14 @@ func TestPolicer_Run_EC(t *testing.T) {
 		})
 	})
 
+	t.Run("kept part is rebalanced locally", func(t *testing.T) {
+		localObj := localObj
+		localObj.ShardIDs = []string{"source"}
+
+		logBuf := testECCheck(t, rule, localObj, nodes, 5, all404, false, nil)
+		logBuf.AssertContainsMsg(zap.InfoLevel, "optimized local object shard location")
+	})
+
 	t.Run("found on more optimal node", func(t *testing.T) {
 		errs := slices.Clone(all404)
 		errs[5] = nil
@@ -966,6 +974,16 @@ func TestPolicer_Run_EC(t *testing.T) {
 			Fields: map[string]any{"component": "Object Policer", "cid": cnr.String(), "partOID": partOID.String(),
 				"rule": "6/3", "partIdx": json.Number("5"), "node": []any{"localhost:10010", "localhost:10011"}},
 		})
+	})
+
+	t.Run("remote part does not trigger local relocation", func(t *testing.T) {
+		localObj := localObj
+		localObj.ShardIDs = []string{"source"}
+		errs := slices.Clone(all404)
+		errs[5] = nil
+
+		logBuf := testECCheck(t, rule, localObj, nodes, 6, errs, true, nil)
+		logBuf.AssertNotContainsMsg(zap.InfoLevel, "optimized local object shard location")
 	})
 
 	t.Run("not found on more optimal node", func(t *testing.T) {
@@ -1265,8 +1283,8 @@ func testECCheckWithNetworkAndShortage(t *testing.T, mockNet *mockNetwork, local
 	return lb
 }
 
-func TestPolicer_DropShardDuplicates(t *testing.T) {
-	t.Run("regular", func(t *testing.T) {
+func TestPolicer_OptimizeLocalShardLocation(t *testing.T) {
+	t.Run("single copy", func(t *testing.T) {
 		cnr := cidtest.ID()
 		objID := oidtest.ID()
 		addr := oid.NewAddress(cnr, objID)
@@ -1276,17 +1294,77 @@ func TestPolicer_DropShardDuplicates(t *testing.T) {
 			Address:    addr,
 			Type:       object.TypeRegular,
 			Attributes: make([]string, 3),
-			ShardIDs:   []string{"redundant", "keeper"},
+			ShardIDs:   []string{"source"},
 		}
 
 		localNode := newTestLocalNode()
-		localNode.deleteRedundantCopies = func(got oid.Address, shardIDs []string) error {
+		mockM := &mockMetrics{}
+		localNode.optimizeShardLocation = func(got oid.Address, shardIDs []string) (bool, error) {
 			require.Equal(t, addr, got)
-			require.ElementsMatch(t, []string{"redundant", "keeper"}, shardIDs)
+			require.Equal(t, []string{"source"}, shardIDs)
 			localNode.delMtx.Lock()
-			localNode.delByShard[addr] = []string{"redundant"}
+			localNode.delByShard[addr] = []string{"source"}
 			localNode.delMtx.Unlock()
-			return nil
+			return true, nil
+		}
+
+		mockNet := newMockNetwork()
+		mockNet.pubKey = nodes[0].PublicKey()
+		mockNet.setObjectNodesRepResult(cnr, objID, nodes, 1)
+
+		p := New(neofscryptotest.Signer(),
+			WithNetwork(mockNet),
+			WithLogger(zap.NewNop()),
+			WithMetrics(mockM),
+		)
+		p.localStorage = localNode
+
+		p.processObject(context.Background(), localObj)
+
+		require.Empty(t, localNode.deletedObjects())
+		require.Equal(t, []string{"source"}, localNode.deletedShardCopies(addr))
+		require.EqualValues(t, 1, mockM.relocated.Load())
+	})
+
+	t.Run("EC part", func(t *testing.T) {
+		addr := oid.NewAddress(cidtest.ID(), oidtest.ID())
+		localNode := newTestLocalNode()
+		localNode.optimizeShardLocation = func(got oid.Address, shardIDs []string) (bool, error) {
+			require.Equal(t, addr, got)
+			require.Equal(t, []string{"source"}, shardIDs)
+			return true, nil
+		}
+		mockM := &mockMetrics{}
+		p := New(neofscryptotest.Signer(), WithLogger(zap.NewNop()), WithMetrics(mockM))
+		p.localStorage = localNode
+
+		p.optimizeLocalShardLocation(context.Background(), objectcore.AddressWithAttributes{
+			Address:  addr,
+			Type:     object.TypeRegular,
+			ShardIDs: []string{"source"},
+		})
+
+		require.EqualValues(t, 1, mockM.relocated.Load())
+	})
+
+	t.Run("duplicates", func(t *testing.T) {
+		cnr := cidtest.ID()
+		objID := oidtest.ID()
+		addr := oid.NewAddress(cnr, objID)
+		nodes := testutil.Nodes(2)
+
+		localObj := objectcore.AddressWithAttributes{
+			Address:    addr,
+			Type:       object.TypeRegular,
+			Attributes: make([]string, 3),
+			ShardIDs:   []string{"source", "target"},
+		}
+
+		localNode := newTestLocalNode()
+		localNode.optimizeShardLocation = func(got oid.Address, shardIDs []string) (bool, error) {
+			require.Equal(t, addr, got)
+			require.Equal(t, []string{"source", "target"}, shardIDs)
+			return false, nil // the preferred shard already contains the object
 		}
 
 		mockNet := newMockNetwork()
@@ -1300,9 +1378,6 @@ func TestPolicer_DropShardDuplicates(t *testing.T) {
 		p.localStorage = localNode
 
 		p.processObject(context.Background(), localObj)
-
-		require.Empty(t, localNode.deletedObjects())
-		require.Equal(t, []string{"redundant"}, localNode.deletedShardCopies(addr))
 	})
 
 	t.Run("broadcast", func(t *testing.T) {
@@ -1321,9 +1396,9 @@ func TestPolicer_DropShardDuplicates(t *testing.T) {
 				}
 
 				localNode := newTestLocalNode()
-				localNode.deleteRedundantCopies = func(oid.Address, []string) error {
-					t.Fatal("DeleteRedundantCopies must not be called for broadcast objects")
-					return nil
+				localNode.optimizeShardLocation = func(oid.Address, []string) (bool, error) {
+					t.Fatal("OptimizeShardLocation must not be called for broadcast objects")
+					return false, nil
 				}
 
 				mockNet := newMockNetwork()
@@ -1423,7 +1498,7 @@ type testLocalNode struct {
 	delMtx                sync.RWMutex
 	del                   map[oid.Address]struct{}
 	delByShard            map[oid.Address][]string
-	deleteRedundantCopies func(oid.Address, []string) error
+	optimizeShardLocation func(oid.Address, []string) (bool, error)
 }
 
 func newTestLocalNode() *testLocalNode {
@@ -1460,6 +1535,7 @@ type mockMetrics struct {
 	replicatedEC     atomic.Uint64
 	deletedRep       atomic.Uint64
 	deletedEC        atomic.Uint64
+	relocated        atomic.Uint64
 }
 
 func (m *mockMetrics) SetPolicerConsistency(b bool) {
@@ -1496,6 +1572,10 @@ func (m *mockMetrics) IncPolicerObjectDeleted(isEC bool) {
 		return
 	}
 	m.deletedRep.Add(1)
+}
+
+func (m *mockMetrics) IncPolicerObjectRelocated() {
+	m.relocated.Add(1)
 }
 
 func (x *mockNetwork) IsLocalNodePublicKey(key []byte) bool {
@@ -1583,19 +1663,15 @@ func (x *testLocalNode) GetRange(_ context.Context, _ oid.Address, _ uint64, _ u
 	panic("unimplemented")
 }
 
-func (x *testLocalNode) DeleteRedundantCopies(_ context.Context, addr oid.Address, shardIDs []string) error {
-	if x.deleteRedundantCopies != nil {
-		return x.deleteRedundantCopies(addr, shardIDs)
-	}
-
-	if len(shardIDs) < 2 {
-		return nil
+func (x *testLocalNode) OptimizeShardLocation(_ context.Context, addr oid.Address, shardIDs []string) (bool, error) {
+	if x.optimizeShardLocation != nil {
+		return x.optimizeShardLocation(addr, shardIDs)
 	}
 
 	x.delMtx.Lock()
-	x.delByShard[addr] = append(x.delByShard[addr], shardIDs[1:]...)
+	x.delByShard[addr] = append(x.delByShard[addr], shardIDs...)
 	x.delMtx.Unlock()
-	return nil
+	return len(shardIDs) > 0, nil
 }
 
 type getNodesKey struct {


### PR DESCRIPTION
Closes #4147.

One edge case to consider: a copy marked with `GarbageMarkRedundant` is still visible to `Exists,` but remains queued for GC. If shard topology changes and this shard becomes the HRW-preferred target again before GC runs, relocation sees that the object already exists and does not clear the redundant mark. GC may then remove the current target copy.

Should we handle this by adding a targeted operation similar to `ClearRedundantMark` for the selected target shard, without reviving regular GC or tombstone marks?