### PR TITLE
core/netmap: fix storage interface comment

### DIFF
--- a/pkg/core/netmap/storage.go
+++ b/pkg/core/netmap/storage.go
@@ -17,7 +17,7 @@ type Source interface {
 	GetNetMapByEpoch(epoch uint64) (*netmap.NetMap, error)
 
 	// Epoch reads the current epoch from the storage.
-	// It returns thw number of the current epoch and any error encountered.
+	// It returns the number of the current epoch and any error encountered.
 	//
 	// Must return exactly one non-default value.
 	Epoch() (uint64, error)


### PR DESCRIPTION
Correct a spelling error in the netmap storage interface documentation (`thw` → `the`). The interface and implementation remain unchanged.
